### PR TITLE
docs(load): T19 load-test scenario + pending-hosting verification report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ docs/
 ├── 03-engineering/       Performance, testing, CI/CD, git workflow, coding standard, observability, roadmap, DoR/DoD, risk register
 ├── 04-design/            Design system: foundations, component standards, patterns, library, UX
 └── agents/               Agent working notes (tracker conventions)
+load-test/                k6 load-test scenario + runbook (T19, NFR-SCALE-001 concurrency)
 ```
 
 **Numbering contract.** Every folder's files are numbered from `00` upward. The folder name's leading number is the doc family; the file's leading number is its position within the family. Never introduce a gap or a duplicate when adding a doc. Design-series family prefixes (`vds`/`vcl`/`vux`) were retired; do not reintroduce them.
@@ -29,6 +30,7 @@ docs/
 - Build plan: `docs/03-engineering/06-implementation-roadmap.md`
 - Design authority: `docs/04-design/00-design-foundations.md` (primary accent `#2563EB`)
 - Decisions: `docs/02-architecture/01-architecture-decision-records.md` (ADR-001…)
+- Load verification: `docs/03-engineering/11-load-verification.md` (T19 report; scenario in `load-test/`, live run pending hosting)
 
 ## Tracker / work
 

--- a/docs/03-engineering/00-performance-and-scalability-strategy.md
+++ b/docs/03-engineering/00-performance-and-scalability-strategy.md
@@ -59,6 +59,8 @@ Two distinct numbers, two distinct guarantees:
 
 Verification: a load test (see T19 — load & capacity verification) records a p95 baseline at a meaningful concurrency (initial target 100–200 concurrent, extrapolating the 500-design shape) and is the evidence cited for this half. Absent that test, the doc-party claim is *target-only* and deliberately stated as such.
 
+**T19 evidence:** the load-test scenario, runbook, and report template live in [11-load-verification.md](11-load-verification.md) (script: `load-test/load-test.js`). Status: *pending hosting* — the live run requires the hosted endpoint (T17); measured p95s and the first bottleneck are backfilled into that report when available. The verdict will cite the measured values above; until then the 500-concurrent claim remains *target-only*.
+
 # 4. Rendering Strategy
 
 ## Server Components

--- a/docs/03-engineering/11-load-verification.md
+++ b/docs/03-engineering/11-load-verification.md
@@ -1,0 +1,71 @@
+# Load & Capacity Verification (T19)
+
+> **Project:** VinTech Challenge 2026
+>
+> **Version:** 1.0
+>
+> **Owner:** Engineering Team
+>
+> **Status:** Pending hosting — scenario ready, live run blocked on T17 deploy
+
+> **Scope note:** This report is the deliverable of tracker ticket T19 — Load & capacity verification (GitHub issue #23 on `hamdi-ab/used-goods-marketplace`). It proves the NFR-SCALE-001 **concurrency** half (500 concurrent) empirically. The scale half (10,000 users / 50,000 listings) is a query-shape guarantee (pagination + indexing) and is out of scope here. Live numbers require a hosted endpoint; see **Status**.
+
+# 1. Run status
+
+| Item | Value |
+|---|---|
+| Script | `load-test/load-test.js` (k6, ramping-vus) |
+| Validated against | k6 v2.2.0, local mock server (syntax + execution, exit 0, thresholds green) |
+| Hosted target | **None yet** — T01 (scaffold) open, T17 (deploy) not started; no preview/staging URL exists |
+| Live measurement | **Pending hosting** — re-run with `BASE_URL=<hosted-url>` once deployed |
+
+Per the T19 brief: the app is not yet hosted, so this ticket delivers the scenario, the methodology, and the report template with the run marked *pending-hosting* rather than blocking. The runbook in `load-test/README.md` is the step-by-step; this doc is where the measured numbers land.
+
+# 2. Tested endpoints
+
+| Endpoint | Request | Expected p95 | Measured p95 |
+|---|---|---|---|
+| Home | `GET /` (SSR page) | < 300 ms | _pending hosting_ |
+| Browse | `GET /api/v1/listings?page=1&limit=20` | < 300 ms | _pending hosting_ |
+| Search | `GET /api/v1/search?query=…` | < 500 ms | _pending hosting_ |
+| Listing detail | `GET /api/v1/listings/{id}` (id chained from browse) | < 300 ms | _pending hosting_ |
+
+# 3. Concurrency
+
+Profile: `ramping-vus`, 0 → 100 VUs (30 s), hold 100 (60 s), ramp 100 → 200 VUs (30 s), hold 200 (60 s), cool-down. The ticket's initial target is **100–200 concurrent VUs**; the 500-concurrent extrapolation run (0 → 300 → 500) is a documented second step in `load-test/README.md`. Thresholds: API p95 < 300 ms, search p95 < 500 ms, error rate < 1%, checks > 99%.
+
+# 4. Results
+
+| Metric | Value |
+|---|---|
+| Run date | _pending hosting_ |
+| Hosted URL | _pending hosting_ |
+| Peak concurrent VUs | _pending hosting_ |
+| Throughput | _pending hosting_ |
+| Home p95 | _pending hosting_ |
+| Browse p95 | _pending hosting_ |
+| Search p95 | _pending hosting_ |
+| Listing detail p95 | _pending hosting_ |
+| Error rate | _pending hosting_ |
+| Threshold result | _pending hosting_ |
+
+# 5. Bottleneck
+
+Not yet measurable. When run, identify the **first** degradation in this order (from `load-test/README.md`):
+
+1. **Frontend instances** — all-endpoint p95 rises together, Vercel function saturation.
+2. **Postgres CPU** — DB-backed endpoints degrade while home stays flat.
+3. **Connection pool** — connection timeouts/exhaustion with low CPU.
+4. **Image CDN** — CDN latency/failures while API stays green.
+
+Record the observed first bottleneck, the concurrency it appeared at, and the evidence (dashboard metric / error class).
+
+# 6. Verdict
+
+**500 concurrent is expected to be realistic without architectural change** — the design (stateless Next.js on Vercel horizontal auto-scale, indexed + paginated Supabase Postgres, single-RPC search, CDN-served images) is built for it — but this is an **architectural assessment, not a measured claim**. The measured p95s above must land before the NFR-SCALE-001 concurrency half is considered verified. Once the hosted endpoint exists (T17), run `load-test/load-test.js` and backfill §2–§5; update the NFR mapping in [00-performance-and-scalability-strategy.md](00-performance-and-scalability-strategy.md) with the measured values.
+
+# 7. Related documents
+
+- [00-performance-and-scalability-strategy.md](00-performance-and-scalability-strategy.md) — NFR-SCALE-001 mapping (this report is its cited evidence)
+- [04-api-specification.md](../02-architecture/04-api-specification.md) — endpoint contracts the scenario targets
+- [10-submission-readiness.md](10-submission-readiness.md) — hosting plan (T17) that unblocks the live run

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -1,0 +1,83 @@
+# Load Test — Methodology & Runbook
+
+k6 scenario proving the NFR-SCALE-001 concurrency half (500 concurrent) for the Used Goods Marketplace. The report is `docs/03-engineering/11-load-verification.md`.
+
+## What it measures
+
+Four public, unauthenticated endpoints that carry the concurrent-user load:
+
+| Endpoint | Request | Target p95 |
+|---|---|---|
+| Home | `GET /` (SSR page) | < 300 ms |
+| Browse | `GET /api/v1/listings?page=1&limit=20` | < 300 ms |
+| Search | `GET /api/v1/search?query=…` | < 500 ms |
+| Listing detail | `GET /api/v1/listings/{id}` | < 300 ms |
+
+The listing `{id}` is chained from the browse response (`data[0].id`), so the scenario exercises a realistic read-after-browse path and hits a real row, not a synthetic one. Override with `LISTING_ID` when the browse payload shape differs.
+
+## Load profile
+
+`ramping-vus` executor (virtual-user concurrency, per the ticket):
+
+| Stage | Duration | Target |
+|---|---|---|
+| Warm-up ramp | 30 s | 0 → 100 VUs |
+| Hold @ 100 | 60 s | 100 VUs |
+| Ramp | 30 s | 100 → 200 VUs |
+| Hold @ 200 | 60 s | 200 VUs |
+| Cool-down | 10 s | 200 → 0 VUs |
+
+Think time of 1–3 s between requests models human pacing. Full run ≈ 3 minutes.
+
+## Running
+
+k6 is required on the runner (k6 ≥ 0.50; the script was validated against k6 v2.2.0). Install via the [official release binary](https://github.com/grafana/k6/releases), or run with Docker where a working daemon exists:
+
+```
+docker run --rm -v "$PWD":/app -i grafana/k6 run --env BASE_URL=<hosted-url> /app/load-test/load-test.js
+```
+
+Local run against a working daemon (dev app on localhost:3000):
+
+```
+k6 run --env BASE_URL=http://localhost:3000 load-test/load-test.js
+```
+
+Hosted run — replace with the live URL (default Vercel deployment, see `docs/03-engineering/10-submission-readiness.md`):
+
+```
+k6 run --env BASE_URL=https://used-goods-marketplace.vercel.app load-test/load-test.js
+```
+
+### Environment variables
+
+| Var | Default | Meaning |
+|---|---|---|
+| `BASE_URL` | `http://localhost:3000` | Target origin; required for a hosted run |
+| `START_VUS` | `100` | Initial concurrency (ticket: 100–200) |
+| `END_VUS` | `200` | Peak concurrency |
+| `RAMP_SEC` | `30` | Ramp duration between plateaus |
+| `HOLD_SEC` | `60` | Plateau hold duration |
+| `SEARCH_QUERY` | `phone` | Search term for the search request |
+| `LISTING_ID` | *(browse-chained)* | Pin a specific listing id |
+| `LIMIT` | `20` | Browse page size |
+
+### Output
+
+- `--summary-export summary.json` gives machine-readable p95 per endpoint (`http_req_duration{name:…}`) and threshold pass/fail. Use this to fill the report table.
+- Thresholds enforce the NFR at run time: API p95 < 300 ms, search p95 < 500 ms, error rate < 1%, checks > 99%. A non-zero exit code means an NFR was missed.
+
+## Identifying the first bottleneck
+
+Ramp concurrency in stages (100 → 200 → 500 for the extrapolation run). Whichever metric degrades first, in this order, names the bottleneck:
+
+1. **Frontend instances** — p95 rises across *all* endpoints together and Vercel shows function saturation/evictions. Fix: horizontal scale / regions; verify with Vercel dashboard.
+2. **Postgres CPU** — p95 rises on browse/search/detail (the DB-backed paths) while home (cached/edge) stays flat; Supabase dashboard shows DB CPU pegging. Fix: read replica, query tuning, cache hot queries.
+3. **Connection pool** — errors jump on DB-backed endpoints (connection timeouts, pool exhaustion) while CPU stays low. Fix: pool sizing (Supabase) or PgBouncer.
+4. **Image CDN** — image/CDN requests start failing or latency climbs while API stays green; CDN cache hit ratio drops. Fix: cache rules, prewarm, next/image config.
+
+Record in the report which one appeared first and at what concurrency.
+
+## Validation note
+
+This scenario was executed successfully against a local mock server (all endpoints returning 200, all thresholds green, exit 0) to prove the script compiles and the per-endpoint tags, chained listing id, and thresholds all work. That mock run produced **no** meaningful latency numbers and is **not** the T19 measurement. The real run is pending a hosted endpoint (T01 scaffold / T17 deploy) — see `docs/03-engineering/11-load-verification.md`.

--- a/load-test/load-test.js
+++ b/load-test/load-test.js
@@ -1,0 +1,89 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const START_VUS = Number(__ENV.START_VUS || 100);
+const END_VUS = Number(__ENV.END_VUS || 200);
+const RAMP_SEC = Number(__ENV.RAMP_SEC || 30);
+const HOLD_SEC = Number(__ENV.HOLD_SEC || 60);
+const SEARCH_QUERY = __ENV.SEARCH_QUERY || 'phone';
+const LISTING_ID = __ENV.LISTING_ID || '';
+const LIMIT = Number(__ENV.LIMIT || 20);
+
+const stages = [
+  { duration: `${RAMP_SEC}s`, target: START_VUS },
+  { duration: `${HOLD_SEC}s`, target: START_VUS },
+  { duration: `${RAMP_SEC}s`, target: END_VUS },
+  { duration: `${HOLD_SEC}s`, target: END_VUS },
+  { duration: '10s', target: 0 },
+];
+
+export const options = {
+  scenarios: {
+    load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: stages,
+      exec: 'publicTraffic',
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:home}': ['p(95)<300'],
+    'http_req_duration{name:browse}': ['p(95)<300'],
+    'http_req_duration{name:listing-detail}': ['p(95)<300'],
+    'http_req_duration{name:search}': ['p(95)<500'],
+    'http_req_failed{name:home}': ['rate<0.01'],
+    'http_req_failed{name:browse}': ['rate<0.01'],
+    'http_req_failed{name:listing-detail}': ['rate<0.01'],
+    'http_req_failed{name:search}': ['rate<0.01'],
+    checks: ['rate>0.99'],
+  },
+};
+
+const browseUrl = `${BASE_URL}/api/v1/listings?page=1&limit=${LIMIT}`;
+const searchUrl = `${BASE_URL}/api/v1/search?query=${encodeURIComponent(SEARCH_QUERY)}`;
+
+function extractListingId(res) {
+  if (!res || !res.body) return '';
+  try {
+    const json = res.json();
+    const arr = json && (json.data || json.listings || json.results);
+    if (Array.isArray(arr) && arr.length > 0 && arr[0].id) return String(arr[0].id);
+    if (json && json.id) return String(json.id);
+  } catch (e) {
+    return '';
+  }
+  return '';
+}
+
+export function publicTraffic() {
+  const home = http.get(`${BASE_URL}/`, { tags: { name: 'home' } });
+  check(home, {
+    'home status 200': (r) => r.status === 200,
+  });
+  sleep(randomIntBetween(1, 3));
+
+  const browse = http.get(browseUrl, { tags: { name: 'browse' } });
+  check(browse, {
+    'browse status 200': (r) => r.status === 200,
+  });
+  sleep(randomIntBetween(1, 3));
+
+  const search = http.get(searchUrl, { tags: { name: 'search' } });
+  check(search, {
+    'search status 200': (r) => r.status === 200,
+  });
+  sleep(randomIntBetween(1, 3));
+
+  let listingId = LISTING_ID || extractListingId(browse);
+  if (listingId) {
+    const detail = http.get(`${BASE_URL}/api/v1/listings/${listingId}`, {
+      tags: { name: 'listing-detail' },
+    });
+    check(detail, {
+      'listing-detail status 200': (r) => r.status === 200,
+    });
+  }
+  sleep(randomIntBetween(1, 3));
+}


### PR DESCRIPTION
Closes #23

## Summary
T19 (NFR-SCALE-001 concurrency half) — delivers the k6 load-test scenario, runbook, and the verification report. The app is **not yet hosted** (T01 scaffold open, T17 deploy not started, no preview URL), so per the ticket brief the run is marked **pending-hosting**: scenario + methodology shipped, live measurement to be backfilled once a hosted endpoint exists.

## Changes
- `load-test/load-test.js` — k6 `ramping-vus` scenario, 100→200 VUs, hitting home, browse, search, listing-detail (listing id chained from browse response). Thresholds: API p95 < 300ms, search p95 < 500ms, error rate < 1%, checks > 99%.
- `load-test/README.md` — runbook: endpoints, load profile, env vars, bottleneck-identification order (frontend instances → Postgres CPU → connection pool → image CDN).
- `docs/03-engineering/11-load-verification.md` — report template (endpoints, concurrency, p95 table, bottleneck, one-line verdict) with run marked pending-hosting.
- `docs/03-engineering/00-performance-and-scalability-strategy.md` — NFR mapping updated (additive) to point at the new report as the T19 evidence location.
- `AGENTS.md` — repo layout + canonical reference for load-test/.

## Validation
Script executed successfully against a local mock server with k6 v2.2.0: all four endpoints return 200, per-name p95 captured, all thresholds green, exit 0. That mock run produced **no** real latency numbers and is explicitly not the measurement.

## Notes
- No fabricated numbers: verdict is an architectural assessment (500 concurrent expected realistic without architectural change), clearly marked target-only until measured.
- Live run blocked on hosted endpoint only, not on tooling.