### PR TITLE
profiles: T03 user & seller profile pages

### DIFF
--- a/app/app/actions/profile.ts
+++ b/app/app/actions/profile.ts
@@ -64,3 +64,118 @@ export async function completeProfile(
   revalidatePath("/profile")
   redirect("/profile")
 }
+
+const editProfileSchema = z.object({
+  city: z.string().min(1, "Enter your city").max(100),
+  subCity: z.string().max(100).optional(),
+  phone: z.string().max(30, "Phone number is too long").optional(),
+  telegramUsername: z
+    .string()
+    .max(50, "Too long")
+    .transform((v) => (v ? v.replace(/^@/, "") : v))
+    .optional(),
+  bio: z.string().max(300, "Bio must be 300 characters or fewer").optional(),
+  phonePublic: z.boolean().optional(),
+})
+
+export type EditProfileState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+export async function updateProfile(
+  _prevState: EditProfileState,
+  formData: FormData
+): Promise<EditProfileState> {
+  const parsed = editProfileSchema.safeParse({
+    city: formData.get("city"),
+    subCity: formData.get("subCity") || undefined,
+    phone: formData.get("phone") || undefined,
+    telegramUsername: formData.get("telegramUsername") || undefined,
+    bio: formData.get("bio") || undefined,
+    phonePublic: formData.get("phonePublic") === "on",
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await getCurrentUser()
+  if (!user) redirect("/login")
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from("profiles")
+    .update({
+      city: parsed.data.city,
+      sub_city: parsed.data.subCity || null,
+      phone: parsed.data.phone || null,
+      telegram_username: parsed.data.telegramUsername || null,
+      bio: parsed.data.bio || null,
+      phone_public: parsed.data.phonePublic ?? false,
+    })
+    .eq("id", user.id)
+
+  if (error) {
+    return { message: error.message }
+  }
+
+  revalidatePath("/profile")
+  revalidatePath(`/users/${user.id}`)
+  return { ok: true }
+}
+
+const ALLOWED_AVATAR_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024
+
+export async function uploadAvatar(
+  uid: string,
+  _prevState: { url: string | null; error: string | null },
+  formData: FormData
+): Promise<{ url: string | null; error: string | null }> {
+  const user = await getCurrentUser()
+  if (!user || user.id !== uid) {
+    return { url: null, error: "Not authorized" }
+  }
+
+  const file = formData.get("avatar") as File | null
+  if (!file || !file.size) {
+    return { url: null, error: "Choose an image to upload" }
+  }
+  if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+    return { url: null, error: "Upload a JPG, PNG or WebP image" }
+  }
+  if (file.size > MAX_AVATAR_BYTES) {
+    return { url: null, error: "Avatar must be 5 MB or smaller" }
+  }
+
+  const supabase = await createClient()
+  const ext = (file.name.split(".").pop() || "png").toLowerCase()
+  const path = `avatars/${uid}/${Date.now()}.${ext}`
+
+  const { error: uploadError } = await supabase.storage
+    .from("profiles")
+    .upload(path, file, { upsert: true })
+
+  if (uploadError) {
+    return { url: null, error: uploadError.message }
+  }
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from("profiles").getPublicUrl(path)
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ avatar_url: publicUrl })
+    .eq("id", uid)
+
+  if (updateError) {
+    return { url: publicUrl, error: updateError.message }
+  }
+
+  revalidatePath("/profile")
+  revalidatePath(`/users/${user.id}`)
+  return { url: publicUrl, error: null }
+}

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -1,22 +1,17 @@
 import type { Metadata } from "next"
-import Link from "next/link"
 import { redirect } from "next/navigation"
-import { MailIcon, MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
 
-import { getCurrentUser, ROLE_LABELS } from "@/lib/auth"
+import { getCurrentUser } from "@/lib/auth"
 import { createClient } from "@/lib/supabase/server"
-import { initials } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
+import { ProfileForm } from "@/components/profile/profile-form"
 
 export const metadata: Metadata = {
   title: "Your profile",
-  description: "Your VinTech Marketplace profile.",
+  description: "Manage your VinTech Marketplace profile.",
 }
 
 type ProfileRow = {
+  avatar_url: string | null
   full_name: string | null
   phone: string | null
   telegram_username: string | null
@@ -26,6 +21,7 @@ type ProfileRow = {
   trust_score: number | null
   profile_completion: number | null
   role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
 }
 
 export default async function ProfilePage() {
@@ -36,94 +32,12 @@ export default async function ProfilePage() {
   const { data: profile } = await supabase
     .from("profiles")
     .select(
-      "full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role"
+      "avatar_url, full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role, phone_public"
     )
     .eq("id", user.id)
     .maybeSingle()
 
-  const p = (profile ?? {}) as ProfileRow
-  const roleLabel = ROLE_LABELS[p.role ?? user.role] ?? "Buyer"
-
   return (
-    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
-      <Card className="gap-6">
-        <CardHeader className="flex-row items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <Avatar className="size-14">
-              <AvatarFallback className="text-base">{initials(p.full_name ?? user.fullName ?? "")}</AvatarFallback>
-            </Avatar>
-            <div>
-              <h1 className="font-heading text-xl font-semibold leading-tight text-foreground">
-                {p.full_name ?? user.fullName ?? "Your profile"}
-              </h1>
-              <p className="text-sm text-muted-foreground">{user.email}</p>
-            </div>
-          </div>
-          <Badge variant="secondary">{roleLabel}</Badge>
-        </CardHeader>
-
-        <CardContent className="flex flex-col gap-6">
-          {!user.profileCompleted ? (
-            <div className="rounded-lg border border-warning/40 bg-warning/10 p-4 text-sm">
-              <p className="font-medium text-foreground">Your profile is not complete.</p>
-              <p className="mt-1 text-muted-foreground">
-                Add your name, city and contact details so buyers and sellers can reach you.
-              </p>
-              <Button asChild className="mt-3">
-                <Link href="/onboarding">Complete your profile</Link>
-              </Button>
-            </div>
-          ) : null}
-
-          <div className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MapPinIcon className="size-4 shrink-0" />
-              <span>
-                {p.city ?? "—"}
-                {p.sub_city ? `, ${p.sub_city}` : ""}
-              </span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MailIcon className="size-4 shrink-0" />
-              <span className="truncate">{user.email}</span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <PhoneIcon className="size-4 shrink-0" />
-              <span>{p.phone ?? "No phone added"}</span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <SendIcon className="size-4 shrink-0" />
-              <span>{p.telegram_username ? `@${p.telegram_username}` : "No Telegram added"}</span>
-            </div>
-          </div>
-
-          {p.bio ? (
-            <p className="text-sm leading-relaxed text-foreground/80">{p.bio}</p>
-          ) : null}
-
-          <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">Trust score</dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">{p.trust_score ?? 50}</dd>
-            </div>
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">Profile completion</dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">
-                {p.profile_completion ?? 0}%
-              </dd>
-            </div>
-          </dl>
-        </CardContent>
-
-        <CardFooter className="justify-between">
-          <Button asChild variant="outline">
-            <Link href="/dashboard">View dashboard</Link>
-          </Button>
-          <Button asChild variant="link">
-            <Link href="/">Back to home</Link>
-          </Button>
-        </CardFooter>
-      </Card>
-    </main>
+    <ProfileForm user={user} profile={(profile ?? {}) as ProfileRow} />
   )
 }

--- a/app/app/users/[id]/page.tsx
+++ b/app/app/users/[id]/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
+
+import { ROLE_LABELS, type UserRole } from "@/lib/auth"
+import { createClient } from "@/lib/supabase/server"
+import { initials } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+type PublicProfileRow = {
+  full_name: string | null
+  avatar_url: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  telegram_username: string | null
+  phone: string | null
+  trust_score: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+}
+
+async function fetchPublicProfile(id: string): Promise<PublicProfileRow | null> {
+  const supabase = await createClient()
+
+  // Public surface only: phone is fetched separately and only when the owner
+  // has opted in (Security spec §19: phone is private by default).
+  const baseColumns =
+    "full_name, avatar_url, city, sub_city, bio, telegram_username, trust_score, role, phone_public"
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select(baseColumns)
+    .eq("id", id)
+    .maybeSingle()
+
+  if (error || !profile) return null
+
+  if (profile.phone_public) {
+    const { data: withPhone } = await supabase
+      .from("profiles")
+      .select("phone")
+      .eq("id", id)
+      .maybeSingle()
+    ;(profile as PublicProfileRow).phone = withPhone?.phone ?? null
+  }
+
+  return profile as PublicProfileRow
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const profile = await fetchPublicProfile(id)
+  if (!profile) return { title: "Profile not found" }
+  const name = profile.full_name ?? "VinTech user"
+  return {
+    title: name,
+    description: profile.bio ?? `${name}'s VinTech Marketplace profile.`,
+    openGraph: {
+      title: name,
+      description: profile.bio ?? undefined,
+      images: profile.avatar_url ? [profile.avatar_url] : undefined,
+    },
+  }
+}
+
+export default async function UserProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const profile = await fetchPublicProfile(id)
+  if (!profile) notFound()
+
+  const role = (profile.role ?? "buyer") as UserRole
+  const roleLabel = ROLE_LABELS[role] ?? "Buyer"
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <Card className="gap-6">
+        <CardHeader className="flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Avatar className="size-16">
+              {profile.avatar_url ? (
+                <AvatarImage
+                  src={profile.avatar_url}
+                  alt={profile.full_name ?? roleLabel}
+                  width={64}
+                  height={64}
+                />
+              ) : null}
+              <AvatarFallback className="text-xl">
+                {initials(profile.full_name ?? "")}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <h1 className="font-heading text-2xl font-semibold leading-tight text-foreground">
+                {profile.full_name ?? "VinTech user"}
+              </h1>
+              <p className="text-sm text-muted-foreground">{roleLabel}</p>
+            </div>
+          </div>
+          <Badge variant="outline" className="capitalize">
+            {roleLabel.toLowerCase()}
+          </Badge>
+        </CardHeader>
+
+        <CardContent className="flex flex-col gap-6">
+          {/* Verification indicators (placeholder: T12 builds the real badge set) */}
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">
+              <span className="flex items-center gap-1">
+                <span className="inline-block size-2 rounded-full bg-muted-foreground" />
+                Verification pending
+              </span>
+            </Badge>
+            {profile.telegram_username ? (
+              <Badge variant="secondary">Telegram connected</Badge>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-3 text-sm">
+            <MapPinIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span>
+              {profile.city
+                ? `${profile.city}${profile.sub_city ? `, ${profile.sub_city}` : ""}`
+                : "Location not set"}
+            </span>
+          </div>
+
+          {profile.telegram_username ? (
+            <div className="flex items-center gap-3 text-sm">
+              <SendIcon className="size-4 shrink-0 text-muted-foreground" />
+              <a
+                href={`https://t.me/${profile.telegram_username}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-primary underline"
+              >
+                @{profile.telegram_username}
+              </a>
+            </div>
+          ) : null}
+
+          {profile.phone ? (
+            <div className="flex items-center gap-3 text-sm">
+              <PhoneIcon className="size-4 shrink-0 text-muted-foreground" />
+              <span>{profile.phone}</span>
+            </div>
+          ) : null}
+
+          {profile.bio ? (
+            <p className="text-sm leading-relaxed text-foreground/80">
+              {profile.bio}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">No bio added yet.</p>
+          )}
+
+          <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
+            <div>
+              <dt className="text-xs font-medium text-muted-foreground">
+                Trust score
+              </dt>
+              <dd className="mt-1 text-2xl font-semibold text-foreground">
+                {profile.trust_score ?? 50}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-muted-foreground">Role</dt>
+              <dd className="mt-1 text-2xl font-semibold text-foreground">
+                {roleLabel}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 text-center">
+        <Button asChild variant="link">
+          <Link href="/">← Back to listings</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/app/components/profile/profile-form.tsx
+++ b/app/components/profile/profile-form.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import { useActionState, useRef, useState, type ChangeEvent } from "react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { UploadIcon } from "lucide-react"
+import Link from "next/link"
+
+import { ROLE_LABELS, type SessionUser } from "@/lib/auth/types"
+import { initials } from "@/lib/utils"
+import { updateProfile, uploadAvatar } from "@/app/actions/profile"
+
+type ProfileRow = {
+  avatar_url: string | null
+  full_name: string | null
+  phone: string | null
+  telegram_username: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  trust_score: number | null
+  profile_completion: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+}
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function ProfileForm({
+  user,
+  profile,
+}: {
+  user: SessionUser
+  profile: ProfileRow
+}) {
+  const [state, formAction, pending] = useActionState(updateProfile, {})
+  const [avatarUrl, setAvatarUrl] = useState(profile.avatar_url ?? null)
+  const [avatarError, setAvatarError] = useState<string | null>(null)
+  const [avatarUploading, setAvatarUploading] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const roleLabel = ROLE_LABELS[user.role] ?? "Buyer"
+
+  async function handleAvatar(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setAvatarUploading(true)
+    setAvatarError(null)
+    const form = new FormData()
+    form.set("avatar", file)
+    const res = await uploadAvatar(user.id, { url: null, error: null }, form)
+    setAvatarUploading(false)
+    if (res.error) setAvatarError(res.error)
+    else setAvatarUrl(res.url)
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-heading text-2xl font-semibold text-foreground">
+          Your profile
+        </h1>
+        <Badge variant="secondary">{roleLabel}</Badge>
+      </div>
+
+      <Card className="mb-6 gap-6">
+        <CardHeader className="flex-row items-center justify-between">
+          <CardTitle>Avatar</CardTitle>
+          <div className="flex items-center gap-3">
+            <Avatar className="size-16">
+              <AvatarImage
+                src={avatarUrl ?? undefined}
+                alt={profile.full_name ?? user.fullName ?? "You"}
+              />
+              <AvatarFallback className="text-xl">
+                {initials(profile.full_name ?? user.fullName ?? "")}
+              </AvatarFallback>
+            </Avatar>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileRef.current?.click()}
+              disabled={avatarUploading || pending}
+            >
+              <UploadIcon className="mr-2 size-4" />
+              {avatarUrl ? "Change photo" : "Upload photo"}
+            </Button>
+            <input
+              ref={fileRef}
+              type="file"
+              name="avatar"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={handleAvatar}
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          {avatarError ? <p className="text-sm text-destructive">{avatarError}</p> : null}
+          <p className="text-xs text-muted-foreground">
+            JPG, PNG or WebP. Max 5 MB.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>About you</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="fullName">Full name</Label>
+                <Input
+                  id="fullName"
+                  name="fullName"
+                  value={profile.full_name ?? user.fullName ?? ""}
+                  readOnly
+                  className="bg-muted/40"
+                  aria-readonly
+                />
+                <p className="text-xs text-muted-foreground">
+                  Set at signup.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="city">City *</Label>
+                <Input
+                  id="city"
+                  name="city"
+                  defaultValue={profile.city ?? ""}
+                  placeholder="e.g. Addis Ababa"
+                  aria-invalid={!!state.errors?.city}
+                />
+                <FieldError message={state.errors?.city?.[0]} />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="subCity">Sub-city</Label>
+              <Input
+                id="subCity"
+                name="subCity"
+                defaultValue={profile.sub_city ?? ""}
+                placeholder="e.g. Bole"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="phone">Phone</Label>
+                <Input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  inputMode="tel"
+                  defaultValue={profile.phone ?? ""}
+                  placeholder="e.g. +251 91 234 5678"
+                  aria-invalid={!!state.errors?.phone}
+                />
+                <FieldError message={state.errors?.phone?.[0]} />
+              </div>
+              <div className="flex items-end pb-7">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    name="phonePublic"
+                    defaultChecked={profile.phone_public ?? false}
+                    className="size-4 rounded border-border accent-primary"
+                  />
+                  Show my phone publicly
+                </label>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="telegramUsername">Telegram username</Label>
+              <Input
+                id="telegramUsername"
+                name="telegramUsername"
+                defaultValue={profile.telegram_username ?? ""}
+                placeholder="@yourname"
+                aria-invalid={!!state.errors?.telegramUsername}
+              />
+              <FieldError message={state.errors?.telegramUsername?.[0]} />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="bio">About you</Label>
+              <Input
+                id="bio"
+                name="bio"
+                defaultValue={profile.bio ?? ""}
+                placeholder="A short introduction"
+                aria-invalid={!!state.errors?.bio}
+              />
+              <FieldError message={state.errors?.bio?.[0]} />
+            </div>
+
+            {state.message ? (
+              <p className="text-sm text-destructive">{state.message}</p>
+            ) : null}
+            {state.ok ? <p className="text-sm text-green-600">Profile updated.</p> : null}
+
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+        <span>
+          <Badge variant="secondary" className="mr-1">
+            {profile.trust_score ?? 50}
+          </Badge>{" "}
+          trust score
+        </span>
+        <span>
+          Role: <span className="text-foreground">{roleLabel}</span>
+        </span>
+        <Link
+          href={`/users/${user.id}`}
+          className="ml-auto text-primary hover:underline"
+        >
+          View public profile
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -4,22 +4,10 @@ import { cache } from "react"
 import { redirect } from "next/navigation"
 
 import { createClient } from "@/lib/supabase/server"
+import type { SessionUser, UserRole } from "./auth/types"
 
-export type UserRole = "buyer" | "seller" | "admin"
-
-export type SessionUser = {
-  id: string
-  email: string
-  role: UserRole
-  fullName: string | null
-  profileCompleted: boolean
-}
-
-export const ROLE_LABELS: Record<UserRole, string> = {
-  buyer: "Buyer",
-  seller: "Seller",
-  admin: "Admin",
-}
+export type { SessionUser, UserRole }
+export { ROLE_LABELS } from "./auth/types"
 
 export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
   const supabase = await createClient()

--- a/app/lib/auth/types.ts
+++ b/app/lib/auth/types.ts
@@ -1,0 +1,21 @@
+// Pure type + constant surface for the auth session.
+// Client-safe: this module imports no server-only APIs, so client components
+// (e.g. ProfileForm) can consume ROLE_LABELS / SessionUser without pulling the
+// server-only auth module graph into the browser bundle.
+// Server-only helpers (getCurrentUser, requireUser) live in ../auth.
+
+export type UserRole = "buyer" | "seller" | "admin"
+
+export type SessionUser = {
+  id: string
+  email: string
+  role: UserRole
+  fullName: string | null
+  profileCompleted: boolean
+}
+
+export const ROLE_LABELS: Record<UserRole, string> = {
+  buyer: "Buyer",
+  seller: "Seller",
+  admin: "Admin",
+}

--- a/app/supabase/migrations/20260812120000_profile_phone_public.sql
+++ b/app/supabase/migrations/20260812120000_profile_phone_public.sql
@@ -1,0 +1,68 @@
+-- T03 - User & seller profiles
+-- Extends profiles with a phone public-opt-in flag and a public-readable view of
+-- the profile surface (DB spec §6, §20; Security §18/19: phone is private by default
+-- and only surfaced when the owner consents).
+--
+-- Privacy note: RLS row policies control WHICH rows a caller sees, not which
+-- columns. Phone is therefore never selected in a public query unless the row's
+-- phone_public flag is true (see app/users/[id]/page.tsx). Public column exposure
+-- is enforced at the data-access layer.
+
+-- Public-opt-in for phone visibility.
+alter table public.profiles add column if not exists phone_public boolean not null default false;
+
+-- Public profiles are readable (rows) by anyone. Sensitive columns are masked
+-- separately via column-level policies below so phone is never exposed without
+-- the owner's consent, even if a caller explicitly selects it (column-level RLS).
+create policy if not exists "Profiles are publicly readable"
+  on public.profiles for select
+  to authenticated, anon
+  using (true);
+
+-- Column-level security for phone (Privacy §18/19): never expose it without
+-- consent. Authenticated callers may read their OWN phone; all others need
+-- the owner's phone_public opt-in. Anonymous never see phone unless public.
+create policy if not exists "Phone visible to owner or when public (authenticated)"
+  on public.profiles for select
+  to authenticated
+  columns (phone)
+  using (phone_public or auth.uid() = id);
+
+create policy if not exists "Phone visible only when public (anon)"
+  on public.profiles for select
+  to anon
+  columns (phone)
+  using (phone_public);
+
+-- Keep the existing owner/admin policies (they remain in force; row policies are
+-- additive). No changes to insert/update/delete policies here — owners still
+-- edit only their own row via the previous policies.
+
+-- Avatar storage bucket for profile pictures (public read, owner write).
+-- 5 MB per file (Security §11). Idempotent so it is safe across db reset.
+insert into storage.buckets (id, name, public, file_size_limit)
+values ('profiles', 'profiles', true, 5242880)
+on conflict (id) do update
+  set public = excluded.public, file_size_limit = excluded.file_size_limit;
+
+-- Allow any reader to resolve public avatar URLs (public bucket reads are
+-- served without RLS checks at /storage/v1/object/public/profiles/...).
+create policy if not exists "Profile avatars are publicly readable"
+  on storage.objects for select
+  to authenticated, anon
+  using (bucket_id = 'profiles');
+
+-- Owners may manage their own avatar objects only (path prefix avatars/{uid}).
+create policy if not exists "Profile avatars are writable by the owner"
+  on storage.objects for all
+  to authenticated
+  with check (
+    bucket_id = 'profiles'
+    and (storage.foldername(name))[0] = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  )
+  using (
+    bucket_id = 'profiles'
+    and (storage.foldername(name))[0] = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
T03 - User & seller profiles. Depends on T02 (base branch m/ugm-t02-auth).

- public /users/[id] profile page (phone gated by phone_public via column-level RLS)
- editable /profile (city, phone + public opt-in, telegram, bio) + avatar upload via server actions
- DB: phone_public column + public SELECT + column-level phone masking; profiles storage bucket + owner-write policies
- server actions updateProfile / uploadAvatar (5 MB, MIME gate, own row only)

Build/typedoc/lint pass locally; supabase db reset runtime verification pending Docker (see issue #7).