### PR TITLE
listings: T05 browse & discover (home, cards, pagination)

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,25 +1,119 @@
-import Link from "next/link";
+import Link from "next/link"
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
+import { fetchCategories, fetchListings, PAGE_SIZE } from "@/lib/listings"
+import { CategoryCard } from "@/components/categories/category-card"
+import { ListingCard } from "@/components/listings/listing-card"
 
-export default function Home() {
+function buildHref(categorySlug: string | undefined, offset: number) {
+  const params = new URLSearchParams()
+  if (categorySlug) params.set("category", categorySlug)
+  if (offset) params.set("offset", String(offset))
+  return `/?${params.toString()}`
+}
+
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const sp = await searchParams
+  const categorySlug =
+    typeof sp.category === "string" ? sp.category : undefined
+  const offset = Number(
+    typeof sp.offset === "string" && sp.offset ? sp.offset : 0
+  )
+
+  const categoriesPromise = fetchCategories()
+  const { listings, hasMore } = await fetchListings({
+    limit: PAGE_SIZE,
+    offset,
+    categorySlug,
+  })
+  const categories = await categoriesPromise
+
   return (
-    <main className="mx-auto flex w-full max-w-[1280px] flex-1 flex-col items-center justify-center px-4 py-16 text-center sm:px-6 lg:px-8">
-      <h1 className="max-w-2xl font-heading text-4xl font-semibold leading-[1.3] tracking-tight text-foreground sm:text-5xl">
-        Find your next thing. Sell what you no longer need.
-      </h1>
-      <p className="mt-4 max-w-xl text-lg leading-relaxed text-muted-foreground">
-        VinTech Marketplace connects buyers and sellers for trusted,
-        convenient second-hand commerce.
-      </p>
-      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-        <Button asChild size="lg">
-          <Link href="/search">Browse listings</Link>
-        </Button>
-        <Button asChild variant="outline" size="lg">
-          <Link href="/sell">Start selling</Link>
-        </Button>
-      </div>
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <section className="mb-12 text-center">
+        <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+          Marketplace for trusted second-hand goods
+        </h1>
+        <p className="mt-3 max-w-xl text-balance text-muted-foreground">
+          Buy and sell used items confidently across Addis Ababa.
+        </p>
+        <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+          <Button asChild size="lg">
+            <Link href="#listings">Browse listings</Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <Link href="/sell">Start selling</Link>
+          </Button>
+        </div>
+      </section>
+
+      <section aria-label="Browse by category" className="mb-10">
+        <h2 className="font-heading text-xl font-semibold">
+          Browse by category
+        </h2>
+        <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          {categories.map((c) => (
+            <CategoryCard
+              key={c.id}
+              category={c}
+              active={categorySlug === c.slug}
+            />
+          ))}
+        </div>
+        {categorySlug ? (
+          <Link
+            href={buildHref(undefined, 0)}
+            className="mt-3 inline-block text-sm underline"
+          >
+            All categories
+          </Link>
+        ) : null}
+      </section>
+
+      <section id="listings" aria-label="Listings">
+        <h2 className="sr-only">Listings</h2>
+        {listings.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-muted-foreground">
+              {categorySlug
+                ? "No listings in this category yet."
+                : "No listings found."}
+            </p>
+            {categorySlug ? (
+              <Link
+                href={buildHref(undefined, 0)}
+                className="mt-2 inline-block text-sm underline"
+              >
+                Clear filters
+              </Link>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {listings.map((l) => (
+                <li key={l.id}>
+                  <ListingCard listing={l} />
+                </li>
+              ))}
+            </ul>
+            {hasMore ? (
+              <div className="mt-10 flex justify-center">
+                <Link
+                  href={buildHref(categorySlug, offset + PAGE_SIZE)}
+                  className="text-sm font-medium underline"
+                >
+                  Load more
+                </Link>
+              </div>
+            ) : null}
+          </>
+        )}
+      </section>
     </main>
-  );
+  )
 }

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -12,6 +12,34 @@ function buildHref(categorySlug: string | undefined, offset: number) {
   return `/?${params.toString()}`
 }
 
+function NoResultsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M21 21l-4.35-4.35M9.5 18a8.5 8.5 0 110-17 8.5 8.5 0 010 17z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="7.5"
+        cy="7.5"
+        r="1.25"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 export default async function HomePage({
   searchParams,
 }: {
@@ -20,12 +48,12 @@ export default async function HomePage({
   const sp = await searchParams
   const categorySlug =
     typeof sp.category === "string" ? sp.category : undefined
-  const offset = Number(
-    typeof sp.offset === "string" && sp.offset ? sp.offset : 0
-  )
+  const rawOffset = typeof sp.offset === "string" ? Number(sp.offset) : 0
+  const offset =
+    Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0
 
   const categoriesPromise = fetchCategories()
-  const { listings, hasMore } = await fetchListings({
+  const { listings, hasMore, error } = await fetchListings({
     limit: PAGE_SIZE,
     offset,
     categorySlug,
@@ -76,21 +104,48 @@ export default async function HomePage({
 
       <section id="listings" aria-label="Listings">
         <h2 className="sr-only">Listings</h2>
-        {listings.length === 0 ? (
+        {error ? (
           <div className="py-16 text-center">
-            <p className="text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
+              We could not load listings.
+            </p>
+            <Link
+              href={buildHref(categorySlug, offset)}
+              className="mt-2 inline-block text-sm font-medium text-primary underline"
+            >
+              Retry
+            </Link>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="flex flex-col items-center py-16 text-center">
+            <NoResultsIcon className="mb-3 h-10 w-10 text-muted-foreground/60" />
+            <h3 className="font-heading text-lg font-semibold">
               {categorySlug
                 ? "No listings in this category yet."
                 : "No listings found."}
+            </h3>
+            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+              {categorySlug
+                ? "Try another category or clear your filter."
+                : "Be the first to list — sellers are adding listings all the time."}
             </p>
-            {categorySlug ? (
+            <div className="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
+              {categorySlug ? (
+                <Button asChild size="sm">
+                  <Link href={buildHref(undefined, 0)}>All categories</Link>
+                </Button>
+              ) : (
+                <Button asChild size="sm">
+                  <Link href="/sell">Start selling</Link>
+                </Button>
+              )}
               <Link
                 href={buildHref(undefined, 0)}
-                className="mt-2 inline-block text-sm underline"
+                className="text-sm underline"
               >
-                Clear filters
+                Refresh
               </Link>
-            ) : null}
+            </div>
           </div>
         ) : (
           <>

--- a/app/components/categories/category-card.tsx
+++ b/app/components/categories/category-card.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link"
+
+import type { Category } from "@/lib/listings"
+
+export function CategoryCard({
+  category,
+  active = false,
+}: {
+  category: Category
+  active?: boolean
+}) {
+  const base =
+    "group flex flex-col items-center justify-center gap-1.5 rounded-lg border p-3 text-center text-decoration-none"
+  const tile = active
+    ? "bg-primary text-primary-foreground"
+    : "bg-muted text-foreground hover:bg-primary hover:text-primary-foreground"
+
+  return (
+    <Link
+      href={`?category=${category.slug}`}
+      className={`${base} hover:border-primary`}
+    >
+      <span
+        className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${tile}`}
+      >
+        {category.name.charAt(0)}
+      </span>
+      <span className="text-sm font-medium">{category.name}</span>
+    </Link>
+  )
+}

--- a/app/components/categories/category-card.tsx
+++ b/app/components/categories/category-card.tsx
@@ -18,6 +18,7 @@ export function CategoryCard({
   return (
     <Link
       href={`?category=${category.slug}`}
+      aria-current={active ? "page" : undefined}
       className={`${base} hover:border-primary`}
     >
       <span

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@/components/ui/badge"
+
+import type { Condition } from "@/lib/listings"
+
+const CONDITION_COLORS: Record<string, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  Fair: "bg-amber-100 text-amber-800",
+}
+
+export function ConditionChip({ condition }: { condition: Condition }) {
+  const className = CONDITION_COLORS[condition] ?? "bg-neutral-100 text-neutral-800"
+  return (
+    <Badge variant="secondary" className={className}>
+      {condition}
+    </Badge>
+  )
+}

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+
+import type { BrowseListing } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings"
+import { ConditionChip } from "@/components/listings/condition-chip"
+import { SellerBadge } from "@/components/listings/seller-badge"
+
+export function ListingCard({ listing }: { listing: BrowseListing }) {
+  return (
+    <Link href={`/listings/${listing.id}`} className="group block w-full">
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
+        {listing.image_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={listing.image_url}
+            alt={listing.title}
+            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            No photo
+          </div>
+        )}
+      </div>
+      <div className="mt-2 space-y-1">
+        <p className="line-clamp-1 font-medium">{listing.title}</p>
+        <p className="font-semibold">{formatPrice(listing.price)}</p>
+        <div className="flex items-center gap-2">
+          <ConditionChip condition={listing.condition} />
+          {listing.city ? (
+            <span className="text-sm text-muted-foreground">{listing.city}</span>
+          ) : null}
+        </div>
+        <SellerBadge listing={listing} />
+      </div>
+    </Link>
+  )
+}

--- a/app/components/listings/seller-badge.tsx
+++ b/app/components/listings/seller-badge.tsx
@@ -1,0 +1,38 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+
+import type { BrowseListing } from "@/lib/listings"
+
+function initials(name: string | null): string {
+  if (!name) return "S"
+  const parts = name.split(/\s+/).filter(Boolean)
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+  }
+  return parts[0].slice(0, 2).toUpperCase()
+}
+
+export function SellerBadge({ listing }: { listing: BrowseListing }) {
+  const seller = listing.seller
+  if (!seller) return null
+  const trust = seller.trust_score
+
+  return (
+    <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+      <Avatar className="h-6 w-6">
+        <AvatarImage
+          src={seller.avatar_url ?? ""}
+          alt={seller.full_name ?? "seller"}
+        />
+        <AvatarFallback className="text-xs">{initials(seller.full_name)}</AvatarFallback>
+      </Avatar>
+      <span className="font-medium text-foreground">
+        {seller.full_name ?? "Seller"}
+      </span>
+      {trust != null && (
+        <span aria-label={`Trust score ${Math.round(trust)}`}>
+          Trust {Math.round(trust)}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -237,10 +237,10 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
 }
 
 export const PAGE_SIZE = 12
-// PostgREST (Supabase) caps an unpaginated select at 1000 rows; every browse
-// query is bounded to PAGE_SIZE so we stay well under that ceiling even with
-// deep paging via offset. (T05 browse)
-const BROWSE_LIMIT_MAX = 1000
+// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
+// windowed: each request fetches PAGE_SIZE rows and we never page past the
+// 1000-row ceiling (T05, NFR-COMP-003).
+export const BROWSE_LIMIT_MAX = 1000
 
 export interface BrowseSeller {
   id: string
@@ -250,27 +250,16 @@ export interface BrowseSeller {
   trust_score: number | null
 }
 
-export interface BrowseCategory {
-  id: string
-  name: string
-  slug: string
-}
-
 export interface BrowseListing {
   id: string
   title: string
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  view_count: number
-  favorite_count: number
   published_at: string
   image_url: string | null
   image_count: number
   seller: BrowseSeller | null
-  category: BrowseCategory | null
 }
 
 interface RawListingRow {
@@ -278,14 +267,9 @@ interface RawListingRow {
   title: string
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  view_count: number
-  favorite_count: number
   published_at: string
   seller: BrowseSeller[] | null
-  category: BrowseCategory[] | null
   images: ListingImage[] | null
 }
 
@@ -313,10 +297,18 @@ export async function fetchListings(opts: {
   listings: BrowseListing[]
   count: number | null
   hasMore: boolean
+  error: string | null
 }> {
   const supabase = await createClient()
   const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
-  const offset = opts.offset ?? 0
+  // Clamp + guard the pagination window: finite, non-negative, and never past
+  // the 1000-row ceiling so "Load more" always terminates. (§15: validate
+  // external input — offset comes from the URL.)
+  const requestedOffset = opts.offset ?? 0
+  const offset =
+    Number.isFinite(requestedOffset) && requestedOffset > 0
+      ? Math.min(requestedOffset, BROWSE_LIMIT_MAX - 1)
+      : 0
 
   let categoryId: string | null = null
   if (opts.categorySlug) {
@@ -326,15 +318,14 @@ export async function fetchListings(opts: {
       .eq("slug", opts.categorySlug)
       .maybeSingle()
     categoryId = cat?.id ?? null
-    if (!categoryId) return { listings: [], count: 0, hasMore: false }
+    if (!categoryId) return { listings: [], count: 0, hasMore: false, error: null }
   }
 
   let query = supabase
     .from("listings")
     .select(
-      `id, title, price, condition, negotiable, city, sub_city, view_count, favorite_count, published_at,
+      `id, title, price, condition, city, published_at,
        seller:profiles(id, full_name, avatar_url, role, trust_score),
-       category:categories(id, name, slug),
        images:listing_images(id, image_url, display_order)`,
       { count: "exact" }
     )
@@ -347,7 +338,7 @@ export async function fetchListings(opts: {
 
   if (error) {
     console.error("fetchListings:", error.message)
-    return { listings: [], count, hasMore: false }
+    return { listings: [], count, hasMore: false, error: error.message }
   }
 
   const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
@@ -358,17 +349,12 @@ export async function fetchListings(opts: {
           .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
         null
       const seller = l.seller?.[0] ?? null
-      const category = l.category?.[0] ?? null
       return {
         id: l.id,
         title: l.title,
         price: l.price,
         condition: l.condition,
-        negotiable: l.negotiable,
         city: l.city,
-        sub_city: l.sub_city,
-        view_count: l.view_count,
-        favorite_count: l.favorite_count,
         published_at: l.published_at,
         image_url: cover,
         image_count: images.length,
@@ -381,15 +367,12 @@ export async function fetchListings(opts: {
               trust_score: seller.trust_score,
             }
           : null,
-        category: category
-          ? { id: category.id, name: category.name, slug: category.slug }
-          : null,
       }
     }
   )
 
   const hasMore = typeof count === "number" ? offset + listings.length < count : false
-  return { listings, count, hasMore }
+  return { listings, count, hasMore, error: null }
 }
 
 // ---- Writes (called by server actions; DB access centralized here, §17) ----

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -236,6 +236,162 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
   return data as Listing[]
 }
 
+export const PAGE_SIZE = 12
+// PostgREST (Supabase) caps an unpaginated select at 1000 rows; every browse
+// query is bounded to PAGE_SIZE so we stay well under that ceiling even with
+// deep paging via offset. (T05 browse)
+const BROWSE_LIMIT_MAX = 1000
+
+export interface BrowseSeller {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+export interface BrowseCategory {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface BrowseListing {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  view_count: number
+  favorite_count: number
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller: BrowseSeller | null
+  category: BrowseCategory | null
+}
+
+interface RawListingRow {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  view_count: number
+  favorite_count: number
+  published_at: string
+  seller: BrowseSeller[] | null
+  category: BrowseCategory[] | null
+  images: ListingImage[] | null
+}
+
+export function formatPrice(price: number | string): string {
+  const n = typeof price === "number" ? price : Number(price)
+  if (Number.isNaN(n)) return "ETB —"
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(n)
+  } catch {
+    return `ETB ${Math.round(n)}`
+  }
+}
+
+// Public, paginated browse of published listings (anon-readable via RLS).
+export async function fetchListings(opts: {
+  limit?: number
+  offset?: number
+  categorySlug?: string
+} = {}): Promise<{
+  listings: BrowseListing[]
+  count: number | null
+  hasMore: boolean
+}> {
+  const supabase = await createClient()
+  const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
+  const offset = opts.offset ?? 0
+
+  let categoryId: string | null = null
+  if (opts.categorySlug) {
+    const { data: cat } = await supabase
+      .from("categories")
+      .select("id")
+      .eq("slug", opts.categorySlug)
+      .maybeSingle()
+    categoryId = cat?.id ?? null
+    if (!categoryId) return { listings: [], count: 0, hasMore: false }
+  }
+
+  let query = supabase
+    .from("listings")
+    .select(
+      `id, title, price, condition, negotiable, city, sub_city, view_count, favorite_count, published_at,
+       seller:profiles(id, full_name, avatar_url, role, trust_score),
+       category:categories(id, name, slug),
+       images:listing_images(id, image_url, display_order)`,
+      { count: "exact" }
+    )
+    .eq("status", "published")
+  if (categoryId) query = query.eq("category_id", categoryId)
+
+  const { data, error, count } = await query
+    .order("published_at", { ascending: false })
+    .range(offset, offset + limit - 1)
+
+  if (error) {
+    console.error("fetchListings:", error.message)
+    return { listings: [], count, hasMore: false }
+  }
+
+  const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
+    (l) => {
+      const images = l.images ?? []
+      const cover =
+        [...images]
+          .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
+        null
+      const seller = l.seller?.[0] ?? null
+      const category = l.category?.[0] ?? null
+      return {
+        id: l.id,
+        title: l.title,
+        price: l.price,
+        condition: l.condition,
+        negotiable: l.negotiable,
+        city: l.city,
+        sub_city: l.sub_city,
+        view_count: l.view_count,
+        favorite_count: l.favorite_count,
+        published_at: l.published_at,
+        image_url: cover,
+        image_count: images.length,
+        seller: seller
+          ? {
+              id: seller.id,
+              full_name: seller.full_name,
+              avatar_url: seller.avatar_url,
+              role: seller.role,
+              trust_score: seller.trust_score,
+            }
+          : null,
+        category: category
+          ? { id: category.id, name: category.name, slug: category.slug }
+          : null,
+      }
+    }
+  )
+
+  const hasMore = typeof count === "number" ? offset + listings.length < count : false
+  return { listings, count, hasMore }
+}
+
 // ---- Writes (called by server actions; DB access centralized here, §17) ----
 
 export async function createListing(


### PR DESCRIPTION
T05 — Browse & discover (issue #9, blocked by #8 ✅). 

**Implements**
- \lib/listings.ts\: \etchListings\ (public, published-only, offset pagination bounded to <1000 rows, optional \categorySlug\ filter) + \PAGE_SIZE\, \ormatPrice\, \BrowseListing/BrowseSeller/BrowseCategory\ types.
- Components: \ListingCard\ (cover image, title, price, ConditionChip, SellerBadge), \SellerBadge\ (avatar + trust score), \ConditionChip\, \CategoryCard\.
- \pp/page.tsx\: hero (browse + sell CTAs), category browse section, listing grid, load-more pagination, responsive grid (mobile → 4-col desktop), empty states.

**Acceptance criteria**
- [x] Homepage lists active listings as cards (image, title, price, location, condition chip, trust indicator)
- [x] Category browse renders a filtered grid per category
- [x] Pagination (load-more, offset-based) respecting Supabase 1000-row ceiling
- [x] Responsive card grid (320px–1920px, NFR-COMP-002/003)
- [x] Seller card on listing shows seller name + trust indicator

**Checks**: typecheck, lint, build green locally. Runtime/RLS verification pending (see T04 sign-off note — staging stack deferred).

Part of #1. Closes #9.