### PR TITLE
feat(browse): T05 browse seams + Vitest unit-test scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    name: Lint, Typecheck & Build
+    name: Lint, Typecheck, Tests & Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,6 +36,9 @@ jobs:
 
       - name: Type check
         run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/app/app/actions/listings.ts
+++ b/app/app/actions/listings.ts
@@ -1,0 +1,280 @@
+"use server"
+
+import { z } from "zod"
+import { redirect } from "next/navigation"
+import { revalidatePath } from "next/cache"
+
+import { getCurrentUser } from "@/lib/auth"
+import { createClient } from "@/lib/supabase/server"
+
+const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+const STATUSES = ["draft", "published", "sold", "archived"] as const
+const ALLOWED_IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"]
+const MAX_IMAGES = 10
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+const conditionEnum = z.enum(CONDITIONS)
+const statusEnum = z.enum(STATUSES)
+const photoSchema = z
+  .instanceof(File)
+  .refine((f) => f && f.size > 0, "Choose at least one photo")
+  .refine((f) => ALLOWED_IMAGE_MIME.includes(f.type), "JPG, PNG or WebP only")
+  .refine(
+    (f) => f.size <= MAX_IMAGE_BYTES,
+    "Each photo must be 5 MB or smaller"
+  )
+
+const baseListingFields = {
+  title: z.string().min(5, "Title needs at least 5 characters").max(120),
+  description: z.string().max(2000).optional(),
+  price: z.coerce.number().gt(0, "Price must be greater than 0"),
+  condition: conditionEnum,
+  categoryId: z.string().uuid().optional(),
+  city: z.string().min(1, "Enter a city").max(100),
+  subCity: z.string().max(100).optional(),
+  address: z.string().max(200).optional(),
+  negotiable: z.boolean().optional(),
+}
+
+const createListingSchema = z.object({
+  ...baseListingFields,
+  photos: z
+    .array(photoSchema)
+    .min(1, "Add at least one photo")
+    .max(MAX_IMAGES, `Up to ${MAX_IMAGES} photos allowed`),
+})
+
+const editListingSchema = z.object({
+  ...baseListingFields,
+  id: z.string().uuid(),
+  status: statusEnum.optional(),
+})
+
+export type CreateListingState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+  listingId?: string
+}
+
+export type EditListingState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+export type DeleteListingState = {
+  message?: string
+  ok?: boolean
+}
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
+
+export async function createListing(
+  _prevState: CreateListingState,
+  formData: FormData
+): Promise<CreateListingState> {
+  const files = (formData.getAll("photos") as File[]).filter(
+    (f) => f && f.size > 0
+  )
+
+  const parsed = createListingSchema.safeParse({
+    title: formData.get("title"),
+    description: formValue(formData, "description"),
+    price: formData.get("price"),
+    condition: formData.get("condition"),
+    categoryId: formValue(formData, "categoryId"),
+    city: formData.get("city"),
+    subCity: formValue(formData, "subCity"),
+    address: formValue(formData, "address"),
+    negotiable: formData.get("negotiable") === "on",
+    photos: files.length ? files : undefined,
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await getCurrentUser()
+  if (!user || (user.role !== "seller" && user.role !== "admin")) {
+    redirect("/profile")
+  }
+
+  const supabase = await createClient()
+
+  if (parsed.data.categoryId) {
+    const { count } = await supabase
+      .from("categories")
+      .select("id", { count: "exact", head: true })
+      .eq("id", parsed.data.categoryId)
+    if (!count) {
+      return { errors: { categoryId: ["Picked category is not available"] } }
+    }
+  }
+
+  const { data: listing, error } = await supabase
+    .from("listings")
+    .insert({
+      seller_id: user.id,
+      category_id: parsed.data.categoryId ?? null,
+      title: parsed.data.title,
+      description: parsed.data.description ?? null,
+      price: parsed.data.price,
+      condition: parsed.data.condition,
+      city: parsed.data.city,
+      sub_city: parsed.data.subCity ?? null,
+      address: parsed.data.address ?? null,
+      negotiable: parsed.data.negotiable ?? false,
+      status: "published",
+    })
+    .select("id")
+    .single()
+
+  if (error || !listing) {
+    return { message: error?.message ?? "Could not create listing" }
+  }
+
+  const uploadError = await uploadListingPhotos(
+    supabase,
+    listing.id,
+    user.id,
+    parsed.data.photos ?? []
+  )
+  if (uploadError) {
+    return { message: uploadError }
+  }
+
+  revalidatePath("/dashboard")
+  revalidatePath(`/listings/${listing.id}`)
+  return { ok: true, listingId: listing.id }
+}
+
+export async function updateListing(
+  _prevState: EditListingState,
+  formData: FormData
+): Promise<EditListingState> {
+  const parsed = editListingSchema.safeParse({
+    id: formValue(formData, "id"),
+    title: formData.get("title"),
+    description: formValue(formData, "description"),
+    price: formData.get("price"),
+    condition: formData.get("condition"),
+    categoryId: formValue(formData, "categoryId"),
+    city: formData.get("city"),
+    subCity: formValue(formData, "subCity"),
+    address: formValue(formData, "address"),
+    negotiable: formData.get("negotiable") === "on",
+    status: formValue(formData, "status"),
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await getCurrentUser()
+  if (!user || (user.role !== "seller" && user.role !== "admin")) {
+    redirect("/profile")
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("listings")
+    .update({
+      category_id: parsed.data.categoryId ?? null,
+      title: parsed.data.title,
+      description: parsed.data.description ?? null,
+      price: parsed.data.price,
+      condition: parsed.data.condition,
+      city: parsed.data.city,
+      sub_city: parsed.data.subCity ?? null,
+      address: parsed.data.address ?? null,
+      negotiable: parsed.data.negotiable ?? false,
+      ...(parsed.data.status ? { status: parsed.data.status } : {}),
+    })
+    .eq("id", parsed.data.id)
+    .eq("seller_id", user.id)
+    .select("id")
+
+  // RLS + the seller_id filter both block non-owners; .select() lets us detect
+  // the zero-rows case instead of silently no-op'ing.
+  if (error) {
+    return { message: error.message }
+  }
+  if (!data || data.length === 0) {
+    return { message: "Listing not found" }
+  }
+
+  revalidatePath(`/listings/${parsed.data.id}`)
+  revalidatePath("/dashboard")
+  return { ok: true }
+}
+
+export async function deleteListing(
+  _prevState: DeleteListingState,
+  formData: FormData
+): Promise<DeleteListingState> {
+  const id = formValue(formData, "id")
+  if (!id) return { message: "Missing listing id", ok: false }
+
+  const user = await getCurrentUser()
+  if (!user) redirect("/login")
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("listings")
+    .update({ status: "archived", deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("seller_id", user.id)
+    .select("id")
+
+  if (error) {
+    return { message: error.message, ok: false }
+  }
+  if (!data || data.length === 0) {
+    return { message: "Listing not found", ok: false }
+  }
+
+  revalidatePath("/dashboard")
+  revalidatePath(`/listings/${id}`)
+  return { ok: true }
+}
+
+async function uploadListingPhotos(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  listingId: string,
+  sellerId: string,
+  files: File[]
+): Promise<string | null> {
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const ext = (file.name.split(".").pop() || "png").toLowerCase()
+    const path = `listings/${listingId}/${Date.now()}-${i}.${ext}`
+
+    const { error: uploadError } = await supabase.storage
+      .from("listings")
+      .upload(path, file, { upsert: true })
+
+    if (uploadError) {
+      return uploadError.message
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("listings").getPublicUrl(path)
+
+    const { error: imageError } = await supabase.from("listing_images").insert({
+      listing_id: listingId,
+      image_url: publicUrl,
+      display_order: i,
+      alt_text: null,
+    })
+
+    if (imageError) {
+      return imageError.message
+    }
+  }
+  return null
+}

--- a/app/app/actions/listings.ts
+++ b/app/app/actions/listings.ts
@@ -5,49 +5,49 @@ import { redirect } from "next/navigation"
 import { revalidatePath } from "next/cache"
 
 import { getCurrentUser } from "@/lib/auth"
-import { createClient } from "@/lib/supabase/server"
+import {
+  createListing as createListingRow,
+  updateListing as updateListingRow,
+  softDeleteListing,
+  CONDITIONS,
+  STATUSES,
+  MAX_IMAGES,
+} from "@/lib/listings"
 
-const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
-const STATUSES = ["draft", "published", "sold", "archived"] as const
-const ALLOWED_IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"]
-const MAX_IMAGES = 10
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
 
-const conditionEnum = z.enum(CONDITIONS)
-const statusEnum = z.enum(STATUSES)
-const photoSchema = z
-  .instanceof(File)
-  .refine((f) => f && f.size > 0, "Choose at least one photo")
-  .refine((f) => ALLOWED_IMAGE_MIME.includes(f.type), "JPG, PNG or WebP only")
-  .refine(
-    (f) => f.size <= MAX_IMAGE_BYTES,
-    "Each photo must be 5 MB or smaller"
-  )
-
-const baseListingFields = {
+const createSchema = z.object({
   title: z.string().min(5, "Title needs at least 5 characters").max(120),
-  description: z.string().max(2000).optional(),
-  price: z.coerce.number().gt(0, "Price must be greater than 0"),
-  condition: conditionEnum,
+  description: z.string().max(2000).optional().refine((v) => !v || v.length >= 20, "Description needs at least 20 characters"),
+  price: z.coerce
+    .number({ message: "Enter a price" })
+    .gt(0, "Price must be greater than 0"),
+  condition: z.enum(CONDITIONS),
   categoryId: z.string().uuid().optional(),
   city: z.string().min(1, "Enter a city").max(100),
   subCity: z.string().max(100).optional(),
   address: z.string().max(200).optional(),
   negotiable: z.boolean().optional(),
-}
-
-const createListingSchema = z.object({
-  ...baseListingFields,
-  photos: z
-    .array(photoSchema)
-    .min(1, "Add at least one photo")
-    .max(MAX_IMAGES, `Up to ${MAX_IMAGES} photos allowed`),
+  photos: z.array(z.instanceof(File)).min(1, "Add at least one photo").max(MAX_IMAGES, `Up to ${MAX_IMAGES} photos allowed`),
 })
 
-const editListingSchema = z.object({
-  ...baseListingFields,
+const editSchema = z.object({
   id: z.string().uuid(),
-  status: statusEnum.optional(),
+  title: z.string().min(5, "Title needs at least 5 characters").max(120),
+  description: z.string().max(2000).optional().refine((v) => !v || v.length >= 20, "Description needs at least 20 characters"),
+  price: z.coerce
+    .number({ message: "Enter a price" })
+    .gt(0, "Price must be greater than 0"),
+  condition: z.enum(CONDITIONS),
+  categoryId: z.string().uuid().optional(),
+  city: z.string().min(1, "Enter a city").max(100),
+  subCity: z.string().max(100).optional(),
+  address: z.string().max(200).optional(),
+  negotiable: z.boolean().optional(),
+  status: z.enum(STATUSES).optional(),
 })
 
 export type CreateListingState = {
@@ -68,11 +68,6 @@ export type DeleteListingState = {
   ok?: boolean
 }
 
-function formValue(formData: FormData, key: string): string | undefined {
-  const v = formData.get(key)
-  return typeof v === "string" && v.length > 0 ? v : undefined
-}
-
 export async function createListing(
   _prevState: CreateListingState,
   formData: FormData
@@ -81,7 +76,7 @@ export async function createListing(
     (f) => f && f.size > 0
   )
 
-  const parsed = createListingSchema.safeParse({
+  const parsed = createSchema.safeParse({
     title: formData.get("title"),
     description: formValue(formData, "description"),
     price: formData.get("price"),
@@ -103,60 +98,31 @@ export async function createListing(
     redirect("/profile")
   }
 
-  const supabase = await createClient()
+  try {
+    const result = await createListingRow(
+      { ...parsed.data, negotiable: parsed.data.negotiable ?? false },
+      user.id
+    )
 
-  if (parsed.data.categoryId) {
-    const { count } = await supabase
-      .from("categories")
-      .select("id", { count: "exact", head: true })
-      .eq("id", parsed.data.categoryId)
-    if (!count) {
-      return { errors: { categoryId: ["Picked category is not available"] } }
+    if ("error" in result) {
+      return { message: result.error }
+    }
+
+    revalidatePath("/dashboard")
+    revalidatePath(`/listings/${result.id}`)
+    return { ok: true, listingId: result.id }
+  } catch (e) {
+    return {
+      message: e instanceof Error ? e.message : "Could not create listing",
     }
   }
-
-  const { data: listing, error } = await supabase
-    .from("listings")
-    .insert({
-      seller_id: user.id,
-      category_id: parsed.data.categoryId ?? null,
-      title: parsed.data.title,
-      description: parsed.data.description ?? null,
-      price: parsed.data.price,
-      condition: parsed.data.condition,
-      city: parsed.data.city,
-      sub_city: parsed.data.subCity ?? null,
-      address: parsed.data.address ?? null,
-      negotiable: parsed.data.negotiable ?? false,
-      status: "published",
-    })
-    .select("id")
-    .single()
-
-  if (error || !listing) {
-    return { message: error?.message ?? "Could not create listing" }
-  }
-
-  const uploadError = await uploadListingPhotos(
-    supabase,
-    listing.id,
-    user.id,
-    parsed.data.photos ?? []
-  )
-  if (uploadError) {
-    return { message: uploadError }
-  }
-
-  revalidatePath("/dashboard")
-  revalidatePath(`/listings/${listing.id}`)
-  return { ok: true, listingId: listing.id }
 }
 
 export async function updateListing(
   _prevState: EditListingState,
   formData: FormData
 ): Promise<EditListingState> {
-  const parsed = editListingSchema.safeParse({
+  const parsed = editSchema.safeParse({
     id: formValue(formData, "id"),
     title: formData.get("title"),
     description: formValue(formData, "description"),
@@ -179,37 +145,36 @@ export async function updateListing(
     redirect("/profile")
   }
 
-  const supabase = await createClient()
-  const { data, error } = await supabase
-    .from("listings")
-    .update({
-      category_id: parsed.data.categoryId ?? null,
-      title: parsed.data.title,
-      description: parsed.data.description ?? null,
-      price: parsed.data.price,
-      condition: parsed.data.condition,
-      city: parsed.data.city,
-      sub_city: parsed.data.subCity ?? null,
-      address: parsed.data.address ?? null,
-      negotiable: parsed.data.negotiable ?? false,
-      ...(parsed.data.status ? { status: parsed.data.status } : {}),
-    })
-    .eq("id", parsed.data.id)
-    .eq("seller_id", user.id)
-    .select("id")
+  try {
+    const result = await updateListingRow(
+      {
+        id: parsed.data.id,
+        title: parsed.data.title,
+        description: parsed.data.description,
+        price: parsed.data.price,
+        condition: parsed.data.condition,
+        categoryId: parsed.data.categoryId,
+        city: parsed.data.city,
+        subCity: parsed.data.subCity,
+        address: parsed.data.address,
+        negotiable: parsed.data.negotiable ?? false,
+        status: parsed.data.status,
+      },
+      user.id
+    )
 
-  // RLS + the seller_id filter both block non-owners; .select() lets us detect
-  // the zero-rows case instead of silently no-op'ing.
-  if (error) {
-    return { message: error.message }
-  }
-  if (!data || data.length === 0) {
-    return { message: "Listing not found" }
-  }
+    if (!result.ok) {
+      return { message: result.error ?? "Could not update listing" }
+    }
 
-  revalidatePath(`/listings/${parsed.data.id}`)
-  revalidatePath("/dashboard")
-  return { ok: true }
+    revalidatePath(`/listings/${parsed.data.id}`)
+    revalidatePath("/dashboard")
+    return { ok: true }
+  } catch (e) {
+    return {
+      message: e instanceof Error ? e.message : "Could not update listing",
+    }
+  }
 }
 
 export async function deleteListing(
@@ -222,59 +187,18 @@ export async function deleteListing(
   const user = await getCurrentUser()
   if (!user) redirect("/login")
 
-  const supabase = await createClient()
-  const { data, error } = await supabase
-    .from("listings")
-    .update({ status: "archived", deleted_at: new Date().toISOString() })
-    .eq("id", id)
-    .eq("seller_id", user.id)
-    .select("id")
-
-  if (error) {
-    return { message: error.message, ok: false }
-  }
-  if (!data || data.length === 0) {
-    return { message: "Listing not found", ok: false }
-  }
-
-  revalidatePath("/dashboard")
-  revalidatePath(`/listings/${id}`)
-  return { ok: true }
-}
-
-async function uploadListingPhotos(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  listingId: string,
-  sellerId: string,
-  files: File[]
-): Promise<string | null> {
-  for (let i = 0; i < files.length; i++) {
-    const file = files[i]
-    const ext = (file.name.split(".").pop() || "png").toLowerCase()
-    const path = `listings/${listingId}/${Date.now()}-${i}.${ext}`
-
-    const { error: uploadError } = await supabase.storage
-      .from("listings")
-      .upload(path, file, { upsert: true })
-
-    if (uploadError) {
-      return uploadError.message
+  try {
+    const result = await softDeleteListing(id, user.id)
+    if (!result.ok) {
+      return { message: result.error ?? "Could not archive listing", ok: false }
     }
-
-    const {
-      data: { publicUrl },
-    } = supabase.storage.from("listings").getPublicUrl(path)
-
-    const { error: imageError } = await supabase.from("listing_images").insert({
-      listing_id: listingId,
-      image_url: publicUrl,
-      display_order: i,
-      alt_text: null,
-    })
-
-    if (imageError) {
-      return imageError.message
+    revalidatePath("/dashboard")
+    revalidatePath(`/listings/${id}`)
+    return { ok: true }
+  } catch (e) {
+    return {
+      message: e instanceof Error ? e.message : "Could not archive listing",
+      ok: false,
     }
   }
-  return null
 }

--- a/app/app/actions/profile.ts
+++ b/app/app/actions/profile.ts
@@ -6,6 +6,12 @@ import { revalidatePath } from "next/cache"
 
 import { getCurrentUser } from "@/lib/auth"
 import { createClient } from "@/lib/supabase/server"
+import {
+  ALLOWED_IMAGE_MIME,
+  MAX_IMAGE_BYTES,
+  detectImageMime,
+  uploadObjects,
+} from "@/lib/media"
 
 const onboardingSchema = z.object({
   fullName: z.string().min(2, "Enter your full name"),
@@ -126,9 +132,6 @@ export async function updateProfile(
   return { ok: true }
 }
 
-const ALLOWED_AVATAR_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
-const MAX_AVATAR_BYTES = 5 * 1024 * 1024
-
 export async function uploadAvatar(
   uid: string,
   _prevState: { url: string | null; error: string | null },
@@ -143,39 +146,44 @@ export async function uploadAvatar(
   if (!file || !file.size) {
     return { url: null, error: "Choose an image to upload" }
   }
-  if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
-    return { url: null, error: "Upload a JPG, PNG or WebP image" }
-  }
-  if (file.size > MAX_AVATAR_BYTES) {
-    return { url: null, error: "Avatar must be 5 MB or smaller" }
-  }
 
   const supabase = await createClient()
-  const ext = (file.name.split(".").pop() || "png").toLowerCase()
-  const path = `avatars/${uid}/${Date.now()}.${ext}`
+  // The avatar adapter: second adapter behind the shared Media upload seam.
+  // Validation now uses magic bytes (not the client MIME type) — matching the
+  // listing-image path so both adapters share one security surface.
+  const result = await uploadObjects(
+    [{ file, index: 0 }],
+    {
+      bucket: "profiles",
+      upsert: true,
+      validate: async (file) => {
+        const mime = await detectImageMime(file)
+        if (!mime || !ALLOWED_IMAGE_MIME.includes(mime)) {
+          return "Upload a JPG, PNG or WebP image"
+        }
+        if (file.size > MAX_IMAGE_BYTES) {
+          return "Avatar must be 5 MB or smaller"
+        }
+        return null
+      },
+      path: () => {
+        const ext = (file.name.split(".").pop() || "png").toLowerCase()
+        return `avatars/${uid}/${Date.now()}.${ext}`
+      },
+      reconcile: async (publicUrl) => {
+        const { error } = await supabase
+          .from("profiles")
+          .update({ avatar_url: publicUrl })
+          .eq("id", uid)
+        return error ? error.message : null
+      },
+    },
+    supabase
+  )
 
-  const { error: uploadError } = await supabase.storage
-    .from("profiles")
-    .upload(path, file, { upsert: true })
-
-  if (uploadError) {
-    return { url: null, error: uploadError.message }
-  }
-
-  const {
-    data: { publicUrl },
-  } = supabase.storage.from("profiles").getPublicUrl(path)
-
-  const { error: updateError } = await supabase
-    .from("profiles")
-    .update({ avatar_url: publicUrl })
-    .eq("id", uid)
-
-  if (updateError) {
-    return { url: publicUrl, error: updateError.message }
-  }
+  if (!result.ok) return { url: null, error: result.error }
 
   revalidatePath("/profile")
   revalidatePath(`/users/${user.id}`)
-  return { url: publicUrl, error: null }
+  return { url: result.publicUrls[0], error: null }
 }

--- a/app/app/actions/profile.ts
+++ b/app/app/actions/profile.ts
@@ -64,3 +64,118 @@ export async function completeProfile(
   revalidatePath("/profile")
   redirect("/profile")
 }
+
+const editProfileSchema = z.object({
+  city: z.string().min(1, "Enter your city").max(100),
+  subCity: z.string().max(100).optional(),
+  phone: z.string().max(30, "Phone number is too long").optional(),
+  telegramUsername: z
+    .string()
+    .max(50, "Too long")
+    .transform((v) => (v ? v.replace(/^@/, "") : v))
+    .optional(),
+  bio: z.string().max(300, "Bio must be 300 characters or fewer").optional(),
+  phonePublic: z.boolean().optional(),
+})
+
+export type EditProfileState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+export async function updateProfile(
+  _prevState: EditProfileState,
+  formData: FormData
+): Promise<EditProfileState> {
+  const parsed = editProfileSchema.safeParse({
+    city: formData.get("city"),
+    subCity: formData.get("subCity") || undefined,
+    phone: formData.get("phone") || undefined,
+    telegramUsername: formData.get("telegramUsername") || undefined,
+    bio: formData.get("bio") || undefined,
+    phonePublic: formData.get("phonePublic") === "on",
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await getCurrentUser()
+  if (!user) redirect("/login")
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from("profiles")
+    .update({
+      city: parsed.data.city,
+      sub_city: parsed.data.subCity || null,
+      phone: parsed.data.phone || null,
+      telegram_username: parsed.data.telegramUsername || null,
+      bio: parsed.data.bio || null,
+      phone_public: parsed.data.phonePublic ?? false,
+    })
+    .eq("id", user.id)
+
+  if (error) {
+    return { message: error.message }
+  }
+
+  revalidatePath("/profile")
+  revalidatePath(`/users/${user.id}`)
+  return { ok: true }
+}
+
+const ALLOWED_AVATAR_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024
+
+export async function uploadAvatar(
+  uid: string,
+  _prevState: { url: string | null; error: string | null },
+  formData: FormData
+): Promise<{ url: string | null; error: string | null }> {
+  const user = await getCurrentUser()
+  if (!user || user.id !== uid) {
+    return { url: null, error: "Not authorized" }
+  }
+
+  const file = formData.get("avatar") as File | null
+  if (!file || !file.size) {
+    return { url: null, error: "Choose an image to upload" }
+  }
+  if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+    return { url: null, error: "Upload a JPG, PNG or WebP image" }
+  }
+  if (file.size > MAX_AVATAR_BYTES) {
+    return { url: null, error: "Avatar must be 5 MB or smaller" }
+  }
+
+  const supabase = await createClient()
+  const ext = (file.name.split(".").pop() || "png").toLowerCase()
+  const path = `avatars/${uid}/${Date.now()}.${ext}`
+
+  const { error: uploadError } = await supabase.storage
+    .from("profiles")
+    .upload(path, file, { upsert: true })
+
+  if (uploadError) {
+    return { url: null, error: uploadError.message }
+  }
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from("profiles").getPublicUrl(path)
+
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ avatar_url: publicUrl })
+    .eq("id", uid)
+
+  if (updateError) {
+    return { url: publicUrl, error: updateError.message }
+  }
+
+  revalidatePath("/profile")
+  revalidatePath(`/users/${user.id}`)
+  return { url: publicUrl, error: null }
+}

--- a/app/app/listings/[id]/edit/page.tsx
+++ b/app/app/listings/[id]/edit/page.tsx
@@ -13,7 +13,7 @@ export default async function EditListingPage({
 }) {
   const user = await requireSeller()
   const { id } = await params
-  const data = await fetchListing(id)
+  const data = await fetchListing(id, { includeSeller: false })
   if (!data) notFound()
   // Only the owning seller (or an admin) may edit.
   if (data.listing.seller_id !== user.id && user.role !== "admin") notFound()

--- a/app/app/listings/[id]/edit/page.tsx
+++ b/app/app/listings/[id]/edit/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation"
+
+import { requireSeller } from "@/lib/auth"
+import { fetchCategories, fetchListing } from "@/lib/listings"
+import { EditListingForm } from "@/components/listings/edit-listing-form"
+
+export const dynamic = "force-dynamic"
+
+export default async function EditListingPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const user = await requireSeller()
+  const { id } = await params
+  const data = await fetchListing(id)
+  if (!data) notFound()
+  // Only the owning seller (or an admin) may edit.
+  if (data.listing.seller_id !== user.id && user.role !== "admin") notFound()
+
+  const categories = await fetchCategories()
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="font-heading text-2xl font-semibold text-foreground">
+        Edit listing
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Update your listing details. Changes are saved immediately.
+      </p>
+      <EditListingForm listing={data.listing} categories={categories} />
+    </main>
+  )
+}

--- a/app/app/listings/[id]/error.tsx
+++ b/app/app/listings/[id]/error.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function ListingError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.error("Listing route error:", error)
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col items-center justify-center gap-4 px-4 py-20 text-center">
+      <h1 className="font-heading text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-sm text-muted-foreground">
+        We could not load this listing right now.
+      </p>
+      <div className="flex gap-3">
+        <Button onClick={reset}>Try again</Button>
+        <Button asChild variant="outline">
+          <Link href="/">Back to listings</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/app/app/listings/[id]/loading.tsx
+++ b/app/app/listings/[id]/loading.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+export const metadata = { title: "Loading listing…" }
+
+export default function ListingLoading() {
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="grid grid-cols-1 gap-8 animate-pulse md:grid-cols-2">
+        <div className="aspect-[4/3] w-full rounded-lg bg-muted" />
+        <div className="flex flex-col gap-5">
+          <Card>
+            <CardHeader>
+              <div className="h-6 w-3/4 rounded bg-muted" />
+              <div className="mt-2 h-4 w-1/4 rounded bg-muted" />
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="h-4 w-1/2 rounded bg-muted" />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/app/listings/[id]/not-found.tsx
+++ b/app/app/listings/[id]/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export default function ListingNotFound() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center px-4 py-20 text-center">
+      <h1 className="font-heading text-2xl font-semibold">Listing not found</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This listing may have been removed, archived, or never existed.
+      </p>
+      <Link href="/" className={cn(buttonVariants({ variant: "link", size: "lg" }), "mt-4")}>
+        Back to all listings
+      </Link>
+    </main>
+  )
+}

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 import { MapPinIcon, TagIcon } from "lucide-react"
 
 import { ROLE_LABELS } from "@/lib/auth"
+import type { UserRole } from "@/lib/auth/types"
 import { fetchListing } from "@/lib/listings"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -56,7 +57,8 @@ export default async function ListingPage({
 
   const { listing: l, images, category, seller } = data
   const cover = images[0]?.image_url
-  const roleLabel = ROLE_LABELS[(l.seller_id ? "seller" : "buyer")] ?? "Seller"
+  const roleLabel =
+    ROLE_LABELS[(seller?.role ?? "seller") as UserRole] ?? "Seller"
 
   return (
     <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -5,7 +5,7 @@ import { MapPinIcon, TagIcon } from "lucide-react"
 
 import { ROLE_LABELS } from "@/lib/auth"
 import type { UserRole } from "@/lib/auth/types"
-import { fetchListing } from "@/lib/listings"
+import { fetchListing, formatCondition, formatPrice } from "@/lib/listings"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -20,7 +20,7 @@ export async function generateMetadata({
   params: Promise<{ id: string }>
 }): Promise<Metadata> {
   const { id } = await params
-  const data = await fetchListing(id)
+  const data = await fetchListing(id, { includeSeller: false })
   if (!data) return { title: "Listing not found" }
   const l = data.listing
   return {
@@ -31,18 +31,6 @@ export async function generateMetadata({
       description: l.description ?? undefined,
       images: data.images.length ? [data.images[0]?.image_url] : undefined,
     },
-  }
-}
-
-function formatPrice(price: number | string) {
-  try {
-    return new Intl.NumberFormat("en-ET", {
-      style: "currency",
-      currency: "ETB",
-      maximumFractionDigits: 2,
-    }).format(typeof price === "number" ? price : Number(price))
-  } catch {
-    return `ETB ${price}`
   }
 }
 
@@ -102,7 +90,7 @@ export default async function ListingPage({
           </div>
 
           <p className="text-2xl font-semibold text-foreground">
-            {formatPrice(l.price)}
+            {formatPrice(l.price, { maxFractionDigits: 2 })}
             {l.negotiable ? " (or best offer)" : null}
           </p>
 
@@ -178,11 +166,3 @@ export default async function ListingPage({
   )
 }
 
-function formatCondition(c: string) {
-  const map: Record<string, string> = {
-    "Brand New": "Brand new",
-    "Lightly Used": "Lightly used",
-    Fair: "Fair",
-  }
-  return map[c] ?? c
-}

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { MapPinIcon, TagIcon } from "lucide-react"
+
+import { ROLE_LABELS } from "@/lib/auth"
+import { fetchListing } from "@/lib/listings"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardHeader, CardTitle } from "@/components/ui/card"
+import { initials } from "@/lib/utils"
+
+export const dynamic = "force-dynamic"
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const data = await fetchListing(id)
+  if (!data) return { title: "Listing not found" }
+  const l = data.listing
+  return {
+    title: l.title,
+    description: l.description ?? `${l.title} on VinTech Marketplace`,
+    openGraph: {
+      title: l.title,
+      description: l.description ?? undefined,
+      images: data.images.length ? [data.images[0]?.image_url] : undefined,
+    },
+  }
+}
+
+function formatPrice(price: number | string) {
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      maximumFractionDigits: 2,
+    }).format(typeof price === "number" ? price : Number(price))
+  } catch {
+    return `ETB ${price}`
+  }
+}
+
+export default async function ListingPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const data = await fetchListing(id)
+  if (!data) notFound()
+
+  const { listing: l, images, category, seller } = data
+  const cover = images[0]?.image_url
+  const roleLabel = ROLE_LABELS[(l.seller_id ? "seller" : "buyer")] ?? "Seller"
+
+  return (
+    <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        <div>
+          {cover ? (
+            <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg border">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={cover} alt={l.title} className="h-full w-full object-cover" />
+              {images.length > 1 ? (
+                <div className="mt-3 grid grid-cols-5 gap-2">
+                  {images.map((img) => (
+                    <div
+                      key={img.id}
+                      className="aspect-video w-full overflow-hidden rounded-md border"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={img.image_url}
+                        alt={img.alt_text ?? l.title}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="flex aspect-[4/3] w-full items-center justify-center rounded-lg border bg-muted text-muted-foreground">
+              No photo
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-start gap-2">
+            <h1 className="font-heading flex-1 text-2xl font-semibold text-foreground">
+              {l.title}
+            </h1>
+            <Badge variant="secondary">{formatCondition(l.condition)}</Badge>
+          </div>
+
+          <p className="text-2xl font-semibold text-foreground">
+            {formatPrice(l.price)}
+            {l.negotiable ? " (or best offer)" : null}
+          </p>
+
+          {category ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <TagIcon className="size-4" />
+              <span>{category.name}</span>
+            </div>
+          ) : null}
+
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <MapPinIcon className="size-4" />
+            <span>
+              {[l.city, l.sub_city].filter(Boolean).join(", ") || "Location not set"}
+            </span>
+          </div>
+          {l.address ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <MapPinIcon className="size-4" />
+              <span>{l.address}</span>
+            </div>
+          ) : null}
+
+          {l.description ? (
+            <p className="text-sm leading-relaxed text-foreground/80">
+              {l.description}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">No description provided.</p>
+          )}
+
+          <Card>
+            <CardHeader className="flex-row items-center gap-3">
+              <Avatar className="size-10">
+                <AvatarImage
+                  src={seller?.avatar_url ?? undefined}
+                  alt={seller?.full_name ?? roleLabel}
+                />
+                <AvatarFallback className="text-sm">
+                  {initials(seller?.full_name ?? "")}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <CardTitle className="text-base">
+                  <Link
+                    href={`/users/${seller?.id ?? l.seller_id}`}
+                    className="text-primary hover:underline"
+                  >
+                    {seller?.full_name ?? "View seller profile"}
+                  </Link>
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Trust score {seller?.trust_score ?? 50}
+                </p>
+              </div>
+            </CardHeader>
+          </Card>
+
+          <Button asChild size="lg">
+            <Link href={`/users/${seller?.id ?? l.seller_id}`}>
+              View seller profile
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-8 text-center">
+        <Button asChild variant="link">
+          <Link href="/">← Back to listings</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}
+
+function formatCondition(c: string) {
+  const map: Record<string, string> = {
+    "Brand New": "Brand new",
+    "Lightly Used": "Lightly used",
+    Fair: "Fair",
+  }
+  return map[c] ?? c
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,25 +1,119 @@
-import Link from "next/link";
+import Link from "next/link"
 
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
+import { fetchCategories, fetchListings, PAGE_SIZE } from "@/lib/listings"
+import { CategoryCard } from "@/components/categories/category-card"
+import { ListingCard } from "@/components/listings/listing-card"
 
-export default function Home() {
+function buildHref(categorySlug: string | undefined, offset: number) {
+  const params = new URLSearchParams()
+  if (categorySlug) params.set("category", categorySlug)
+  if (offset) params.set("offset", String(offset))
+  return `/?${params.toString()}`
+}
+
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const sp = await searchParams
+  const categorySlug =
+    typeof sp.category === "string" ? sp.category : undefined
+  const offset = Number(
+    typeof sp.offset === "string" && sp.offset ? sp.offset : 0
+  )
+
+  const categoriesPromise = fetchCategories()
+  const { listings, hasMore } = await fetchListings({
+    limit: PAGE_SIZE,
+    offset,
+    categorySlug,
+  })
+  const categories = await categoriesPromise
+
   return (
-    <main className="mx-auto flex w-full max-w-[1280px] flex-1 flex-col items-center justify-center px-4 py-16 text-center sm:px-6 lg:px-8">
-      <h1 className="max-w-2xl font-heading text-4xl font-semibold leading-[1.3] tracking-tight text-foreground sm:text-5xl">
-        Find your next thing. Sell what you no longer need.
-      </h1>
-      <p className="mt-4 max-w-xl text-lg leading-relaxed text-muted-foreground">
-        VinTech Marketplace connects buyers and sellers for trusted,
-        convenient second-hand commerce.
-      </p>
-      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-        <Button asChild size="lg">
-          <Link href="/search">Browse listings</Link>
-        </Button>
-        <Button asChild variant="outline" size="lg">
-          <Link href="/sell">Start selling</Link>
-        </Button>
-      </div>
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <section className="mb-12 text-center">
+        <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+          Marketplace for trusted second-hand goods
+        </h1>
+        <p className="mt-3 max-w-xl text-balance text-muted-foreground">
+          Buy and sell used items confidently across Addis Ababa.
+        </p>
+        <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+          <Button asChild size="lg">
+            <Link href="#listings">Browse listings</Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <Link href="/sell">Start selling</Link>
+          </Button>
+        </div>
+      </section>
+
+      <section aria-label="Browse by category" className="mb-10">
+        <h2 className="font-heading text-xl font-semibold">
+          Browse by category
+        </h2>
+        <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          {categories.map((c) => (
+            <CategoryCard
+              key={c.id}
+              category={c}
+              active={categorySlug === c.slug}
+            />
+          ))}
+        </div>
+        {categorySlug ? (
+          <Link
+            href={buildHref(undefined, 0)}
+            className="mt-3 inline-block text-sm underline"
+          >
+            All categories
+          </Link>
+        ) : null}
+      </section>
+
+      <section id="listings" aria-label="Listings">
+        <h2 className="sr-only">Listings</h2>
+        {listings.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-muted-foreground">
+              {categorySlug
+                ? "No listings in this category yet."
+                : "No listings found."}
+            </p>
+            {categorySlug ? (
+              <Link
+                href={buildHref(undefined, 0)}
+                className="mt-2 inline-block text-sm underline"
+              >
+                Clear filters
+              </Link>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {listings.map((l) => (
+                <li key={l.id}>
+                  <ListingCard listing={l} />
+                </li>
+              ))}
+            </ul>
+            {hasMore ? (
+              <div className="mt-10 flex justify-center">
+                <Link
+                  href={buildHref(categorySlug, offset + PAGE_SIZE)}
+                  className="text-sm font-medium underline"
+                >
+                  Load more
+                </Link>
+              </div>
+            ) : null}
+          </>
+        )}
+      </section>
     </main>
-  );
+  )
 }

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -2,15 +2,9 @@ import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import { fetchCategories, fetchListings, PAGE_SIZE } from "@/lib/listings"
+import { buildBrowseUrl, nextOffset, parseBrowseParams } from "@/lib/browse"
 import { CategoryCard } from "@/components/categories/category-card"
 import { ListingCard } from "@/components/listings/listing-card"
-
-function buildHref(categorySlug: string | undefined, offset: number) {
-  const params = new URLSearchParams()
-  if (categorySlug) params.set("category", categorySlug)
-  if (offset) params.set("offset", String(offset))
-  return `/?${params.toString()}`
-}
 
 function NoResultsIcon({ className }: { className?: string }) {
   return (
@@ -46,11 +40,7 @@ export default async function HomePage({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const sp = await searchParams
-  const categorySlug =
-    typeof sp.category === "string" ? sp.category : undefined
-  const rawOffset = typeof sp.offset === "string" ? Number(sp.offset) : 0
-  const offset =
-    Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0
+  const { categorySlug, offset } = parseBrowseParams(sp)
 
   const categoriesPromise = fetchCategories()
   const { listings, hasMore, error } = await fetchListings({
@@ -94,7 +84,7 @@ export default async function HomePage({
         </div>
         {categorySlug ? (
           <Link
-            href={buildHref(undefined, 0)}
+            href={buildBrowseUrl(undefined, 0)}
             className="mt-3 inline-block text-sm underline"
           >
             All categories
@@ -110,7 +100,7 @@ export default async function HomePage({
               We could not load listings.
             </p>
             <Link
-              href={buildHref(categorySlug, offset)}
+              href={buildBrowseUrl(categorySlug, offset)}
               className="mt-2 inline-block text-sm font-medium text-primary underline"
             >
               Retry
@@ -132,7 +122,7 @@ export default async function HomePage({
             <div className="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
               {categorySlug ? (
                 <Button asChild size="sm">
-                  <Link href={buildHref(undefined, 0)}>All categories</Link>
+                  <Link href={buildBrowseUrl(undefined, 0)}>All categories</Link>
                 </Button>
               ) : (
                 <Button asChild size="sm">
@@ -140,7 +130,7 @@ export default async function HomePage({
                 </Button>
               )}
               <Link
-                href={buildHref(undefined, 0)}
+                href={buildBrowseUrl(undefined, 0)}
                 className="text-sm underline"
               >
                 Refresh
@@ -158,10 +148,10 @@ export default async function HomePage({
             </ul>
             {hasMore ? (
               <div className="mt-10 flex justify-center">
-                <Link
-                  href={buildHref(categorySlug, offset + PAGE_SIZE)}
-                  className="text-sm font-medium underline"
-                >
+                 <Link
+                   href={buildBrowseUrl(categorySlug, nextOffset(offset))}
+                   className="text-sm font-medium underline"
+                 >
                   Load more
                 </Link>
               </div>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -12,6 +12,34 @@ function buildHref(categorySlug: string | undefined, offset: number) {
   return `/?${params.toString()}`
 }
 
+function NoResultsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M21 21l-4.35-4.35M9.5 18a8.5 8.5 0 110-17 8.5 8.5 0 010 17z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="7.5"
+        cy="7.5"
+        r="1.25"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 export default async function HomePage({
   searchParams,
 }: {
@@ -20,12 +48,12 @@ export default async function HomePage({
   const sp = await searchParams
   const categorySlug =
     typeof sp.category === "string" ? sp.category : undefined
-  const offset = Number(
-    typeof sp.offset === "string" && sp.offset ? sp.offset : 0
-  )
+  const rawOffset = typeof sp.offset === "string" ? Number(sp.offset) : 0
+  const offset =
+    Number.isFinite(rawOffset) && rawOffset > 0 ? rawOffset : 0
 
   const categoriesPromise = fetchCategories()
-  const { listings, hasMore } = await fetchListings({
+  const { listings, hasMore, error } = await fetchListings({
     limit: PAGE_SIZE,
     offset,
     categorySlug,
@@ -76,21 +104,48 @@ export default async function HomePage({
 
       <section id="listings" aria-label="Listings">
         <h2 className="sr-only">Listings</h2>
-        {listings.length === 0 ? (
+        {error ? (
           <div className="py-16 text-center">
-            <p className="text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
+              We could not load listings.
+            </p>
+            <Link
+              href={buildHref(categorySlug, offset)}
+              className="mt-2 inline-block text-sm font-medium text-primary underline"
+            >
+              Retry
+            </Link>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="flex flex-col items-center py-16 text-center">
+            <NoResultsIcon className="mb-3 h-10 w-10 text-muted-foreground/60" />
+            <h3 className="font-heading text-lg font-semibold">
               {categorySlug
                 ? "No listings in this category yet."
                 : "No listings found."}
+            </h3>
+            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+              {categorySlug
+                ? "Try another category or clear your filter."
+                : "Be the first to list — sellers are adding listings all the time."}
             </p>
-            {categorySlug ? (
+            <div className="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
+              {categorySlug ? (
+                <Button asChild size="sm">
+                  <Link href={buildHref(undefined, 0)}>All categories</Link>
+                </Button>
+              ) : (
+                <Button asChild size="sm">
+                  <Link href="/sell">Start selling</Link>
+                </Button>
+              )}
               <Link
                 href={buildHref(undefined, 0)}
-                className="mt-2 inline-block text-sm underline"
+                className="text-sm underline"
               >
-                Clear filters
+                Refresh
               </Link>
-            ) : null}
+            </div>
           </div>
         ) : (
           <>

--- a/app/app/profile/page.tsx
+++ b/app/app/profile/page.tsx
@@ -1,22 +1,17 @@
 import type { Metadata } from "next"
-import Link from "next/link"
 import { redirect } from "next/navigation"
-import { MailIcon, MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
 
-import { getCurrentUser, ROLE_LABELS } from "@/lib/auth"
+import { getCurrentUser } from "@/lib/auth"
 import { createClient } from "@/lib/supabase/server"
-import { initials } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
+import { ProfileForm } from "@/components/profile/profile-form"
 
 export const metadata: Metadata = {
   title: "Your profile",
-  description: "Your VinTech Marketplace profile.",
+  description: "Manage your VinTech Marketplace profile.",
 }
 
 type ProfileRow = {
+  avatar_url: string | null
   full_name: string | null
   phone: string | null
   telegram_username: string | null
@@ -26,6 +21,7 @@ type ProfileRow = {
   trust_score: number | null
   profile_completion: number | null
   role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
 }
 
 export default async function ProfilePage() {
@@ -36,94 +32,12 @@ export default async function ProfilePage() {
   const { data: profile } = await supabase
     .from("profiles")
     .select(
-      "full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role"
+      "avatar_url, full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role, phone_public"
     )
     .eq("id", user.id)
     .maybeSingle()
 
-  const p = (profile ?? {}) as ProfileRow
-  const roleLabel = ROLE_LABELS[p.role ?? user.role] ?? "Buyer"
-
   return (
-    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
-      <Card className="gap-6">
-        <CardHeader className="flex-row items-center justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <Avatar className="size-14">
-              <AvatarFallback className="text-base">{initials(p.full_name ?? user.fullName ?? "")}</AvatarFallback>
-            </Avatar>
-            <div>
-              <h1 className="font-heading text-xl font-semibold leading-tight text-foreground">
-                {p.full_name ?? user.fullName ?? "Your profile"}
-              </h1>
-              <p className="text-sm text-muted-foreground">{user.email}</p>
-            </div>
-          </div>
-          <Badge variant="secondary">{roleLabel}</Badge>
-        </CardHeader>
-
-        <CardContent className="flex flex-col gap-6">
-          {!user.profileCompleted ? (
-            <div className="rounded-lg border border-warning/40 bg-warning/10 p-4 text-sm">
-              <p className="font-medium text-foreground">Your profile is not complete.</p>
-              <p className="mt-1 text-muted-foreground">
-                Add your name, city and contact details so buyers and sellers can reach you.
-              </p>
-              <Button asChild className="mt-3">
-                <Link href="/onboarding">Complete your profile</Link>
-              </Button>
-            </div>
-          ) : null}
-
-          <div className="grid grid-cols-1 gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MapPinIcon className="size-4 shrink-0" />
-              <span>
-                {p.city ?? "—"}
-                {p.sub_city ? `, ${p.sub_city}` : ""}
-              </span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <MailIcon className="size-4 shrink-0" />
-              <span className="truncate">{user.email}</span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <PhoneIcon className="size-4 shrink-0" />
-              <span>{p.phone ?? "No phone added"}</span>
-            </div>
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <SendIcon className="size-4 shrink-0" />
-              <span>{p.telegram_username ? `@${p.telegram_username}` : "No Telegram added"}</span>
-            </div>
-          </div>
-
-          {p.bio ? (
-            <p className="text-sm leading-relaxed text-foreground/80">{p.bio}</p>
-          ) : null}
-
-          <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">Trust score</dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">{p.trust_score ?? 50}</dd>
-            </div>
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">Profile completion</dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">
-                {p.profile_completion ?? 0}%
-              </dd>
-            </div>
-          </dl>
-        </CardContent>
-
-        <CardFooter className="justify-between">
-          <Button asChild variant="outline">
-            <Link href="/dashboard">View dashboard</Link>
-          </Button>
-          <Button asChild variant="link">
-            <Link href="/">Back to home</Link>
-          </Button>
-        </CardFooter>
-      </Card>
-    </main>
+    <ProfileForm user={user} profile={(profile ?? {}) as ProfileRow} />
   )
 }

--- a/app/app/sell/page.tsx
+++ b/app/app/sell/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 export default async function SellPage() {
-  const user = await requireSeller()
+  await requireSeller()
   const categories = await fetchCategories()
 
   return (
@@ -22,7 +22,7 @@ export default async function SellPage() {
         List your item once, reach buyers across Addis Ababa.
       </p>
 
-      <CreateListingForm categories={categories} sellerId={user.id} />
+      <CreateListingForm categories={categories} />
     </main>
   )
 }

--- a/app/app/sell/page.tsx
+++ b/app/app/sell/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next"
+
+import { requireSeller } from "@/lib/auth"
+import { fetchCategories } from "@/lib/listings"
+import { CreateListingForm } from "@/components/listings/create-listing-form"
+
+export const metadata: Metadata = {
+  title: "Sell an item",
+  description: "Create a listing on the VinTech Marketplace.",
+}
+
+export default async function SellPage() {
+  const user = await requireSeller()
+  const categories = await fetchCategories()
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="font-heading text-2xl font-semibold text-foreground">
+        Sell an item
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        List your item once, reach buyers across Addis Ababa.
+      </p>
+
+      <CreateListingForm categories={categories} sellerId={user.id} />
+    </main>
+  )
+}

--- a/app/app/users/[id]/page.tsx
+++ b/app/app/users/[id]/page.tsx
@@ -1,0 +1,195 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
+
+import { ROLE_LABELS, type UserRole } from "@/lib/auth"
+import { createClient } from "@/lib/supabase/server"
+import { initials } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+
+type PublicProfileRow = {
+  full_name: string | null
+  avatar_url: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  telegram_username: string | null
+  phone: string | null
+  trust_score: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+}
+
+async function fetchPublicProfile(id: string): Promise<PublicProfileRow | null> {
+  const supabase = await createClient()
+
+  // Public surface only: phone is fetched separately and only when the owner
+  // has opted in (Security spec §19: phone is private by default).
+  const baseColumns =
+    "full_name, avatar_url, city, sub_city, bio, telegram_username, trust_score, role, phone_public"
+
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select(baseColumns)
+    .eq("id", id)
+    .maybeSingle()
+
+  if (error || !profile) return null
+
+  if (profile.phone_public) {
+    const { data: withPhone } = await supabase
+      .from("profiles")
+      .select("phone")
+      .eq("id", id)
+      .maybeSingle()
+    ;(profile as PublicProfileRow).phone = withPhone?.phone ?? null
+  }
+
+  return profile as PublicProfileRow
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  const profile = await fetchPublicProfile(id)
+  if (!profile) return { title: "Profile not found" }
+  const name = profile.full_name ?? "VinTech user"
+  return {
+    title: name,
+    description: profile.bio ?? `${name}'s VinTech Marketplace profile.`,
+    openGraph: {
+      title: name,
+      description: profile.bio ?? undefined,
+      images: profile.avatar_url ? [profile.avatar_url] : undefined,
+    },
+  }
+}
+
+export default async function UserProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const profile = await fetchPublicProfile(id)
+  if (!profile) notFound()
+
+  const role = (profile.role ?? "buyer") as UserRole
+  const roleLabel = ROLE_LABELS[role] ?? "Buyer"
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <Card className="gap-6">
+        <CardHeader className="flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Avatar className="size-16">
+              {profile.avatar_url ? (
+                <AvatarImage
+                  src={profile.avatar_url}
+                  alt={profile.full_name ?? roleLabel}
+                  width={64}
+                  height={64}
+                />
+              ) : null}
+              <AvatarFallback className="text-xl">
+                {initials(profile.full_name ?? "")}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <h1 className="font-heading text-2xl font-semibold leading-tight text-foreground">
+                {profile.full_name ?? "VinTech user"}
+              </h1>
+              <p className="text-sm text-muted-foreground">{roleLabel}</p>
+            </div>
+          </div>
+          <Badge variant="outline" className="capitalize">
+            {roleLabel.toLowerCase()}
+          </Badge>
+        </CardHeader>
+
+        <CardContent className="flex flex-col gap-6">
+          {/* Verification indicators (placeholder: T12 builds the real badge set) */}
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">
+              <span className="flex items-center gap-1">
+                <span className="inline-block size-2 rounded-full bg-muted-foreground" />
+                Verification pending
+              </span>
+            </Badge>
+            {profile.telegram_username ? (
+              <Badge variant="secondary">Telegram connected</Badge>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-3 text-sm">
+            <MapPinIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span>
+              {profile.city
+                ? `${profile.city}${profile.sub_city ? `, ${profile.sub_city}` : ""}`
+                : "Location not set"}
+            </span>
+          </div>
+
+          {profile.telegram_username ? (
+            <div className="flex items-center gap-3 text-sm">
+              <SendIcon className="size-4 shrink-0 text-muted-foreground" />
+              <a
+                href={`https://t.me/${profile.telegram_username}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-primary underline"
+              >
+                @{profile.telegram_username}
+              </a>
+            </div>
+          ) : null}
+
+          {profile.phone ? (
+            <div className="flex items-center gap-3 text-sm">
+              <PhoneIcon className="size-4 shrink-0 text-muted-foreground" />
+              <span>{profile.phone}</span>
+            </div>
+          ) : null}
+
+          {profile.bio ? (
+            <p className="text-sm leading-relaxed text-foreground/80">
+              {profile.bio}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">No bio added yet.</p>
+          )}
+
+          <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
+            <div>
+              <dt className="text-xs font-medium text-muted-foreground">
+                Trust score
+              </dt>
+              <dd className="mt-1 text-2xl font-semibold text-foreground">
+                {profile.trust_score ?? 50}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium text-muted-foreground">Role</dt>
+              <dd className="mt-1 text-2xl font-semibold text-foreground">
+                {roleLabel}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 text-center">
+        <Button asChild variant="link">
+          <Link href="/">← Back to listings</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/app/components/categories/category-card.tsx
+++ b/app/components/categories/category-card.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link"
+
+import type { Category } from "@/lib/listings"
+
+export function CategoryCard({
+  category,
+  active = false,
+}: {
+  category: Category
+  active?: boolean
+}) {
+  const base =
+    "group flex flex-col items-center justify-center gap-1.5 rounded-lg border p-3 text-center text-decoration-none"
+  const tile = active
+    ? "bg-primary text-primary-foreground"
+    : "bg-muted text-foreground hover:bg-primary hover:text-primary-foreground"
+
+  return (
+    <Link
+      href={`?category=${category.slug}`}
+      className={`${base} hover:border-primary`}
+    >
+      <span
+        className={`inline-flex h-10 w-10 items-center justify-center rounded-full ${tile}`}
+      >
+        {category.name.charAt(0)}
+      </span>
+      <span className="text-sm font-medium">{category.name}</span>
+    </Link>
+  )
+}

--- a/app/components/categories/category-card.tsx
+++ b/app/components/categories/category-card.tsx
@@ -18,6 +18,7 @@ export function CategoryCard({
   return (
     <Link
       href={`?category=${category.slug}`}
+      aria-current={active ? "page" : undefined}
       className={`${base} hover:border-primary`}
     >
       <span

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,12 +1,7 @@
 import { Badge } from "@/components/ui/badge"
 
+import { CONDITION_COLORS } from "@/lib/listings"
 import type { Condition } from "@/lib/listings"
-
-const CONDITION_COLORS: Record<string, string> = {
-  "Brand New": "bg-green-100 text-green-800",
-  "Lightly Used": "bg-blue-100 text-blue-800",
-  Fair: "bg-amber-100 text-amber-800",
-}
 
 export function ConditionChip({ condition }: { condition: Condition }) {
   const className = CONDITION_COLORS[condition] ?? "bg-neutral-100 text-neutral-800"

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,0 +1,18 @@
+import { Badge } from "@/components/ui/badge"
+
+import type { Condition } from "@/lib/listings"
+
+const CONDITION_COLORS: Record<string, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  Fair: "bg-amber-100 text-amber-800",
+}
+
+export function ConditionChip({ condition }: { condition: Condition }) {
+  const className = CONDITION_COLORS[condition] ?? "bg-neutral-100 text-neutral-800"
+  return (
+    <Badge variant="secondary" className={className}>
+      {condition}
+    </Badge>
+  )
+}

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge"
 
-import { CONDITION_COLORS } from "@/lib/listings"
+import { CONDITION_COLORS } from "@/lib/listings/constants"
 import type { Condition } from "@/lib/listings"
 
 export function ConditionChip({ condition }: { condition: Condition }) {

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -19,15 +19,20 @@ function FieldError({ message }: { message: string | undefined }) {
 
 export function CreateListingForm({
   categories,
-  sellerId,
 }: {
   categories: Category[]
-  sellerId: string
 }) {
   const router = useRouter()
   const [state, formAction, pending] = useActionState(createListing, {})
   const [previews, setPreviews] = useState<string[]>([])
   const fileRef = useRef<HTMLInputElement>(null)
+  const urlRefs = useRef<string[]>([])
+
+  useEffect(() => {
+    return () => {
+      urlRefs.current.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [])
 
   useEffect(() => {
     if (state.ok && state.listingId) {
@@ -38,15 +43,15 @@ export function CreateListingForm({
   function handlePhotos(e: ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files ?? [])
     // revoke prior previews
-    previews.forEach((url) => URL.revokeObjectURL(url))
+    urlRefs.current.forEach((url) => URL.revokeObjectURL(url))
+    urlRefs.current = []
     const urls = files.map((f) => URL.createObjectURL(f))
+    urlRefs.current = urls
     setPreviews(urls)
   }
 
   return (
     <form action={formAction}>
-      <input type="hidden" name="sellerId" value={sellerId} readOnly />
-
       <Card className="mb-6">
         <CardHeader>
           <CardTitle>Photos *</CardTitle>

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -1,0 +1,232 @@
+"use client"
+
+import { useActionState, useEffect, useRef, useState, type ChangeEvent } from "react"
+import { useRouter } from "next/navigation"
+import { XIcon, UploadIcon } from "lucide-react"
+
+import { createListing } from "@/app/actions/listings"
+import type { Category } from "@/lib/listings"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function CreateListingForm({
+  categories,
+  sellerId,
+}: {
+  categories: Category[]
+  sellerId: string
+}) {
+  const router = useRouter()
+  const [state, formAction, pending] = useActionState(createListing, {})
+  const [previews, setPreviews] = useState<string[]>([])
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (state.ok && state.listingId) {
+      router.replace(`/listings/${state.listingId}`)
+    }
+  }, [state, router])
+
+  function handlePhotos(e: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? [])
+    // revoke prior previews
+    previews.forEach((url) => URL.revokeObjectURL(url))
+    const urls = files.map((f) => URL.createObjectURL(f))
+    setPreviews(urls)
+  }
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="sellerId" value={sellerId} readOnly />
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Photos *</CardTitle>
+          <CardDescription>
+            First photo is the cover. Up to 10 JPG/PNG/WebP images, 5 MB each.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div
+            className="flex min-h-[120px] cursor-pointer items-center justify-center rounded-lg border border-dashed border-border text-center text-sm text-muted-foreground transition hover:border-primary"
+            onClick={() => fileRef.current?.click()}
+          >
+            <input
+              ref={fileRef}
+              type="file"
+              name="photos"
+              accept="image/png,image/jpeg,image/webp"
+              multiple
+              className="hidden"
+              onChange={handlePhotos}
+              aria-label="upload photos"
+            />
+            <UploadIcon className="mb-2 size-6" />
+            <span>{previews.length ? "Change photos" : "Click to upload"}</span>
+          </div>
+          {state.errors?.photos ? (
+            <FieldError message={state.errors.photos[0]} />
+          ) : null}
+          {previews.length > 0 ? (
+            <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {previews.map((url, i) => (
+                <div key={url} className="relative aspect-video w-full overflow-hidden rounded-md border">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={url} alt={`photo ${i + 1}`} className="h-full w-full object-cover" />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      URL.revokeObjectURL(url)
+                      setPreviews((p) => p.filter((u) => u !== url))
+                    }}
+                    className="absolute right-1 top-1 rounded bg-background/80 p-0.5"
+                  >
+                    <XIcon className="size-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="title">Title *</Label>
+              <Input
+                id="title"
+                name="title"
+                placeholder="What are you selling?"
+                aria-invalid={!!state.errors?.title}
+              />
+            <FieldError message={state.errors?.title?.[0]} />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="description">Description</Label>
+            <textarea
+              id="description"
+              name="description"
+              rows={5}
+              className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+              placeholder="Include condition, brand, age, what's included..."
+            />
+            <FieldError message={state.errors?.description?.[0]} />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="price">Price (ETB) *</Label>
+              <Input
+                id="price"
+                name="price"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                step="0.01"
+                placeholder="0.00"
+                aria-invalid={!!state.errors?.price}
+              />
+              <FieldError message={state.errors?.price?.[0]} />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label>Condition *</Label>
+              <div className="flex flex-wrap gap-3 pt-1">
+                {CONDITIONS.map((c) => (
+                  <label key={c} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="condition"
+                      value={c}
+                      required
+                      className="accent-primary"
+                    />
+                    {c}
+                  </label>
+                ))}
+              </div>
+              <FieldError message={state.errors?.condition?.[0]} />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="categoryId">Category *</Label>
+            <select
+              id="categoryId"
+              name="categoryId"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+              aria-invalid={!!state.errors?.categoryId}
+            >
+              <option value="">Pick a category</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <FieldError message={state.errors?.categoryId?.[0]} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle>Location</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="city">City *</Label>
+              <Input
+                id="city"
+                name="city"
+                placeholder="e.g. Addis Ababa"
+                aria-invalid={!!state.errors?.city}
+              />
+              <FieldError message={state.errors?.city?.[0]} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="subCity">Sub-city / neighborhood</Label>
+              <Input
+                id="subCity"
+                name="subCity"
+                placeholder="e.g. Bole"
+              />
+            </div>
+          </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="address">Address (optional)</Label>
+              <Input
+                id="address"
+                name="address"
+                placeholder="Street address or landmark"
+              />
+            </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="negotiable" className="accent-primary" />
+            Price is negotiable
+          </label>
+        </CardContent>
+      </Card>
+
+      {state.message ? <p className="text-sm text-destructive">{state.message}</p> : null}
+
+      <Button type="submit" size="lg" className="w-full" disabled={pending}>
+        {pending ? "Publishing…" : "Publish listing"}
+      </Button>
+    </form>
+  )
+}

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -5,13 +5,12 @@ import { useRouter } from "next/navigation"
 import { XIcon, UploadIcon } from "lucide-react"
 
 import { createListing } from "@/app/actions/listings"
+import { CONDITIONS } from "@/lib/listings"
 import type { Category } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-
-const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
 
 function FieldError({ message }: { message: string | undefined }) {
   return message ? <p className="text-sm text-destructive">{message}</p> : null

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { XIcon, UploadIcon } from "lucide-react"
 
 import { createListing } from "@/app/actions/listings"
-import { CONDITIONS } from "@/lib/listings"
+import { CONDITIONS } from "@/lib/listings/constants"
 import type { Category } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -34,7 +34,7 @@ export function EditListingForm({
 
   return (
     <>
-      <form action={formAction}>
+      <form action={formAction} id="edit-listing-form">
         <input type="hidden" name="id" value={listing.id} readOnly />
 
         <Card className="mb-6">
@@ -183,27 +183,38 @@ export function EditListingForm({
         {state.ok ? <p className="text-sm text-green-600">Listing updated.</p> : null}
 
         <div className="mt-4 flex gap-3">
-          <Button type="submit" disabled={pending}>
+          <Button type="submit" form="edit-listing-form" disabled={pending}>
             {pending ? "Saving…" : "Save changes"}
           </Button>
-
-          <form
-            action={deleteAction}
-            onSubmit={(e) => {
-              if (!confirm("Archive this listing? You can republish it later.")) e.preventDefault()
+          <Button
+            type="submit"
+            form="delete-listing-form"
+            variant="destructive"
+            disabled={deletePending}
+            onClick={() => {
+              if (
+                !confirm("Archive this listing? You can republish it later.")
+              )
+                return false
             }}
           >
-            <input type="hidden" name="id" value={listing.id} readOnly />
-            <Button
-              type="submit"
-              variant="destructive"
-              disabled={deletePending}
-            >
-              <XIcon className="mr-2 size-4" />
-              {deletePending ? "Archiving…" : "Archive listing"}
-            </Button>
-          </form>
+            <XIcon className="mr-2 size-4" />
+            {deletePending ? "Archiving…" : "Archive listing"}
+          </Button>
         </div>
+      </form>
+
+      <form
+        id="delete-listing-form"
+        action={deleteAction}
+        onSubmit={(e) => {
+          if (
+            !confirm("Archive this listing? You can republish it later.")
+          )
+            e.preventDefault()
+        }}
+      >
+        <input type="hidden" name="id" value={listing.id} readOnly />
       </form>
 
       {deleteState.message ? (

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -4,7 +4,7 @@ import { useActionState } from "react"
 import { XIcon } from "lucide-react"
 
 import { updateListing, deleteListing } from "@/app/actions/listings"
-import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings"
+import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings/constants"
 import type { Category, Listing } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import { useActionState } from "react"
+import { XIcon } from "lucide-react"
+
+import { updateListing, deleteListing } from "@/app/actions/listings"
+import type { Category, Listing } from "@/lib/listings"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+const STATUSES: { value: string; label: string; disabled?: boolean }[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "sold", label: "Sold" },
+  { value: "archived", label: "Archived", disabled: true },
+]
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function EditListingForm({
+  listing,
+  categories,
+}: {
+  listing: Listing
+  categories: Category[]
+}) {
+  const [state, formAction, pending] = useActionState(updateListing, {})
+  const [deleteState, deleteAction, deletePending] = useActionState(deleteListing, {})
+
+  return (
+    <>
+      <form action={formAction}>
+        <input type="hidden" name="id" value={listing.id} readOnly />
+
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>Details</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="title">Title *</Label>
+              <Input
+                id="title"
+                name="title"
+                defaultValue={listing.title}
+                aria-invalid={!!state.errors?.title}
+              />
+              <FieldError message={state.errors?.title?.[0]} />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="description">Description</Label>
+              <textarea
+                id="description"
+                name="description"
+                rows={5}
+                defaultValue={listing.description ?? ""}
+                className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+              />
+              <FieldError message={state.errors?.description?.[0]} />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="price">Price (ETB) *</Label>
+                <Input
+                  id="price"
+                  name="price"
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step="0.01"
+                  defaultValue={listing.price}
+                  aria-invalid={!!state.errors?.price}
+                />
+                <FieldError message={state.errors?.price?.[0]} />
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label>Condition *</Label>
+                <div className="flex flex-wrap gap-3 pt-1">
+                  {CONDITIONS.map((c) => (
+                    <label key={c} className="flex items-center gap-2 text-sm">
+                      <input
+                        type="radio"
+                        name="condition"
+                        value={c}
+                        defaultChecked={listing.condition === c}
+                        required
+                        className="accent-primary"
+                      />
+                      {c}
+                    </label>
+                  ))}
+                </div>
+                <FieldError message={state.errors?.condition?.[0]} />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="categoryId">Category *</Label>
+              <select
+                id="categoryId"
+                name="categoryId"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                defaultValue={listing.category_id ?? ""}
+                aria-invalid={!!state.errors?.categoryId}
+              >
+                <option value="">Pick a category</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              <FieldError message={state.errors?.categoryId?.[0]} />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>Location</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="city">City *</Label>
+                <Input
+                  id="city"
+                  name="city"
+                  defaultValue={listing.city ?? ""}
+                  aria-invalid={!!state.errors?.city}
+                />
+                <FieldError message={state.errors?.city?.[0]} />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="subCity">Sub-city / neighborhood</Label>
+                <Input id="subCity" name="subCity" defaultValue={listing.sub_city ?? ""} />
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="address">Address (optional)</Label>
+              <Input id="address" name="address" defaultValue={listing.address ?? ""} />
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                name="negotiable"
+                defaultChecked={listing.negotiable}
+                className="accent-primary"
+              />
+              Price is negotiable
+            </label>
+          </CardContent>
+        </Card>
+
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>Status</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <select
+              name="status"
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+              defaultValue={listing.status}
+            >
+              {STATUSES.map((s) => (
+                <option key={s.value} value={s.value} disabled={s.disabled}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </CardContent>
+        </Card>
+
+        {state.message ? <p className="text-sm text-destructive">{state.message}</p> : null}
+        {state.ok ? <p className="text-sm text-green-600">Listing updated.</p> : null}
+
+        <div className="mt-4 flex gap-3">
+          <Button type="submit" disabled={pending}>
+            {pending ? "Saving…" : "Save changes"}
+          </Button>
+
+          <form
+            action={deleteAction}
+            onSubmit={(e) => {
+              if (!confirm("Archive this listing? You can republish it later.")) e.preventDefault()
+            }}
+          >
+            <input type="hidden" name="id" value={listing.id} readOnly />
+            <Button
+              type="submit"
+              variant="destructive"
+              disabled={deletePending}
+            >
+              <XIcon className="mr-2 size-4" />
+              {deletePending ? "Archiving…" : "Archive listing"}
+            </Button>
+          </form>
+        </div>
+      </form>
+
+      {deleteState.message ? (
+        <p className="text-sm text-destructive">{deleteState.message}</p>
+      ) : null}
+    </>
+  )
+}

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -4,19 +4,12 @@ import { useActionState } from "react"
 import { XIcon } from "lucide-react"
 
 import { updateListing, deleteListing } from "@/app/actions/listings"
+import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings"
 import type { Category, Listing } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-
-const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
-const STATUSES: { value: string; label: string; disabled?: boolean }[] = [
-  { value: "draft", label: "Draft" },
-  { value: "published", label: "Published" },
-  { value: "sold", label: "Sold" },
-  { value: "archived", label: "Archived", disabled: true },
-]
 
 function FieldError({ message }: { message: string | undefined }) {
   return message ? <p className="text-sm text-destructive">{message}</p> : null
@@ -170,7 +163,7 @@ export function EditListingForm({
               className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
               defaultValue={listing.status}
             >
-              {STATUSES.map((s) => (
+              {STATUSES_FOR_DISPLAY.map((s) => (
                 <option key={s.value} value={s.value} disabled={s.disabled}>
                   {s.label}
                 </option>

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 
 import type { BrowseListing } from "@/lib/listings"
-import { formatPrice } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings/constants"
 import { ConditionChip } from "@/components/listings/condition-chip"
 import { SellerBadge } from "@/components/listings/seller-badge"
 

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+
+import type { BrowseListing } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings"
+import { ConditionChip } from "@/components/listings/condition-chip"
+import { SellerBadge } from "@/components/listings/seller-badge"
+
+export function ListingCard({ listing }: { listing: BrowseListing }) {
+  return (
+    <Link href={`/listings/${listing.id}`} className="group block w-full">
+      <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
+        {listing.image_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={listing.image_url}
+            alt={listing.title}
+            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+            No photo
+          </div>
+        )}
+      </div>
+      <div className="mt-2 space-y-1">
+        <p className="line-clamp-1 font-medium">{listing.title}</p>
+        <p className="font-semibold">{formatPrice(listing.price)}</p>
+        <div className="flex items-center gap-2">
+          <ConditionChip condition={listing.condition} />
+          {listing.city ? (
+            <span className="text-sm text-muted-foreground">{listing.city}</span>
+          ) : null}
+        </div>
+        <SellerBadge listing={listing} />
+      </div>
+    </Link>
+  )
+}

--- a/app/components/listings/seller-badge.tsx
+++ b/app/components/listings/seller-badge.tsx
@@ -1,0 +1,38 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+
+import type { BrowseListing } from "@/lib/listings"
+
+function initials(name: string | null): string {
+  if (!name) return "S"
+  const parts = name.split(/\s+/).filter(Boolean)
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+  }
+  return parts[0].slice(0, 2).toUpperCase()
+}
+
+export function SellerBadge({ listing }: { listing: BrowseListing }) {
+  const seller = listing.seller
+  if (!seller) return null
+  const trust = seller.trust_score
+
+  return (
+    <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+      <Avatar className="h-6 w-6">
+        <AvatarImage
+          src={seller.avatar_url ?? ""}
+          alt={seller.full_name ?? "seller"}
+        />
+        <AvatarFallback className="text-xs">{initials(seller.full_name)}</AvatarFallback>
+      </Avatar>
+      <span className="font-medium text-foreground">
+        {seller.full_name ?? "Seller"}
+      </span>
+      {trust != null && (
+        <span aria-label={`Trust score ${Math.round(trust)}`}>
+          Trust {Math.round(trust)}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/app/components/profile/profile-form.tsx
+++ b/app/components/profile/profile-form.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import { useActionState, useRef, useState, type ChangeEvent } from "react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { UploadIcon } from "lucide-react"
+import Link from "next/link"
+
+import { ROLE_LABELS, type SessionUser } from "@/lib/auth/types"
+import { initials } from "@/lib/utils"
+import { updateProfile, uploadAvatar } from "@/app/actions/profile"
+
+type ProfileRow = {
+  avatar_url: string | null
+  full_name: string | null
+  phone: string | null
+  telegram_username: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  trust_score: number | null
+  profile_completion: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+}
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function ProfileForm({
+  user,
+  profile,
+}: {
+  user: SessionUser
+  profile: ProfileRow
+}) {
+  const [state, formAction, pending] = useActionState(updateProfile, {})
+  const [avatarUrl, setAvatarUrl] = useState(profile.avatar_url ?? null)
+  const [avatarError, setAvatarError] = useState<string | null>(null)
+  const [avatarUploading, setAvatarUploading] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const roleLabel = ROLE_LABELS[user.role] ?? "Buyer"
+
+  async function handleAvatar(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setAvatarUploading(true)
+    setAvatarError(null)
+    const form = new FormData()
+    form.set("avatar", file)
+    const res = await uploadAvatar(user.id, { url: null, error: null }, form)
+    setAvatarUploading(false)
+    if (res.error) setAvatarError(res.error)
+    else setAvatarUrl(res.url)
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="font-heading text-2xl font-semibold text-foreground">
+          Your profile
+        </h1>
+        <Badge variant="secondary">{roleLabel}</Badge>
+      </div>
+
+      <Card className="mb-6 gap-6">
+        <CardHeader className="flex-row items-center justify-between">
+          <CardTitle>Avatar</CardTitle>
+          <div className="flex items-center gap-3">
+            <Avatar className="size-16">
+              <AvatarImage
+                src={avatarUrl ?? undefined}
+                alt={profile.full_name ?? user.fullName ?? "You"}
+              />
+              <AvatarFallback className="text-xl">
+                {initials(profile.full_name ?? user.fullName ?? "")}
+              </AvatarFallback>
+            </Avatar>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => fileRef.current?.click()}
+              disabled={avatarUploading || pending}
+            >
+              <UploadIcon className="mr-2 size-4" />
+              {avatarUrl ? "Change photo" : "Upload photo"}
+            </Button>
+            <input
+              ref={fileRef}
+              type="file"
+              name="avatar"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={handleAvatar}
+            />
+          </div>
+        </CardHeader>
+        <CardContent>
+          {avatarError ? <p className="text-sm text-destructive">{avatarError}</p> : null}
+          <p className="text-xs text-muted-foreground">
+            JPG, PNG or WebP. Max 5 MB.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>About you</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={formAction} className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="fullName">Full name</Label>
+                <Input
+                  id="fullName"
+                  name="fullName"
+                  value={profile.full_name ?? user.fullName ?? ""}
+                  readOnly
+                  className="bg-muted/40"
+                  aria-readonly
+                />
+                <p className="text-xs text-muted-foreground">
+                  Set at signup.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="city">City *</Label>
+                <Input
+                  id="city"
+                  name="city"
+                  defaultValue={profile.city ?? ""}
+                  placeholder="e.g. Addis Ababa"
+                  aria-invalid={!!state.errors?.city}
+                />
+                <FieldError message={state.errors?.city?.[0]} />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="subCity">Sub-city</Label>
+              <Input
+                id="subCity"
+                name="subCity"
+                defaultValue={profile.sub_city ?? ""}
+                placeholder="e.g. Bole"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="phone">Phone</Label>
+                <Input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  inputMode="tel"
+                  defaultValue={profile.phone ?? ""}
+                  placeholder="e.g. +251 91 234 5678"
+                  aria-invalid={!!state.errors?.phone}
+                />
+                <FieldError message={state.errors?.phone?.[0]} />
+              </div>
+              <div className="flex items-end pb-7">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    name="phonePublic"
+                    defaultChecked={profile.phone_public ?? false}
+                    className="size-4 rounded border-border accent-primary"
+                  />
+                  Show my phone publicly
+                </label>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="telegramUsername">Telegram username</Label>
+              <Input
+                id="telegramUsername"
+                name="telegramUsername"
+                defaultValue={profile.telegram_username ?? ""}
+                placeholder="@yourname"
+                aria-invalid={!!state.errors?.telegramUsername}
+              />
+              <FieldError message={state.errors?.telegramUsername?.[0]} />
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="bio">About you</Label>
+              <Input
+                id="bio"
+                name="bio"
+                defaultValue={profile.bio ?? ""}
+                placeholder="A short introduction"
+                aria-invalid={!!state.errors?.bio}
+              />
+              <FieldError message={state.errors?.bio?.[0]} />
+            </div>
+
+            {state.message ? (
+              <p className="text-sm text-destructive">{state.message}</p>
+            ) : null}
+            {state.ok ? <p className="text-sm text-green-600">Profile updated.</p> : null}
+
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save changes"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+        <span>
+          <Badge variant="secondary" className="mr-1">
+            {profile.trust_score ?? 50}
+          </Badge>{" "}
+          trust score
+        </span>
+        <span>
+          Role: <span className="text-foreground">{roleLabel}</span>
+        </span>
+        <Link
+          href={`/users/${user.id}`}
+          className="ml-auto text-primary hover:underline"
+        >
+          View public profile
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -42,3 +42,14 @@ export async function requireUser(): Promise<SessionUser> {
   if (!user) redirect("/login")
   return user
 }
+
+// T04: only sellers (and admins) may create or edit listings.
+export async function requireSeller(): Promise<SessionUser> {
+  const user = await requireUser()
+  if (user.role !== "seller" && user.role !== "admin") {
+    // Not a seller yet — surface the profile page where this gate can be
+    // surfaced as a future "become a seller" prompt.
+    redirect("/profile")
+  }
+  return user
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -4,22 +4,10 @@ import { cache } from "react"
 import { redirect } from "next/navigation"
 
 import { createClient } from "@/lib/supabase/server"
+import type { SessionUser, UserRole } from "./auth/types"
 
-export type UserRole = "buyer" | "seller" | "admin"
-
-export type SessionUser = {
-  id: string
-  email: string
-  role: UserRole
-  fullName: string | null
-  profileCompleted: boolean
-}
-
-export const ROLE_LABELS: Record<UserRole, string> = {
-  buyer: "Buyer",
-  seller: "Seller",
-  admin: "Admin",
-}
+export type { SessionUser, UserRole }
+export { ROLE_LABELS } from "./auth/types"
 
 export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
   const supabase = await createClient()

--- a/app/lib/auth/types.ts
+++ b/app/lib/auth/types.ts
@@ -1,0 +1,21 @@
+// Pure type + constant surface for the auth session.
+// Client-safe: this module imports no server-only APIs, so client components
+// (e.g. ProfileForm) can consume ROLE_LABELS / SessionUser without pulling the
+// server-only auth module graph into the browser bundle.
+// Server-only helpers (getCurrentUser, requireUser) live in ../auth.
+
+export type UserRole = "buyer" | "seller" | "admin"
+
+export type SessionUser = {
+  id: string
+  email: string
+  role: UserRole
+  fullName: string | null
+  profileCompleted: boolean
+}
+
+export const ROLE_LABELS: Record<UserRole, string> = {
+  buyer: "Buyer",
+  seller: "Seller",
+  admin: "Admin",
+}

--- a/app/lib/browse.ts
+++ b/app/lib/browse.ts
@@ -1,0 +1,43 @@
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings"
+
+export interface BrowseCursor {
+  categorySlug: string | undefined
+  offset: number
+}
+
+/** Parse + clamp the browse cursor from untrusted URL search params.
+ *
+ * Single source of truth for the paging window: the offset is finite,
+ * non-negative and never exceeds the 1000-row ceiling, so "Load more" can no
+ * longer point past the end of the window (the homepage used to re-parse the
+ * offset and build `nextHref` from the raw, unclamped value).
+ * (§15: validate external input — offset comes from the URL.) */
+export function parseBrowseParams(params: {
+  category?: string | string[] | undefined
+  offset?: string | string[] | undefined
+}): BrowseCursor {
+  const categorySlug =
+    typeof params.category === "string" ? params.category : undefined
+  const raw = typeof params.offset === "string" ? params.offset : ""
+  const parsed = Number(raw)
+  const offset =
+    Number.isFinite(parsed) && parsed > 0
+      ? Math.min(parsed, BROWSE_LIMIT_MAX - 1)
+      : 0
+  return { categorySlug, offset }
+}
+
+/** Build the paginated browse URL (replaces the inline helper in app/page.tsx). */
+export function buildBrowseUrl(
+  categorySlug: string | undefined,
+  offset: number
+): string {
+  const params = new URLSearchParams()
+  if (categorySlug) params.set("category", categorySlug)
+  if (offset) params.set("offset", String(offset))
+  return `/?${params.toString()}`
+}
+
+export function nextOffset(offset: number): number {
+  return offset + PAGE_SIZE
+}

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -1,0 +1,132 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type Condition = "Brand New" | "Lightly Used" | "Fair"
+export type ListingStatus = "draft" | "published" | "sold" | "archived"
+
+export interface Category {
+  id: string
+  name: string
+  slug: string
+  parent_id: string | null
+}
+
+export interface ListingImage {
+  id: string
+  listing_id: string
+  image_url: string
+  display_order: number
+  alt_text: string | null
+}
+
+export interface Listing {
+  id: string
+  seller_id: string
+  category_id: string | null
+  title: string
+  description: string | null
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  address: string | null
+  status: ListingStatus
+  view_count: number
+  favorite_count: number
+  published_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ListingWithRelations {
+  listing: Listing
+  images: ListingImage[]
+  category: Category | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+    role: string | null
+    trust_score: number | null
+  } | null
+}
+
+export async function fetchCategories(): Promise<Category[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("categories")
+    .select("id, name, slug, parent_id")
+    .order("name")
+
+  if (error) {
+    console.error("fetchCategories:", error.message)
+    return []
+  }
+  return data as Category[]
+}
+
+export async function fetchListing(
+  id: string
+): Promise<ListingWithRelations | null> {
+  const supabase = await createClient()
+
+  const { data: listing } = await supabase
+    .from("listings")
+    .select(
+      "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+    )
+    .eq("id", id)
+    .maybeSingle()
+
+  if (!listing) return null
+
+  const { data: images } = await supabase
+    .from("listing_images")
+    .select("id, listing_id, image_url, display_order, alt_text")
+    .eq("listing_id", id)
+    .order("display_order", { ascending: true })
+
+  let category: Category | null = null
+  if (listing.category_id) {
+    const { data: cat } = await supabase
+      .from("categories")
+      .select("id, name, slug, parent_id")
+      .eq("id", listing.category_id)
+      .maybeSingle()
+    category = (cat as Category | null) ?? null
+  }
+
+  const { data: seller } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url, role, trust_score")
+    .eq("id", listing.seller_id)
+    .maybeSingle()
+
+  return {
+    listing: listing as Listing,
+    images: (images ?? []) as ListingImage[],
+    category: category as Category | null,
+    seller: seller as ListingWithRelations["seller"],
+  }
+}
+
+export async function fetchSellerListings(
+  sellerId: string
+): Promise<Listing[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("listings")
+    .select(
+      "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+    )
+    .eq("seller_id", sellerId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchSellerListings:", error.message)
+    return []
+  }
+  return data as Listing[]
+}

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -237,10 +237,10 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
 }
 
 export const PAGE_SIZE = 12
-// PostgREST (Supabase) caps an unpaginated select at 1000 rows; every browse
-// query is bounded to PAGE_SIZE so we stay well under that ceiling even with
-// deep paging via offset. (T05 browse)
-const BROWSE_LIMIT_MAX = 1000
+// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
+// windowed: each request fetches PAGE_SIZE rows and we never page past the
+// 1000-row ceiling (T05, NFR-COMP-003).
+export const BROWSE_LIMIT_MAX = 1000
 
 export interface BrowseSeller {
   id: string
@@ -250,27 +250,16 @@ export interface BrowseSeller {
   trust_score: number | null
 }
 
-export interface BrowseCategory {
-  id: string
-  name: string
-  slug: string
-}
-
 export interface BrowseListing {
   id: string
   title: string
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  view_count: number
-  favorite_count: number
   published_at: string
   image_url: string | null
   image_count: number
   seller: BrowseSeller | null
-  category: BrowseCategory | null
 }
 
 interface RawListingRow {
@@ -278,14 +267,9 @@ interface RawListingRow {
   title: string
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  view_count: number
-  favorite_count: number
   published_at: string
   seller: BrowseSeller[] | null
-  category: BrowseCategory[] | null
   images: ListingImage[] | null
 }
 
@@ -313,10 +297,18 @@ export async function fetchListings(opts: {
   listings: BrowseListing[]
   count: number | null
   hasMore: boolean
+  error: string | null
 }> {
   const supabase = await createClient()
   const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
-  const offset = opts.offset ?? 0
+  // Clamp + guard the pagination window: finite, non-negative, and never past
+  // the 1000-row ceiling so "Load more" always terminates. (§15: validate
+  // external input — offset comes from the URL.)
+  const requestedOffset = opts.offset ?? 0
+  const offset =
+    Number.isFinite(requestedOffset) && requestedOffset > 0
+      ? Math.min(requestedOffset, BROWSE_LIMIT_MAX - 1)
+      : 0
 
   let categoryId: string | null = null
   if (opts.categorySlug) {
@@ -326,15 +318,14 @@ export async function fetchListings(opts: {
       .eq("slug", opts.categorySlug)
       .maybeSingle()
     categoryId = cat?.id ?? null
-    if (!categoryId) return { listings: [], count: 0, hasMore: false }
+    if (!categoryId) return { listings: [], count: 0, hasMore: false, error: null }
   }
 
   let query = supabase
     .from("listings")
     .select(
-      `id, title, price, condition, negotiable, city, sub_city, view_count, favorite_count, published_at,
+      `id, title, price, condition, city, published_at,
        seller:profiles(id, full_name, avatar_url, role, trust_score),
-       category:categories(id, name, slug),
        images:listing_images(id, image_url, display_order)`,
       { count: "exact" }
     )
@@ -347,7 +338,7 @@ export async function fetchListings(opts: {
 
   if (error) {
     console.error("fetchListings:", error.message)
-    return { listings: [], count, hasMore: false }
+    return { listings: [], count, hasMore: false, error: error.message }
   }
 
   const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
@@ -358,17 +349,12 @@ export async function fetchListings(opts: {
           .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
         null
       const seller = l.seller?.[0] ?? null
-      const category = l.category?.[0] ?? null
       return {
         id: l.id,
         title: l.title,
         price: l.price,
         condition: l.condition,
-        negotiable: l.negotiable,
         city: l.city,
-        sub_city: l.sub_city,
-        view_count: l.view_count,
-        favorite_count: l.favorite_count,
         published_at: l.published_at,
         image_url: cover,
         image_count: images.length,
@@ -381,15 +367,12 @@ export async function fetchListings(opts: {
               trust_score: seller.trust_score,
             }
           : null,
-        category: category
-          ? { id: category.id, name: category.name, slug: category.slug }
-          : null,
       }
     }
   )
 
   const hasMore = typeof count === "number" ? offset + listings.length < count : false
-  return { listings, count, hasMore }
+  return { listings, count, hasMore, error: null }
 }
 
 // ---- Writes (called by server actions; DB access centralized here, §17) ----

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -300,14 +300,10 @@ export async function fetchListings(opts: {
 }> {
   const supabase = await createClient()
   const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
-  // Clamp + guard the pagination window: finite, non-negative, and never past
-  // the 1000-row ceiling so "Load more" always terminates. (§15: validate
-  // external input — offset comes from the URL.)
-  const requestedOffset = opts.offset ?? 0
-  const offset =
-    Number.isFinite(requestedOffset) && requestedOffset > 0
-      ? Math.min(requestedOffset, BROWSE_LIMIT_MAX - 1)
-      : 0
+  // offset is an untrusted cursor from the URL; parseBrowseParams
+  // (lib/browse) is the single source of truth that validates + clamps it
+  // to the 1000-row paging window so "Load more" always terminates.
+  const offset = opts.offset ?? 0
 
   let categoryId: string | null = null
   if (opts.categorySlug) {

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -1,13 +1,18 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import {
+  detectImageMime,
+  EXT_BY_MIME,
+  MAX_IMAGE_BYTES,
+  ALLOWED_IMAGE_MIME,
+  uploadObjects,
+} from "@/lib/media"
 
 // ---- Shared value sets (also drive the client form via literals) ----
 export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
 export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
 export const MAX_IMAGES = 10
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024
-export const ALLOWED_IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"]
 
 export type Condition = (typeof CONDITIONS)[number]
 export type ListingStatus = (typeof STATUSES)[number] | "archived"
@@ -99,34 +104,9 @@ export function isValidUuid(id: string): boolean {
   return UUID_RE.test(id)
 }
 
-/** Returns the image MIME derived from magic bytes, or null if it's not a real image (rejects executables). */
-async function detectImageMime(file: File): Promise<string | null> {
-  const slice = file.slice(0, 12)
-  const buf = await slice.arrayBuffer()
-  const b = new Uint8Array(buf)
-  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return "image/jpeg"
-  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return "image/png"
-  // RIFF....WEBP
-  if (
-    b[0] === 0x52 &&
-    b[1] === 0x49 &&
-    b[2] === 0x46 &&
-    b[3] === 0x46 &&
-    b[8] === 0x57 &&
-    b[9] === 0x45 &&
-    b[10] === 0x42 &&
-    b[11] === 0x50
-  ) {
-    return "image/webp"
-  }
-  return null
-}
-
-const EXT_BY_MIME: Record<string, string> = {
-  "image/jpeg": "jpg",
-  "image/png": "png",
-  "image/webp": "webp",
-}
+// Image validation primitives (detectImageMime, ALLOWED_IMAGE_MIME,
+// MAX_IMAGE_BYTES, EXT_BY_MIME) live in the Media object module (lib/media),
+// imported at the top of this file.
 
 // ---- Reads ----
 
@@ -487,61 +467,40 @@ export async function uploadListingPhotos(
     return `Up to ${MAX_IMAGES} photos allowed`
   }
 
-  // Track objects successfully uploaded so they can be cleaned up if a later
-  // step fails — otherwise a partial batch would orphan storage objects.
-  const uploadedPaths: string[] = []
-  const cleanupUploaded = async () => {
-    if (uploadedPaths.length) {
-      await supabase.storage.from("listing-images").remove(uploadedPaths).catch(() => {})
-    }
-  }
+  // The listing-image adapter: one of two adapters behind the shared Media
+  // upload seam (see lib/media). Bucket + path + reconciliation vary; the
+  // validate/upload/publicUrl/cleanup skeleton does not.
+  const result = await uploadObjects(
+    files.map((file, i) => ({ file, index: i })),
+    {
+      bucket: "listing-images",
+      validate: async (file) => {
+        const detected = await detectImageMime(file)
+        if (!detected || !ALLOWED_IMAGE_MIME.includes(detected)) {
+          return `${file.name || "Photo"} is not a valid JPG, PNG or WebP image`
+        }
+        if (file.size > MAX_IMAGE_BYTES) {
+          return "Each photo must be 5 MB or smaller"
+        }
+        return null
+      },
+      path: async (file, i) => {
+        const ext = EXT_BY_MIME[(await detectImageMime(file)) ?? ""] ?? "jpg"
+        return `${listingId}/${crypto.randomUUID()}-${i}.${ext}`
+      },
+      upsert: false,
+      reconcile: async (publicUrl, _file, i) => {
+        const { error } = await supabase.from("listing_images").insert({
+          listing_id: listingId,
+          image_url: publicUrl,
+          display_order: i,
+          alt_text: null,
+        })
+        return error ? error.message : null
+      },
+    },
+    supabase
+  )
 
-  try {
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i]
-      const detected = await detectImageMime(file)
-      if (!detected || !ALLOWED_IMAGE_MIME.includes(detected)) {
-        await cleanupUploaded()
-        return `${file.name || "Photo"} is not a valid JPG, PNG or WebP image`
-      }
-      if (file.size > MAX_IMAGE_BYTES) {
-        await cleanupUploaded()
-        return "Each photo must be 5 MB or smaller"
-      }
-
-      const ext = EXT_BY_MIME[detected]
-      const path = `${listingId}/${crypto.randomUUID()}-${i}.${ext}`
-
-      const { error: uploadError } = await supabase.storage
-        .from("listing-images")
-        .upload(path, file, { upsert: false })
-
-      if (uploadError) {
-        await cleanupUploaded()
-        return uploadError.message
-      }
-      uploadedPaths.push(path)
-
-      const {
-        data: { publicUrl },
-      } = supabase.storage.from("listing-images").getPublicUrl(path)
-
-      const { error: imageError } = await supabase.from("listing_images").insert({
-        listing_id: listingId,
-        image_url: publicUrl,
-        display_order: i,
-        alt_text: null,
-      })
-
-      if (imageError) {
-        await cleanupUploaded()
-        return imageError.message
-      }
-    }
-
-    return null
-  } catch (error) {
-    await cleanupUploaded()
-    return error instanceof Error ? error.message : "Failed to upload photos"
-  }
+  return result.ok ? null : result.error
 }

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -143,7 +143,18 @@ export async function fetchCategories(): Promise<Category[]> {
   return data as Category[]
 }
 
-export async function fetchListing(id: string): Promise<ListingWithRelations | null> {
+export interface FetchListingOptions {
+  /** Include the joined seller profile. The detail view renders the seller card,
+   * but the edit flow only authorizes via the page and never reads the profile
+   * row — so it can opt out of the extra profiles join. (RLS "readable by the
+   * owner" already lets an owner see their unpubished/draft rows.) */
+  includeSeller?: boolean
+}
+
+export async function fetchListing(
+  id: string,
+  opts: FetchListingOptions = {}
+): Promise<ListingWithRelations | null> {
   if (!isValidUuid(id)) return null
   const supabase = await createClient()
 
@@ -170,55 +181,23 @@ export async function fetchListing(id: string): Promise<ListingWithRelations | n
     category = (cat as Category | null) ?? null
   }
 
-  const { data: seller } = await supabase
-    .from("profiles")
-    .select("id, full_name, avatar_url, role, trust_score")
-    .eq("id", listing.seller_id)
-    .maybeSingle()
+  // The seller join is opt-out: one seam serves both read intents (detail wants
+  // seller, edit does not), instead of two near-copied functions.
+  let seller: ListingWithRelations["seller"] = null
+  if (opts.includeSeller !== false) {
+    const { data: s } = await supabase
+      .from("profiles")
+      .select("id, full_name, avatar_url, role, trust_score")
+      .eq("id", listing.seller_id)
+      .maybeSingle()
+    seller = s as ListingWithRelations["seller"]
+  }
 
   return {
     listing: listing as Listing,
     images: (images ?? []) as ListingImage[],
     category: category as Category | null,
-    seller: seller as ListingWithRelations["seller"],
-  }
-}
-
-// Reads the row for the owner even when not published (used by edit page).
-export async function fetchListingForEdit(
-  id: string,
-  sellerId: string
-): Promise<ListingWithRelations | null> {
-  if (!isValidUuid(id)) return null
-  const supabase = await createClient()
-
-  const { data: listing } = await supabase
-    .from("listings")
-    .select(LISTING_COLUMNS)
-    .eq("id", id)
-    .eq("seller_id", sellerId)
-    .maybeSingle()
-  if (!listing) return null
-
-  const { data: images } = await supabase
-    .from("listing_images")
-    .select("id, listing_id, image_url, display_order, alt_text")
-    .eq("listing_id", id)
-    .order("display_order", { ascending: true })
-
-  const { data: category } = listing.category_id
-    ? await supabase
-        .from("categories")
-        .select("id, name, slug, parent_id")
-        .eq("id", listing.category_id)
-        .maybeSingle()
-    : { data: null }
-
-  return {
-    listing: listing as Listing,
-    images: (images ?? []) as ListingImage[],
-    category: (category as Category | null) ?? null,
-    seller: null,
+    seller,
   }
 }
 
@@ -273,19 +252,43 @@ interface RawListingRow {
   images: ListingImage[] | null
 }
 
-export function formatPrice(price: number | string): string {
+export interface FormatPriceOptions {
+  maxFractionDigits?: number
+}
+
+export function formatPrice(
+  price: number | string,
+  opts: FormatPriceOptions = {}
+): string {
   const n = typeof price === "number" ? price : Number(price)
   if (Number.isNaN(n)) return "ETB —"
+  const maxFractionDigits = opts.maxFractionDigits ?? 0
   try {
     return new Intl.NumberFormat("en-ET", {
       style: "currency",
       currency: "ETB",
       minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
     }).format(n)
   } catch {
     return `ETB ${Math.round(n)}`
   }
+}
+
+const CONDITION_LABELS: Record<Condition, string> = {
+  "Brand New": "Brand new",
+  "Lightly Used": "Lightly used",
+  Fair: "Fair",
+}
+
+export function formatCondition(condition: Condition): string {
+  return CONDITION_LABELS[condition] ?? condition
+}
+
+export const CONDITION_COLORS: Record<Condition, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  Fair: "bg-amber-100 text-amber-800",
 }
 
 // Public, paginated browse of published listings (anon-readable via RLS).

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -2,8 +2,15 @@ import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
 
-export type Condition = "Brand New" | "Lightly Used" | "Fair"
-export type ListingStatus = "draft" | "published" | "sold" | "archived"
+// ---- Shared value sets (also drive the client form via literals) ----
+export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
+export const MAX_IMAGES = 10
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+export const ALLOWED_IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"]
+
+export type Condition = (typeof CONDITIONS)[number]
+export type ListingStatus = (typeof STATUSES)[number] | "archived"
 
 export interface Category {
   id: string
@@ -53,13 +60,82 @@ export interface ListingWithRelations {
   } | null
 }
 
+export interface ListingPayload {
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  photos?: File[]
+}
+
+export interface ListingEditPayload {
+  id: string
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  status?: ListingStatus
+}
+
+export const LISTING_COLUMNS =
+  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+
+// ---- Helpers ----
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isValidUuid(id: string): boolean {
+  return UUID_RE.test(id)
+}
+
+/** Returns the image MIME derived from magic bytes, or null if it's not a real image (rejects executables). */
+async function detectImageMime(file: File): Promise<string | null> {
+  const slice = file.slice(0, 12)
+  const buf = await slice.arrayBuffer()
+  const b = new Uint8Array(buf)
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return "image/jpeg"
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return "image/png"
+  // RIFF....WEBP
+  if (
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50
+  ) {
+    return "image/webp"
+  }
+  return null
+}
+
+const EXT_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+}
+
+// ---- Reads ----
+
 export async function fetchCategories(): Promise<Category[]> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from("categories")
     .select("id, name, slug, parent_id")
     .order("name")
-
   if (error) {
     console.error("fetchCategories:", error.message)
     return []
@@ -67,19 +143,15 @@ export async function fetchCategories(): Promise<Category[]> {
   return data as Category[]
 }
 
-export async function fetchListing(
-  id: string
-): Promise<ListingWithRelations | null> {
+export async function fetchListing(id: string): Promise<ListingWithRelations | null> {
+  if (!isValidUuid(id)) return null
   const supabase = await createClient()
 
   const { data: listing } = await supabase
     .from("listings")
-    .select(
-      "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
-    )
+    .select(LISTING_COLUMNS)
     .eq("id", id)
     .maybeSingle()
-
   if (!listing) return null
 
   const { data: images } = await supabase
@@ -112,21 +184,222 @@ export async function fetchListing(
   }
 }
 
-export async function fetchSellerListings(
+// Reads the row for the owner even when not published (used by edit page).
+export async function fetchListingForEdit(
+  id: string,
   sellerId: string
-): Promise<Listing[]> {
+): Promise<ListingWithRelations | null> {
+  if (!isValidUuid(id)) return null
+  const supabase = await createClient()
+
+  const { data: listing } = await supabase
+    .from("listings")
+    .select(LISTING_COLUMNS)
+    .eq("id", id)
+    .eq("seller_id", sellerId)
+    .maybeSingle()
+  if (!listing) return null
+
+  const { data: images } = await supabase
+    .from("listing_images")
+    .select("id, listing_id, image_url, display_order, alt_text")
+    .eq("listing_id", id)
+    .order("display_order", { ascending: true })
+
+  const { data: category } = listing.category_id
+    ? await supabase
+        .from("categories")
+        .select("id, name, slug, parent_id")
+        .eq("id", listing.category_id)
+        .maybeSingle()
+    : { data: null }
+
+  return {
+    listing: listing as Listing,
+    images: (images ?? []) as ListingImage[],
+    category: (category as Category | null) ?? null,
+    seller: null,
+  }
+}
+
+export async function fetchSellerListings(sellerId: string): Promise<Listing[]> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from("listings")
-    .select(
-      "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
-    )
+    .select(LISTING_COLUMNS)
     .eq("seller_id", sellerId)
     .order("created_at", { ascending: false })
-
   if (error) {
     console.error("fetchSellerListings:", error.message)
     return []
   }
   return data as Listing[]
+}
+
+// ---- Writes (called by server actions; DB access centralized here, §17) ----
+
+export async function createListing(
+  values: ListingPayload,
+  sellerId: string
+): Promise<{ id: string } | { error: string }> {
+  const supabase = await createClient()
+
+  if (values.categoryId) {
+    const { count } = await supabase
+      .from("categories")
+      .select("id", { count: "exact", head: true })
+      .eq("id", values.categoryId)
+    if (!count) return { error: "Invalid category" }
+  }
+
+  const { data: listing, error } = await supabase
+    .from("listings")
+    .insert({
+      seller_id: sellerId,
+      category_id: values.categoryId ?? null,
+      title: values.title,
+      description: values.description ?? null,
+      price: values.price,
+      condition: values.condition,
+      city: values.city,
+      sub_city: values.subCity ?? null,
+      address: values.address ?? null,
+      negotiable: values.negotiable ?? false,
+      status: "published" as ListingStatus,
+    })
+    .select("id")
+    .single()
+
+  if (error || !listing) {
+    return { error: error?.message ?? "Could not create listing" }
+  }
+
+  // Photos are required by the schema; upload them. If upload fails, compensate
+  // by deleting the half-created listing so we never persist a gallery-less row.
+  const uploadError = await uploadListingPhotos(
+    supabase,
+    listing.id,
+    sellerId,
+    values.photos ?? []
+  )
+  if (uploadError) {
+    await supabase.from("listings").delete().eq("id", listing.id)
+    return { error: uploadError }
+  }
+
+  return { id: listing.id }
+}
+
+export async function updateListing(
+  values: ListingEditPayload,
+  sellerId: string
+): Promise<{ ok: boolean; error: string | null }> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("listings")
+    .update({
+      category_id: values.categoryId ?? null,
+      title: values.title,
+      description: values.description ?? null,
+      price: values.price,
+      condition: values.condition,
+      city: values.city,
+      sub_city: values.subCity ?? null,
+      address: values.address ?? null,
+      negotiable: values.negotiable ?? false,
+      ...(values.status ? { status: values.status } : {}),
+    })
+    .eq("id", values.id)
+    .eq("seller_id", sellerId)
+    .select("id")
+
+  if (error) return { ok: false, error: error.message }
+  if (!data || data.length === 0) return { ok: false, error: "Listing not found" }
+  return { ok: true, error: null }
+}
+
+export async function softDeleteListing(
+  id: string,
+  sellerId: string
+): Promise<{ ok: boolean; error: string | null }> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("listings")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("seller_id", sellerId)
+    .select("id")
+
+  if (error) return { ok: false, error: error.message }
+  if (!data || data.length === 0) return { ok: false, error: "Listing not found" }
+  return { ok: true, error: null }
+}
+
+export async function uploadListingPhotos(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  listingId: string,
+  sellerId: string,
+  files: File[]
+): Promise<string | null> {
+  if (files.length > MAX_IMAGES) {
+    return `Up to ${MAX_IMAGES} photos allowed`
+  }
+
+  // Track objects successfully uploaded so they can be cleaned up if a later
+  // step fails — otherwise a partial batch would orphan storage objects.
+  const uploadedPaths: string[] = []
+  const cleanupUploaded = async () => {
+    if (uploadedPaths.length) {
+      await supabase.storage.from("listing-images").remove(uploadedPaths).catch(() => {})
+    }
+  }
+
+  try {
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]
+      const detected = await detectImageMime(file)
+      if (!detected || !ALLOWED_IMAGE_MIME.includes(detected)) {
+        await cleanupUploaded()
+        return `${file.name || "Photo"} is not a valid JPG, PNG or WebP image`
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        await cleanupUploaded()
+        return "Each photo must be 5 MB or smaller"
+      }
+
+      const ext = EXT_BY_MIME[detected]
+      const path = `${listingId}/${crypto.randomUUID()}-${i}.${ext}`
+
+      const { error: uploadError } = await supabase.storage
+        .from("listing-images")
+        .upload(path, file, { upsert: false })
+
+      if (uploadError) {
+        await cleanupUploaded()
+        return uploadError.message
+      }
+      uploadedPaths.push(path)
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("listing-images").getPublicUrl(path)
+
+      const { error: imageError } = await supabase.from("listing_images").insert({
+        listing_id: listingId,
+        image_url: publicUrl,
+        display_order: i,
+        alt_text: null,
+      })
+
+      if (imageError) {
+        await cleanupUploaded()
+        return imageError.message
+      }
+    }
+
+    return null
+  } catch (error) {
+    await cleanupUploaded()
+    return error instanceof Error ? error.message : "Failed to upload photos"
+  }
 }

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -17,6 +17,22 @@ export const MAX_IMAGES = 10
 export type Condition = (typeof CONDITIONS)[number]
 export type ListingStatus = (typeof STATUSES)[number] | "archived"
 
+export interface ListingStatusOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+// Canonical status options for the edit flow: the writable statuses plus the
+// terminal "archived" state surfaced as disabled (delete-only). Kept here so
+// the form never drifts from the ListingStatus value set.
+export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "sold", label: "Sold" },
+  { value: "archived", label: "Archived", disabled: true },
+]
+
 export interface Category {
   id: string
   name: string

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -236,6 +236,162 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
   return data as Listing[]
 }
 
+export const PAGE_SIZE = 12
+// PostgREST (Supabase) caps an unpaginated select at 1000 rows; every browse
+// query is bounded to PAGE_SIZE so we stay well under that ceiling even with
+// deep paging via offset. (T05 browse)
+const BROWSE_LIMIT_MAX = 1000
+
+export interface BrowseSeller {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+export interface BrowseCategory {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface BrowseListing {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  view_count: number
+  favorite_count: number
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller: BrowseSeller | null
+  category: BrowseCategory | null
+}
+
+interface RawListingRow {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  view_count: number
+  favorite_count: number
+  published_at: string
+  seller: BrowseSeller[] | null
+  category: BrowseCategory[] | null
+  images: ListingImage[] | null
+}
+
+export function formatPrice(price: number | string): string {
+  const n = typeof price === "number" ? price : Number(price)
+  if (Number.isNaN(n)) return "ETB —"
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(n)
+  } catch {
+    return `ETB ${Math.round(n)}`
+  }
+}
+
+// Public, paginated browse of published listings (anon-readable via RLS).
+export async function fetchListings(opts: {
+  limit?: number
+  offset?: number
+  categorySlug?: string
+} = {}): Promise<{
+  listings: BrowseListing[]
+  count: number | null
+  hasMore: boolean
+}> {
+  const supabase = await createClient()
+  const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
+  const offset = opts.offset ?? 0
+
+  let categoryId: string | null = null
+  if (opts.categorySlug) {
+    const { data: cat } = await supabase
+      .from("categories")
+      .select("id")
+      .eq("slug", opts.categorySlug)
+      .maybeSingle()
+    categoryId = cat?.id ?? null
+    if (!categoryId) return { listings: [], count: 0, hasMore: false }
+  }
+
+  let query = supabase
+    .from("listings")
+    .select(
+      `id, title, price, condition, negotiable, city, sub_city, view_count, favorite_count, published_at,
+       seller:profiles(id, full_name, avatar_url, role, trust_score),
+       category:categories(id, name, slug),
+       images:listing_images(id, image_url, display_order)`,
+      { count: "exact" }
+    )
+    .eq("status", "published")
+  if (categoryId) query = query.eq("category_id", categoryId)
+
+  const { data, error, count } = await query
+    .order("published_at", { ascending: false })
+    .range(offset, offset + limit - 1)
+
+  if (error) {
+    console.error("fetchListings:", error.message)
+    return { listings: [], count, hasMore: false }
+  }
+
+  const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
+    (l) => {
+      const images = l.images ?? []
+      const cover =
+        [...images]
+          .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
+        null
+      const seller = l.seller?.[0] ?? null
+      const category = l.category?.[0] ?? null
+      return {
+        id: l.id,
+        title: l.title,
+        price: l.price,
+        condition: l.condition,
+        negotiable: l.negotiable,
+        city: l.city,
+        sub_city: l.sub_city,
+        view_count: l.view_count,
+        favorite_count: l.favorite_count,
+        published_at: l.published_at,
+        image_url: cover,
+        image_count: images.length,
+        seller: seller
+          ? {
+              id: seller.id,
+              full_name: seller.full_name,
+              avatar_url: seller.avatar_url,
+              role: seller.role,
+              trust_score: seller.trust_score,
+            }
+          : null,
+        category: category
+          ? { id: category.id, name: category.name, slug: category.slug }
+          : null,
+      }
+    }
+  )
+
+  const hasMore = typeof count === "number" ? offset + listings.length < count : false
+  return { listings, count, hasMore }
+}
+
 // ---- Writes (called by server actions; DB access centralized here, §17) ----
 
 export async function createListing(

--- a/app/lib/listings/constants.ts
+++ b/app/lib/listings/constants.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure listing domain value objects.
+ *
+ * Framework-agnostic constants, types and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/listings` re-exports everything
+ * here (`export *`) so existing server-side imports keep resolving.
+ */
+
+export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
+export const MAX_IMAGES = 10
+
+export type Condition = (typeof CONDITIONS)[number]
+export type ListingStatus = (typeof STATUSES)[number] | "archived"
+
+export interface ListingStatusOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "sold", label: "Sold" },
+  { value: "archived", label: "Archived", disabled: true },
+]
+
+export interface Category {
+  id: string
+  name: string
+  slug: string
+  parent_id: string | null
+}
+
+export interface ListingImage {
+  id: string
+  listing_id: string
+  image_url: string
+  display_order: number
+  alt_text: string | null
+}
+
+export interface Listing {
+  id: string
+  seller_id: string
+  category_id: string | null
+  title: string
+  description: string | null
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  address: string | null
+  status: ListingStatus
+  view_count: number
+  favorite_count: number
+  published_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ListingWithRelations {
+  listing: Listing
+  images: ListingImage[]
+  category: Category | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+    role: string | null
+    trust_score: number | null
+  } | null
+}
+
+export interface ListingPayload {
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  photos?: File[]
+}
+
+export interface ListingEditPayload {
+  id: string
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  status?: ListingStatus
+}
+
+export const LISTING_COLUMNS =
+  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+
+export const PAGE_SIZE = 12
+// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
+// windowed: each request fetches PAGE_SIZE rows and we never page past the
+// 1000-row ceiling (T05, NFR-COMP-003).
+export const BROWSE_LIMIT_MAX = 1000
+
+export interface BrowseSeller {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+export interface BrowseListing {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  city: string | null
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller: BrowseSeller | null
+}
+
+export interface FormatPriceOptions {
+  maxFractionDigits?: number
+}
+
+export function formatPrice(
+  price: number | string,
+  opts: FormatPriceOptions = {}
+): string {
+  const n = typeof price === "number" ? price : Number(price)
+  if (Number.isNaN(n)) return "ETB \u2014"
+  const maxFractionDigits = opts.maxFractionDigits ?? 0
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
+    }).format(n)
+  } catch {
+    return `ETB ${Math.round(n)}`
+  }
+}
+
+const CONDITION_LABELS: Record<Condition, string> = {
+  "Brand New": "Brand new",
+  "Lightly Used": "Lightly used",
+  "Fair": "Fair",
+}
+
+export function formatCondition(condition: Condition): string {
+  return CONDITION_LABELS[condition] ?? condition
+}
+
+export const CONDITION_COLORS: Record<Condition, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  "Fair": "bg-amber-100 text-amber-800",
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isValidUuid(id: string): boolean {
+  return UUID_RE.test(id)
+}

--- a/app/lib/media.ts
+++ b/app/lib/media.ts
@@ -1,0 +1,131 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type Supabase = Awaited<ReturnType<typeof createClient>>
+
+// ---- Image primitives (shared by every upload adapter) ----
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+export const ALLOWED_IMAGE_MIME = ["image/jpeg", "image/png", "image/webp"]
+
+export const EXT_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+}
+
+/** Returns the image MIME derived from magic bytes, or null if it's not a real
+ * image (rejects executables masquerading as images). */
+export async function detectImageMime(file: File): Promise<string | null> {
+  const slice = file.slice(0, 12)
+  const buf = await slice.arrayBuffer()
+  const b = new Uint8Array(buf)
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return "image/jpeg"
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return "image/png"
+  // RIFF....WEBP
+  if (
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50
+  ) {
+    return "image/webp"
+  }
+  return null
+}
+
+// ---- Upload seam ----
+//
+// One adapter = hypothetical seam; two = real. The listing gallery and the
+// profile avatar are two adapters (different bucket / path / reconcile), so the
+// shared skeleton below earns its seam. Each adapter supplies:
+//   - validate(file):        magic-byte + size rules, with its own error wording
+//   - path(file, index):     the storage object name
+//   - reconcile(url, file, i): persist the URL (row insert / profile update)
+//   - upsert?:               overwrite semantics (avatar overwrites, photos don't)
+
+export interface MediaFile {
+  file: File
+  index: number
+}
+
+export interface UploadAdapter {
+  bucket: string
+  validate(file: File): Promise<string | null>
+  path(file: File, index: number): string | Promise<string>
+  upsert?: boolean
+  reconcile(
+    publicUrl: string,
+    file: File,
+    index: number
+  ): Promise<string | null>
+}
+
+export type UploadResult =
+  | { ok: true; publicUrls: string[] }
+  | { ok: false; error: string }
+
+export async function uploadObjects(
+  files: MediaFile[],
+  adapter: UploadAdapter,
+  supabase: Supabase
+): Promise<UploadResult> {
+  // Validate every file before uploading any, so a bad batch never starts.
+  for (const { file } of files) {
+    const err = await adapter.validate(file)
+    if (err) return { ok: false, error: err }
+  }
+
+  // Track objects successfully uploaded so they can be cleaned up if a later
+  // step fails — otherwise a partial batch orphans storage objects.
+  const uploadedPaths: string[] = []
+  const cleanup = async () => {
+    if (uploadedPaths.length) {
+      await supabase.storage
+        .from(adapter.bucket)
+        .remove(uploadedPaths)
+        .catch(() => {})
+    }
+  }
+
+  const publicUrls: string[] = []
+  try {
+    for (const { file, index } of files) {
+      const path = await adapter.path(file, index)
+
+      const { error: uploadError } = await supabase.storage
+        .from(adapter.bucket)
+        .upload(path, file, { upsert: adapter.upsert ?? false })
+
+      if (uploadError) {
+        await cleanup()
+        return { ok: false, error: uploadError.message }
+      }
+      uploadedPaths.push(path)
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from(adapter.bucket).getPublicUrl(path)
+      publicUrls.push(publicUrl)
+
+      const recErr = await adapter.reconcile(publicUrl, file, index)
+      if (recErr) {
+        await cleanup()
+        return { ok: false, error: recErr }
+      }
+    }
+
+    return { ok: true, publicUrls }
+  } catch (error) {
+    await cleanup()
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Failed to upload",
+    }
+  }
+}

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  // T04: allow multi-photo create requests (10 x 5 MB) in a single server action.
+  experimental: { serverActions: { bodySizeLimit: "50mb" } },
 };
 
 export default nextConfig;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,10 +29,12 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^9",
         "eslint-config-next": "16.3.0",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -451,6 +453,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -1961,6 +1973,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
@@ -3457,6 +3479,251 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3481,6 +3748,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -3970,6 +4244,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -4647,6 +4939,150 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4938,6 +5374,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -4954,6 +5400,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5224,6 +5689,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5996,6 +6471,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -6519,6 +7001,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6583,6 +7075,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -6867,6 +7369,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7232,6 +7749,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -7943,6 +8467,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -8516,6 +9079,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8969,6 +9573,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9266,6 +9884,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9919,6 +10544,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10399,6 +11057,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10442,6 +11107,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10450,6 +11122,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -10828,6 +11507,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10874,6 +11570,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11331,6 +12037,461 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11433,6 +12594,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ci": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -31,9 +35,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^9",
     "eslint-config-next": "16.3.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   }
 }

--- a/app/supabase/migrations/20260812120000_profile_phone_public.sql
+++ b/app/supabase/migrations/20260812120000_profile_phone_public.sql
@@ -1,0 +1,68 @@
+-- T03 - User & seller profiles
+-- Extends profiles with a phone public-opt-in flag and a public-readable view of
+-- the profile surface (DB spec §6, §20; Security §18/19: phone is private by default
+-- and only surfaced when the owner consents).
+--
+-- Privacy note: RLS row policies control WHICH rows a caller sees, not which
+-- columns. Phone is therefore never selected in a public query unless the row's
+-- phone_public flag is true (see app/users/[id]/page.tsx). Public column exposure
+-- is enforced at the data-access layer.
+
+-- Public-opt-in for phone visibility.
+alter table public.profiles add column if not exists phone_public boolean not null default false;
+
+-- Public profiles are readable (rows) by anyone. Sensitive columns are masked
+-- separately via column-level policies below so phone is never exposed without
+-- the owner's consent, even if a caller explicitly selects it (column-level RLS).
+create policy if not exists "Profiles are publicly readable"
+  on public.profiles for select
+  to authenticated, anon
+  using (true);
+
+-- Column-level security for phone (Privacy §18/19): never expose it without
+-- consent. Authenticated callers may read their OWN phone; all others need
+-- the owner's phone_public opt-in. Anonymous never see phone unless public.
+create policy if not exists "Phone visible to owner or when public (authenticated)"
+  on public.profiles for select
+  to authenticated
+  columns (phone)
+  using (phone_public or auth.uid() = id);
+
+create policy if not exists "Phone visible only when public (anon)"
+  on public.profiles for select
+  to anon
+  columns (phone)
+  using (phone_public);
+
+-- Keep the existing owner/admin policies (they remain in force; row policies are
+-- additive). No changes to insert/update/delete policies here — owners still
+-- edit only their own row via the previous policies.
+
+-- Avatar storage bucket for profile pictures (public read, owner write).
+-- 5 MB per file (Security §11). Idempotent so it is safe across db reset.
+insert into storage.buckets (id, name, public, file_size_limit)
+values ('profiles', 'profiles', true, 5242880)
+on conflict (id) do update
+  set public = excluded.public, file_size_limit = excluded.file_size_limit;
+
+-- Allow any reader to resolve public avatar URLs (public bucket reads are
+-- served without RLS checks at /storage/v1/object/public/profiles/...).
+create policy if not exists "Profile avatars are publicly readable"
+  on storage.objects for select
+  to authenticated, anon
+  using (bucket_id = 'profiles');
+
+-- Owners may manage their own avatar objects only (path prefix avatars/{uid}).
+create policy if not exists "Profile avatars are writable by the owner"
+  on storage.objects for all
+  to authenticated
+  with check (
+    bucket_id = 'profiles'
+    and (storage.foldername(name))[0] = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  )
+  using (
+    bucket_id = 'profiles'
+    and (storage.foldername(name))[0] = 'avatars'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/app/supabase/migrations/20260812200000_create_listings.sql
+++ b/app/supabase/migrations/20260812200000_create_listings.sql
@@ -1,8 +1,8 @@
 -- T04 - Listings service (CRUD, photos, search index)
--- Categories + listings + listing_images, per docs/02-architecture/03-database-design-specification.md
--- §7 (categories), §8 (listings), §7 listing_images (named listing_images),
--- §17 (indexes), §19 (images: max 10 per listing), §20 (RLS), §22 (migration naming).
--- Adds the full-text search index resolved in #3 (tsvector + GIN + pg_trgm).
+-- categories + listings + listing_images, per docs/02-architecture/03-database-design-specification.md
+-- §7 (categories), §8 (listings), §7 listing_images, §17 (indexes), §19 (images: max 10),
+-- §20 (RLS), §22 (migration naming). Full-text search index per resolved #3 (tsvector + GIN + pg_trgm).
+-- File-storage layout: avatars/, listing-images/ (docs/02-architecture/00-system-architecture.md §10).
 
 create extension if not exists pg_trgm;
 
@@ -17,9 +17,8 @@ create table if not exists public.categories (
 );
 
 -- Listing condition + status constrained to the documented value sets.
--- (DB spec §8 lists free-text columns; T04 AC fixes the value sets.)
-create type public.listing_condition as enum ('Brand New', 'Lightly Used', 'Fair');
-create type public.listing_status as enum ('draft', 'published', 'sold', 'archived');
+create type if not exists public.listing_condition as enum ('Brand New', 'Lightly Used', 'Fair');
+create type if not exists public.listing_status as enum ('draft', 'published', 'sold', 'archived');
 
 create table if not exists public.listings (
   id uuid primary key default gen_random_uuid(),
@@ -46,12 +45,12 @@ create table if not exists public.listings (
   deleted_at timestamptz
 );
 
--- Constraint ranges from DB spec §18: title 5-120, description 20-2000.
+-- Constraint ranges from DB spec §18: title 5-120, description 20-2000 (null allowed).
 alter table public.listings
   add constraint listings_title_len check (char_length(title) between 5 and 120),
-  add constraint listings_description_len check (char_length(coalesce(description, '')) <= 2000);
+  add constraint listings_description_len check (description is null or char_length(description) between 20 and 2000);
 
--- Indexes (DB spec §17 + §19 full-text future, now resolved by #3).
+-- Indexes (DB spec §17 + §19 full-text, now resolved by #3).
 create index if not exists listings_seller_id_idx on public.listings (seller_id);
 create index if not exists listings_category_id_idx on public.listings (category_id);
 create index if not exists listings_city_idx on public.listings (city);
@@ -88,13 +87,11 @@ create trigger if not exists listings_set_updated_at
 alter table public.listings enable row level security;
 alter table public.listing_images enable row level security;
 
--- Public read: published, not deleted.
 create policy if not exists "Listings are readable when published"
   on public.listings for select
   to authenticated, anon
   using (status = 'published' and deleted_at is null);
 
--- A seller sees all of their own listings (incl. drafts).
 create policy if not exists "Listings are readable by the owner"
   on public.listings for select
   to authenticated
@@ -116,15 +113,12 @@ create policy if not exists "Listings are deletable by the owner"
   to authenticated
   using ((select auth.uid()) = seller_id);
 
--- Admin override (consistent with profiles).
 create policy if not exists "Listings are manageable by admins"
   on public.listings for all
   to authenticated
   using (public.is_admin())
   with check (public.is_admin());
 
--- Listing images: readable when the parent listing is readable; only the
--- listing owner (or admin) may write them.
 create policy if not exists "Listing images are readable with published listings"
   on public.listing_images for select
   to authenticated, anon
@@ -182,38 +176,35 @@ grant select, insert, update, delete on public.listings, public.listing_images, 
 grant select on public.listings, public.listing_images, public.categories to anon;
 
 ------------------------------------------------------------------------------
--- Storage: listing photos (DB spec §11: JPG/JPEG/PNG/WebP, 5 MB each, max 10).
--- Public read; only the listing owner may write to listings/{listing_id}/.
+-- Storage (design §10): listing photos in the `listing-images` bucket.
+-- Public read (bucket is public); only the listing owner may write to
+-- listing-images/{listing_id}/... (foldername()[0] is the listing id).
+-- 5 MB per image, JPG/JPEG/PNG/WebP; magic-byte + size validation happens in
+-- the upload service (app/lib/listings.ts) — Storage RLS is defense-in-depth.
 ------------------------------------------------------------------------------
 insert into storage.buckets (id, name, public, file_size_limit)
-values ('listings', 'listings', true, 5242880)
+values ('listing-images', 'listing-images', true, 5242880)
 on conflict (id) do update
   set public = excluded.public, file_size_limit = excluded.file_size_limit;
 
 create policy if not exists "Listing photos are publicly readable"
   on storage.objects for select
   to authenticated, anon
-  using (bucket_id = 'listings');
+  using (bucket_id = 'listing-images');
 
 create policy if not exists "Listing photos are writable by the listing owner"
   on storage.objects for all
   to authenticated
   with check (
-    bucket_id = 'listings'
-    and (storage.foldername(name))[0] = 'listings'
-    and exists (
-      select 1 from public.listings l
-      where l.id = (storage.foldername(name))[1]::uuid
-        and l.seller_id = (select auth.uid())
+    bucket_id = 'listing-images'
+    and (storage.foldername(name))[0]::uuid in (
+      select l.id from public.listings l where l.seller_id = (select auth.uid())
     )
   )
   using (
-    bucket_id = 'listings'
-    and (storage.foldername(name))[0] = 'listings'
-    and exists (
-      select 1 from public.listings l
-      where l.id = (storage.foldername(name))[1]::uuid
-        and l.seller_id = (select auth.uid())
+    bucket_id = 'listing-images'
+    and (storage.foldername(name))[0]::uuid in (
+      select l.id from public.listings l where l.seller_id = (select auth.uid())
     )
   );
 

--- a/app/supabase/migrations/20260812200000_create_listings.sql
+++ b/app/supabase/migrations/20260812200000_create_listings.sql
@@ -1,0 +1,233 @@
+-- T04 - Listings service (CRUD, photos, search index)
+-- Categories + listings + listing_images, per docs/02-architecture/03-database-design-specification.md
+-- §7 (categories), §8 (listings), §7 listing_images (named listing_images),
+-- §17 (indexes), §19 (images: max 10 per listing), §20 (RLS), §22 (migration naming).
+-- Adds the full-text search index resolved in #3 (tsvector + GIN + pg_trgm).
+
+create extension if not exists pg_trgm;
+
+-- Categories (top-level + optional parent for sub-categories; T06 search facets them).
+create table if not exists public.categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  parent_id uuid references public.categories (id) on delete set null,
+  icon text,
+  created_at timestamptz not null default now()
+);
+
+-- Listing condition + status constrained to the documented value sets.
+-- (DB spec §8 lists free-text columns; T04 AC fixes the value sets.)
+create type public.listing_condition as enum ('Brand New', 'Lightly Used', 'Fair');
+create type public.listing_status as enum ('draft', 'published', 'sold', 'archived');
+
+create table if not exists public.listings (
+  id uuid primary key default gen_random_uuid(),
+  seller_id uuid not null references public.profiles (id) on delete cascade,
+  category_id uuid references public.categories (id),
+  title text not null,
+  description text,
+  price numeric(12, 2) not null check (price > 0),
+  condition public.listing_condition not null,
+  negotiable boolean not null default false,
+  city text,
+  sub_city text,
+  address text,
+  status public.listing_status not null default 'published',
+  view_count integer not null default 0,
+  favorite_count integer not null default 0,
+  published_at timestamptz not null default now(),
+  search_vector tsvector
+    generated always as
+      (to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, '')))
+    stored,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+-- Constraint ranges from DB spec §18: title 5-120, description 20-2000.
+alter table public.listings
+  add constraint listings_title_len check (char_length(title) between 5 and 120),
+  add constraint listings_description_len check (char_length(coalesce(description, '')) <= 2000);
+
+-- Indexes (DB spec §17 + §19 full-text future, now resolved by #3).
+create index if not exists listings_seller_id_idx on public.listings (seller_id);
+create index if not exists listings_category_id_idx on public.listings (category_id);
+create index if not exists listings_city_idx on public.listings (city);
+create index if not exists listings_status_idx on public.listings (status);
+create index if not exists listings_price_idx on public.listings (price);
+create index if not exists listings_published_at_idx on public.listings (published_at);
+create index if not exists listings_search_idx on public.listings using gin (search_vector);
+create index if not exists listings_trgm_idx on public.listings
+  using gin (title gin_trgm_ops, description gin_trgm_ops);
+
+-- Images: max 10 per listing (§19), enforced in app logic + FK.
+create table if not exists public.listing_images (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.listings (id) on delete cascade,
+  image_url text not null,
+  display_order smallint not null default 0,
+  alt_text text,
+  created_at timestamptz not null default now()
+);
+create index if not exists listing_images_listing_id_idx on public.listing_images (listing_id);
+create index if not exists listing_images_display_order_idx on public.listing_images (listing_id, display_order);
+
+-- Keep listings.updated_at in sync (reuse the generic trigger from T02).
+create trigger if not exists listings_set_updated_at
+  before update on public.listings
+  for each row execute function public.handle_updated_at();
+
+------------------------------------------------------------------------------
+-- RLS (DB spec §20 Listings):
+--   - Public can read PUBLISHED, non-deleted listings.
+--   - Sellers create listings (row bound to the seller via auth.uid()).
+--   - Sellers update/delete only their OWN listings; admins full access.
+------------------------------------------------------------------------------
+alter table public.listings enable row level security;
+alter table public.listing_images enable row level security;
+
+-- Public read: published, not deleted.
+create policy if not exists "Listings are readable when published"
+  on public.listings for select
+  to authenticated, anon
+  using (status = 'published' and deleted_at is null);
+
+-- A seller sees all of their own listings (incl. drafts).
+create policy if not exists "Listings are readable by the owner"
+  on public.listings for select
+  to authenticated
+  using ((select auth.uid()) = seller_id);
+
+create policy if not exists "Listings are insertable by the owner"
+  on public.listings for insert
+  to authenticated
+  with check ((select auth.uid()) = seller_id);
+
+create policy if not exists "Listings are updatable by the owner"
+  on public.listings for update
+  to authenticated
+  using ((select auth.uid()) = seller_id)
+  with check ((select auth.uid()) = seller_id);
+
+create policy if not exists "Listings are deletable by the owner"
+  on public.listings for delete
+  to authenticated
+  using ((select auth.uid()) = seller_id);
+
+-- Admin override (consistent with profiles).
+create policy if not exists "Listings are manageable by admins"
+  on public.listings for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- Listing images: readable when the parent listing is readable; only the
+-- listing owner (or admin) may write them.
+create policy if not exists "Listing images are readable with published listings"
+  on public.listing_images for select
+  to authenticated, anon
+  using (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.status = 'published'
+        and l.deleted_at is null
+    )
+  );
+
+create policy if not exists "Listing images are writable by the listing owner"
+  on public.listing_images for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.seller_id = (select auth.uid())
+    )
+  );
+
+create policy if not exists "Listing images are updatable by the listing owner"
+  on public.listing_images for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.seller_id = (select auth.uid())
+    )
+  );
+
+create policy if not exists "Listing images are deletable by the listing owner"
+  on public.listing_images for delete
+  to authenticated
+  using (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.seller_id = (select auth.uid())
+    )
+  );
+
+create policy if not exists "Listing image admins full access"
+  on public.listing_images for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+grant usage on schema public to anon, authenticated;
+grant select, insert, update, delete on public.listings, public.listing_images, public.categories
+  to authenticated;
+grant select on public.listings, public.listing_images, public.categories to anon;
+
+------------------------------------------------------------------------------
+-- Storage: listing photos (DB spec §11: JPG/JPEG/PNG/WebP, 5 MB each, max 10).
+-- Public read; only the listing owner may write to listings/{listing_id}/.
+------------------------------------------------------------------------------
+insert into storage.buckets (id, name, public, file_size_limit)
+values ('listings', 'listings', true, 5242880)
+on conflict (id) do update
+  set public = excluded.public, file_size_limit = excluded.file_size_limit;
+
+create policy if not exists "Listing photos are publicly readable"
+  on storage.objects for select
+  to authenticated, anon
+  using (bucket_id = 'listings');
+
+create policy if not exists "Listing photos are writable by the listing owner"
+  on storage.objects for all
+  to authenticated
+  with check (
+    bucket_id = 'listings'
+    and (storage.foldername(name))[0] = 'listings'
+    and exists (
+      select 1 from public.listings l
+      where l.id = (storage.foldername(name))[1]::uuid
+        and l.seller_id = (select auth.uid())
+    )
+  )
+  using (
+    bucket_id = 'listings'
+    and (storage.foldername(name))[0] = 'listings'
+    and exists (
+      select 1 from public.listings l
+      where l.id = (storage.foldername(name))[1]::uuid
+        and l.seller_id = (select auth.uid())
+    )
+  );
+
+------------------------------------------------------------------------------
+-- Seed categories (DB spec §23).
+------------------------------------------------------------------------------
+insert into public.categories (name, slug, parent_id) values
+  ('Electronics', 'electronics', null),
+  ('Furniture', 'furniture', null),
+  ('Home Appliances', 'home-appliances', null),
+  ('Vehicles', 'vehicles', null),
+  ('Fashion', 'fashion', null),
+  ('Books', 'books', null),
+  ('Sports', 'sports', null),
+  ('Baby & Kids', 'baby-and-kids', null),
+  ('Other', 'other', null)
+on conflict (slug) do nothing;

--- a/app/tests/unit/browse.test.ts
+++ b/app/tests/unit/browse.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings"
+import { parseBrowseParams, buildBrowseUrl, nextOffset } from "@/lib/browse"
+
+describe("browse.parseBrowseParams", () => {
+  it("defaults offset to 0 when absent", () => {
+    expect(parseBrowseParams({})).toEqual({ categorySlug: undefined, offset: 0 })
+  })
+
+  it("clamps a huge offset to the 1000-row ceiling", () => {
+    expect(parseBrowseParams({ offset: "99999" }).offset).toBe(BROWSE_LIMIT_MAX - 1)
+  })
+
+  it("rejects a negative offset", () => {
+    expect(parseBrowseParams({ offset: "-5" }).offset).toBe(0)
+  })
+
+  it("rejects a non-numeric offset", () => {
+    expect(parseBrowseParams({ offset: "abc" }).offset).toBe(0)
+  })
+
+  it("passes a simple category slug through", () => {
+    expect(parseBrowseParams({ category: "electronics" }).categorySlug).toBe(
+      "electronics"
+    )
+  })
+
+  it("drops a category when it is an array", () => {
+    expect(parseBrowseParams({ category: ["a", "b"] }).categorySlug).toBeUndefined()
+  })
+})
+
+describe("browse.buildBrowseUrl", () => {
+  it("omits offset when it is zero", () => {
+    expect(buildBrowseUrl("books", 0)).toBe("/?category=books")
+  })
+
+  it("includes both params for a non-zero offset", () => {
+    expect(buildBrowseUrl("books", 24)).toBe("/?category=books&offset=24")
+  })
+
+  it("omits the category when undefined", () => {
+    expect(buildBrowseUrl(undefined, 24)).toBe("/?offset=24")
+  })
+})
+
+describe("browse.nextOffset", () => {
+  it("advances by one page", () => {
+    expect(nextOffset(0)).toBe(PAGE_SIZE)
+    expect(nextOffset(PAGE_SIZE)).toBe(PAGE_SIZE * 2)
+  })
+})

--- a/app/tests/unit/listings.test.ts
+++ b/app/tests/unit/listings.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  isValidUuid,
+  formatPrice,
+  formatCondition,
+  CONDITION_COLORS,
+} from "@/lib/listings"
+
+describe("listings.isValidUuid", () => {
+  it("accepts a canonical v4 UUID", () => {
+    expect(isValidUuid("550e8400-e29b-41d4-a716-446655440000")).toBe(true)
+  })
+
+  it("rejects a short id", () => {
+    expect(isValidUuid("550e8400")).toBe(false)
+  })
+
+  it("rejects a UUID with trailing extra characters", () => {
+    expect(isValidUuid("550e8400-e29b-41d4-a716-446655440000 extra")).toBe(false)
+  })
+})
+
+describe("listings.formatPrice", () => {
+  it("falls back to the placeholder when the value is NaN", () => {
+    expect(formatPrice(NaN)).toBe("ETB \u2014")
+  })
+
+  it("falls back to the placeholder when a non-numeric string is given", () => {
+    expect(formatPrice("not-a-number")).toBe("ETB \u2014")
+  })
+
+  it("formats a finite number as a non-empty string (locale-stable contract)", () => {
+    const out = formatPrice(5)
+    expect(out).not.toBe("ETB \u2014")
+    expect(out).toContain("5")
+  })
+})
+
+describe("listings.formatCondition", () => {
+  it("title-cases the brand-new label", () => {
+    expect(formatCondition("Brand New")).toBe("Brand new")
+  })
+
+  it("passes unknown conditions through unchanged", () => {
+    expect(formatCondition("Fair")).toBe("Fair")
+  })
+})
+
+describe("listings.CONDITION_COLORS", () => {
+  it("exposes a palette entry for every condition", () => {
+    expect(Object.keys(CONDITION_COLORS).sort()).toEqual(
+      ["Brand New", "Lightly Used", "Fair"].sort()
+    )
+  })
+})

--- a/app/tests/unit/media.test.ts
+++ b/app/tests/unit/media.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest"
+
+import { detectImageMime, uploadObjects } from "@/lib/media"
+
+const makeFile = (bytes: number[], name = "photo.jpg"): File =>
+  new File([new Uint8Array(bytes)], name, { type: "application/octet-stream" })
+
+describe("media.detectImageMime", () => {
+  it("detects a JPEG from magic bytes (ff d8 ff)", async () => {
+    expect(
+      await detectImageMime(makeFile([0xff, 0xd8, 0xff, 0xe0, ...new Array(8)]))
+    ).toBe("image/jpeg")
+  })
+
+  it("detects a PNG from magic bytes (89 50 4e 47)", async () => {
+    expect(
+      await detectImageMime(
+        makeFile([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, ...new Array(6)])
+      )
+    ).toBe("image/png")
+  })
+
+  it("detects a WEBP from the RIFF....WEBP signature", async () => {
+    const riff = [0x52, 0x49, 0x46, 0x46, ...new Array(4), 0x57, 0x45, 0x42, 0x50]
+    expect(await detectImageMime(makeFile(riff))).toBe("image/webp")
+  })
+
+  it("rejects plain text as null", async () => {
+    expect(await detectImageMime(makeFile([0x48, 0x65, 0x6c, 0x6c, 0x6f]))).toBeNull()
+  })
+
+  it("rejects an empty file as null", async () => {
+    expect(await detectImageMime(makeFile([]))).toBeNull()
+  })
+})
+
+describe("media.uploadObjects", () => {
+  it("fails fast on a validation error before touching storage", async () => {
+    const adapter = {
+      bucket: "listing-images",
+      validate: vi.fn().mockResolvedValue("bad image"),
+      path: vi.fn(),
+      upsert: false,
+      reconcile: vi.fn(),
+    }
+    const result = await uploadObjects(
+      [{ file: makeFile([0x48]), index: 0 }],
+      adapter,
+      {} as never
+    )
+    expect(result).toEqual({ ok: false, error: "bad image" })
+    // No storage access on a validation failure.
+    expect(adapter.path).not.toHaveBeenCalled()
+    expect(adapter.reconcile).not.toHaveBeenCalled()
+  })
+})

--- a/app/vitest.config.mts
+++ b/app/vitest.config.mts
@@ -1,0 +1,39 @@
+/// <reference types="vitest/globals" />
+import { defineConfig } from "vitest/config"
+import { fileURLToPath } from "node:url"
+
+const root = fileURLToPath(new URL(".", import.meta.url)).replaceAll("\\", "/")
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["./vitest/setup.ts"],
+    include: [
+      "tests/unit/**/*.test.ts",
+      "lib/**/__tests__/**/*.test.ts",
+      "lib/**/*.test.ts",
+    ],
+    exclude: ["node_modules/**", "dist/**", ".next/**", "tests/**/*.spec.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["lib/**/*.{ts,tsx}", "!lib/**/*.test.ts", "!lib/**/*.spec.ts"],
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: "server-only",
+        replacement: root + "/vitest/stubs/server-only.ts",
+      },
+      {
+        find: "@/lib/supabase/server",
+        replacement: root + "/vitest/stubs/supabase-server.ts",
+      },
+      { find: "@/", replacement: root + "/" },
+    ],
+  },
+})

--- a/app/vitest/setup.ts
+++ b/app/vitest/setup.ts
@@ -1,0 +1,10 @@
+// Global Vitest setup.
+//
+// The module-graph stubs (server-only / @/lib/supabase/server) are applied via
+// resolve.alias in vitest.config.ts, so importing the pure seam modules
+// (lib/listings, lib/media, lib/browse) works under Node without pulling in the
+// Next server runtime or triggering the `server-only` import-time throw.
+//
+// No per-test mocking is required for the pure function surfaces. Reopen this
+// file to register shared hooks (e.g. @testing-library/jest-dom) once component
+// tests are added.

--- a/app/vitest/stubs/server-only.ts
+++ b/app/vitest/stubs/server-only.ts
@@ -1,0 +1,7 @@
+// Empty stub for Next's `server-only` marker.
+//
+// Importing the real `server-only` module throws at runtime ("This module cannot
+// be imported from a Client Component module…"). It is a build-time directive,
+// not runtime code, so under Vitest's Node environment we alias it to nothing.
+// This lets the pure seam modules (lib/listings, lib/media, lib/browse) load
+// without executing the Next server graph — no per-test mocking needed.

--- a/app/vitest/stubs/supabase-server.ts
+++ b/app/vitest/stubs/supabase-server.ts
@@ -1,0 +1,8 @@
+// Stub for @/lib/supabase/server. Importing the real module pulls in
+// `next/headers` and `@supabase/ssr`, which resolve fine under Vitest but are
+// irrelevant to the pure seam functions — and `createClient` is never called at
+// module-load time. Any test that genuinely needs a live client should mock the
+// call site; the pure surfaces (formatting, paging, upload skeleton) don't.
+export const createClient = (): never => {
+  throw new Error("createClient is not available in unit tests")
+}

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -54,6 +54,19 @@ Examples:
 Tools:
 - Vitest
 - React Testing Library
+- @vitest/coverage-v8
+
+### Unit Testing Setup (app/)
+
+| Concern | Convention |
+|---------|------------|
+| Runner | `vitest.config.mts`, `environment: node`, `globals: true` |
+| Scripts | `npm test` (run), `npm run test:watch`, `npm run test:ci` (run + coverage) |
+| Stubs | `vitest/stubs/server-only.ts`, `vitest/stubs/supabase-server.ts` — alias `server-only` and `@/lib/supabase/server` so pure seam modules load under Node without the Next server graph |
+| Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
+| Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
+
+Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`).
 
 ## Integration Testing
 


### PR DESCRIPTION
﻿## Summary
T05 browse feature branch with the Vitest unit-test scaffold as its capstone. Adds the last top-priority gap: automated unit tests for the pure seam modules, running under Node without the Next server graph.

## What the scaffold adds (commit a99a64c)
- `app/vitest.config.mts` — Vitest config: node env, globals, v8 coverage, aliases
- `app/vitest/stubs/` — `server-only.ts`, `supabase-server.ts` (let pure seam modules load under Node)
- `app/tests/unit/` — 25 tests:
  - media.test.ts — detectImageMime (JPEG/PNG/WEBP magic bytes + rejection), uploadObjects validation-fail-fast
  - listings.test.ts — isValidUuid, formatPrice (NaN/non-numeric fallback), formatCondition, CONDITION_COLORS
  - browse.test.ts — parseBrowseParams (offset clamped to 1000-row ceiling), buildBrowseUrl, nextOffset
- app/package.json — `test` / `test:watch` / `test:ci` scripts
- docs/03-engineering/01-testing-strategy.md — conventions documented

## Verification
- `npm test` → 25/25 passing (3 files)
- `npm run typecheck` → clean
- `npx eslint tests/unit vitest.config.mts vitest/` → clean

## Notes
- Tests use `@/lib/...` aliases (not `../lib/...`); relative specifiers resolve incorrectly under the node env on Windows.
- No CI workflow exists in `.github/` yet; follow-up ticket to gate PRs (lint + typecheck + test).

Refs: docs/03-engineering/01-testing-strategy.md
