### PR TITLE
T06: Intelligent search & filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    name: Lint, Typecheck & Build
+    name: Lint, Typecheck, Tests & Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,6 +36,9 @@ jobs:
 
       - name: Type check
         run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -61,7 +61,7 @@ export default async function HomePage({
         </p>
         <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
           <Button asChild size="lg">
-            <Link href="#listings">Browse listings</Link>
+            <Link href="/search">Browse listings</Link>
           </Button>
           <Button asChild variant="outline" size="lg">
             <Link href="/sell">Start selling</Link>

--- a/app/app/search/loading.tsx
+++ b/app/app/search/loading.tsx
@@ -1,0 +1,25 @@
+export default function SearchLoading() {
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <div className="mb-8 space-y-3">
+        <div className="h-9 w-72 animate-pulse rounded-lg bg-muted" />
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+      </div>
+
+      <div className="animate-pulse rounded-lg border bg-card p-4">
+        <div className="h-9 w-full rounded-md bg-muted" />
+        <div className="mt-4 h-9 w-full rounded-md bg-muted" />
+      </div>
+
+      <div className="mt-8 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }, (_, i) => (
+          <div key={i} className="animate-pulse">
+            <div className="aspect-[4/3] rounded-lg bg-muted" />
+            <div className="mt-3 h-4 w-3/4 rounded bg-muted" />
+            <div className="mt-2 h-4 w-1/3 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/search/page.tsx
+++ b/app/app/search/page.tsx
@@ -43,7 +43,7 @@ export default async function SearchPage({
   const filters = parseSearchParams(sp)
 
   const categoriesPromise = fetchCategories()
-  const { listings, totalCount, hasMore, error } = await searchListings({
+  const { listings, count, hasMore, error } = await searchListings({
     q: filters.q || undefined,
     categorySlug: filters.categorySlug,
     minPrice: filters.minPrice,
@@ -64,7 +64,7 @@ export default async function SearchPage({
         <p className="mt-2 text-muted-foreground">
           {error
             ? "We could not run your search."
-            : `${totalCount} ${totalCount === 1 ? "listing" : "listings"}`}
+            : `${count} ${count === 1 ? "listing" : "listings"}`}
         </p>
       </section>
 

--- a/app/app/search/page.tsx
+++ b/app/app/search/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link"
+
+import { Button } from "@/components/ui/button"
+import { fetchCategories, searchListings } from "@/lib/listings"
+import { buildSearchUrl, nextOffset, parseSearchParams } from "@/lib/search"
+import { ListingCard } from "@/components/listings/listing-card"
+import { SearchFilters } from "@/components/search/search-filters"
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M21 21l-4.35-4.35M9.5 18a8.5 8.5 0 110-17 8.5 8.5 0 010 17z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="7.5"
+        cy="7.5"
+        r="1.25"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const sp = await searchParams
+  const filters = parseSearchParams(sp)
+
+  const categoriesPromise = fetchCategories()
+  const { listings, totalCount, hasMore, error } = await searchListings({
+    q: filters.q || undefined,
+    categorySlug: filters.categorySlug,
+    minPrice: filters.minPrice,
+    maxPrice: filters.maxPrice,
+    condition: filters.condition,
+    city: filters.city || undefined,
+    sort: filters.sort,
+    offset: filters.offset,
+  })
+  const categories = await categoriesPromise
+
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <section className="mb-8">
+        <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+          {filters.q ? `Results for “${filters.q}”` : "Browse listings"}
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          {error
+            ? "We could not run your search."
+            : `${totalCount} ${totalCount === 1 ? "listing" : "listings"}`}
+        </p>
+      </section>
+
+      <SearchFilters categories={categories} filters={filters} />
+
+      <section aria-label="Search results" className="mt-8">
+        {error ? (
+          <div className="py-16 text-center">
+            <p className="text-sm text-muted-foreground">
+              We could not load listings.
+            </p>
+            <Link
+              href={buildSearchUrl(filters)}
+              className="mt-2 inline-block text-sm font-medium text-primary underline"
+            >
+              Retry
+            </Link>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="flex flex-col items-center py-16 text-center">
+            <SearchIcon className="mb-3 h-10 w-10 text-muted-foreground/60" />
+            <h2 className="font-heading text-lg font-semibold">
+              No results found.
+            </h2>
+            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+              Try a different keyword, or widen your filters.
+            </p>
+            <Button asChild size="sm" className="mt-4">
+              <Link href="/search">Clear all filters</Link>
+            </Button>
+          </div>
+        ) : (
+          <>
+            <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {listings.map((l) => (
+                <li key={l.id}>
+                  <ListingCard listing={l} />
+                </li>
+              ))}
+            </ul>
+            {hasMore ? (
+              <div className="mt-10 flex justify-center">
+                <Link
+                  href={buildSearchUrl({
+                    ...filters,
+                    offset: nextOffset(filters.offset),
+                  })}
+                  className="text-sm font-medium underline"
+                >
+                  Load more
+                </Link>
+              </div>
+            ) : null}
+          </>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge"
 
-import { CONDITION_COLORS } from "@/lib/listings"
+import { CONDITION_COLORS } from "@/lib/listings/constants"
 import type { Condition } from "@/lib/listings"
 
 export function ConditionChip({ condition }: { condition: Condition }) {

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { XIcon, UploadIcon } from "lucide-react"
 
 import { createListing } from "@/app/actions/listings"
-import { CONDITIONS } from "@/lib/listings"
+import { CONDITIONS } from "@/lib/listings/constants"
 import type { Category } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -4,7 +4,7 @@ import { useActionState } from "react"
 import { XIcon } from "lucide-react"
 
 import { updateListing, deleteListing } from "@/app/actions/listings"
-import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings"
+import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings/constants"
 import type { Category, Listing } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 
 import type { BrowseListing } from "@/lib/listings"
-import { formatPrice } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings/constants"
 import { ConditionChip } from "@/components/listings/condition-chip"
 import { SellerBadge } from "@/components/listings/seller-badge"
 

--- a/app/components/search/search-filters.tsx
+++ b/app/components/search/search-filters.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { SearchIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { CONDITIONS, type Category, type Condition } from "@/lib/listings/constants"
+import { buildSearchUrl, SEARCH_SORTS, type SearchFilters as SearchFiltersState } from "@/lib/search"
+
+const fieldClass =
+  "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+
+const SELECT_SORT_LABELS: Record<(typeof SEARCH_SORTS)[number], string> = {
+  newest: "Newest first",
+  oldest: "Oldest first",
+  price_asc: "Price: low to high",
+  price_desc: "Price: high to low",
+}
+
+export function SearchFilters({
+  categories,
+  filters,
+}: {
+  categories: Category[]
+  filters: SearchFiltersState
+}) {
+  const router = useRouter()
+  const [q, setQ] = useState(filters.q)
+  const [categorySlug, setCategorySlug] = useState(filters.categorySlug ?? "")
+  const [condition, setCondition] = useState<Condition | "">(
+    filters.condition ?? ""
+  )
+  const [minPrice, setMinPrice] = useState(filters.minPrice?.toString() ?? "")
+  const [maxPrice, setMaxPrice] = useState(filters.maxPrice?.toString() ?? "")
+  const [city, setCity] = useState(filters.city)
+  const [sort, setSort] = useState(filters.sort)
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    router.push(
+      buildSearchUrl({
+        q,
+        categorySlug: categorySlug || undefined,
+        minPrice: minPrice ? Number(minPrice) : undefined,
+        maxPrice: maxPrice ? Number(maxPrice) : undefined,
+        condition: condition || undefined,
+        city,
+        sort,
+        offset: 0,
+      })
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} aria-label="Search and filter listings">
+      <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
+        <div className="relative">
+          <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            name="q"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search by keyword, e.g. “laptop”"
+            className="pl-9"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-category">Category</Label>
+            <select
+              id="search-category"
+              value={categorySlug}
+              onChange={(e) => setCategorySlug(e.target.value)}
+              className={fieldClass}
+            >
+              <option value="">All categories</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.slug}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-condition">Condition</Label>
+            <select
+              id="search-condition"
+              value={condition}
+              onChange={(e) =>
+                setCondition(e.target.value as Condition | "")
+              }
+              className={fieldClass}
+            >
+              <option value="">Any condition</option>
+              {CONDITIONS.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-min">Min price (ETB)</Label>
+            <Input
+              id="search-min"
+              type="number"
+              min="0"
+              value={minPrice}
+              onChange={(e) => setMinPrice(e.target.value)}
+              placeholder="No minimum"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-max">Max price (ETB)</Label>
+            <Input
+              id="search-max"
+              type="number"
+              min="0"
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(e.target.value)}
+              placeholder="No maximum"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-city">City</Label>
+            <Input
+              id="search-city"
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="e.g. Addis Ababa"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-sort">Sort by</Label>
+            <select
+              id="search-sort"
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SearchFiltersState["sort"])}
+              className={fieldClass}
+            >
+              {SEARCH_SORTS.map((s) => (
+                <option key={s} value={s}>
+                  {SELECT_SORT_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push("/search")}>
+              Clear
+            </Button>
+            <Button type="submit">Search</Button>
+          </div>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/app/components/search/search-filters.tsx
+++ b/app/components/search/search-filters.tsx
@@ -8,9 +8,9 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { CONDITIONS, type Category, type Condition } from "@/lib/listings/constants"
-import { buildSearchUrl, SEARCH_SORTS, type SearchFilters as SearchFiltersState } from "@/lib/search"
+import { buildSearchUrl, SEARCH_SORTS, type SearchQuery } from "@/lib/search"
 
-const fieldClass =
+const FIELD_CLASS =
   "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
 
 const SELECT_SORT_LABELS: Record<(typeof SEARCH_SORTS)[number], string> = {
@@ -25,7 +25,7 @@ export function SearchFilters({
   filters,
 }: {
   categories: Category[]
-  filters: SearchFiltersState
+  filters: SearchQuery
 }) {
   const router = useRouter()
   const [q, setQ] = useState(filters.q)
@@ -76,7 +76,7 @@ export function SearchFilters({
               id="search-category"
               value={categorySlug}
               onChange={(e) => setCategorySlug(e.target.value)}
-              className={fieldClass}
+              className={FIELD_CLASS}
             >
               <option value="">All categories</option>
               {categories.map((c) => (
@@ -95,7 +95,7 @@ export function SearchFilters({
               onChange={(e) =>
                 setCondition(e.target.value as Condition | "")
               }
-              className={fieldClass}
+              className={FIELD_CLASS}
             >
               <option value="">Any condition</option>
               {CONDITIONS.map((c) => (
@@ -148,8 +148,8 @@ export function SearchFilters({
             <select
               id="search-sort"
               value={sort}
-              onChange={(e) => setSort(e.target.value as SearchFiltersState["sort"])}
-              className={fieldClass}
+              onChange={(e) => setSort(e.target.value as SearchQuery["sort"])}
+              className={FIELD_CLASS}
             >
               {SEARCH_SORTS.map((s) => (
                 <option key={s} value={s}>

--- a/app/lib/browse.ts
+++ b/app/lib/browse.ts
@@ -1,4 +1,6 @@
-import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings"
+import { nextOffset, parseOffset } from "@/lib/pagination"
+
+export { nextOffset }
 
 export interface BrowseCursor {
   categorySlug: string | undefined
@@ -18,13 +20,8 @@ export function parseBrowseParams(params: {
 }): BrowseCursor {
   const categorySlug =
     typeof params.category === "string" ? params.category : undefined
-  const raw = typeof params.offset === "string" ? params.offset : ""
-  const parsed = Number(raw)
-  const offset =
-    Number.isFinite(parsed) && parsed > 0
-      ? Math.min(parsed, BROWSE_LIMIT_MAX - 1)
-      : 0
-  return { categorySlug, offset }
+  const raw = typeof params.offset === "string" ? params.offset : undefined
+  return { categorySlug, offset: parseOffset(raw) }
 }
 
 /** Build the paginated browse URL (replaces the inline helper in app/page.tsx). */
@@ -36,8 +33,4 @@ export function buildBrowseUrl(
   if (categorySlug) params.set("category", categorySlug)
   if (offset) params.set("offset", String(offset))
   return `/?${params.toString()}`
-}
-
-export function nextOffset(offset: number): number {
-  return offset + PAGE_SIZE
 }

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -9,120 +9,43 @@ import {
   uploadObjects,
 } from "@/lib/media"
 
-// ---- Shared value sets (also drive the client form via literals) ----
-export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
-export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
-export const MAX_IMAGES = 10
+import {
+  BROWSE_LIMIT_MAX,
+  LISTING_COLUMNS,
+  MAX_IMAGES,
+  PAGE_SIZE,
+  isValidUuid,
+} from "./listings/constants"
+import type {
+  BrowseListing,
+  BrowseSeller,
+  Category,
+  Condition,
+  Listing,
+  ListingEditPayload,
+  ListingImage,
+  ListingPayload,
+  ListingStatus,
+  ListingWithRelations,
+} from "./listings/constants"
+import type { SearchSort } from "@/lib/search"
 
-export type Condition = (typeof CONDITIONS)[number]
-export type ListingStatus = (typeof STATUSES)[number] | "archived"
+// Re-export the pure value objects so imports from "@/lib/listings" keep
+// resolving. Definitions live in ./listings/constants (server-free).
+export * from "./listings/constants"
 
-export interface ListingStatusOption {
-  value: string
-  label: string
-  disabled?: boolean
-}
+// ---- Internal row shape (server-only; not part of the public value object) ----
 
-// Canonical status options for the edit flow: the writable statuses plus the
-// terminal "archived" state surfaced as disabled (delete-only). Kept here so
-// the form never drifts from the ListingStatus value set.
-export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
-  { value: "draft", label: "Draft" },
-  { value: "published", label: "Published" },
-  { value: "sold", label: "Sold" },
-  { value: "archived", label: "Archived", disabled: true },
-]
-
-export interface Category {
+interface RawListingRow {
   id: string
-  name: string
-  slug: string
-  parent_id: string | null
-}
-
-export interface ListingImage {
-  id: string
-  listing_id: string
-  image_url: string
-  display_order: number
-  alt_text: string | null
-}
-
-export interface Listing {
-  id: string
-  seller_id: string
-  category_id: string | null
   title: string
-  description: string | null
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  address: string | null
-  status: ListingStatus
-  view_count: number
-  favorite_count: number
   published_at: string
-  created_at: string
-  updated_at: string
+  seller: BrowseSeller[] | null
+  images: ListingImage[] | null
 }
-
-export interface ListingWithRelations {
-  listing: Listing
-  images: ListingImage[]
-  category: Category | null
-  seller: {
-    id: string
-    full_name: string | null
-    avatar_url: string | null
-    role: string | null
-    trust_score: number | null
-  } | null
-}
-
-export interface ListingPayload {
-  title: string
-  description?: string
-  price: number
-  condition: Condition
-  categoryId?: string
-  city: string
-  subCity?: string
-  address?: string
-  negotiable: boolean
-  photos?: File[]
-}
-
-export interface ListingEditPayload {
-  id: string
-  title: string
-  description?: string
-  price: number
-  condition: Condition
-  categoryId?: string
-  city: string
-  subCity?: string
-  address?: string
-  negotiable: boolean
-  status?: ListingStatus
-}
-
-export const LISTING_COLUMNS =
-  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
-
-// ---- Helpers ----
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-export function isValidUuid(id: string): boolean {
-  return UUID_RE.test(id)
-}
-
-// Image validation primitives (detectImageMime, ALLOWED_IMAGE_MIME,
-// MAX_IMAGE_BYTES, EXT_BY_MIME) live in the Media object module (lib/media),
-// imported at the top of this file.
 
 // ---- Reads ----
 
@@ -211,82 +134,6 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
   return data as Listing[]
 }
 
-export const PAGE_SIZE = 12
-// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
-// windowed: each request fetches PAGE_SIZE rows and we never page past the
-// 1000-row ceiling (T05, NFR-COMP-003).
-export const BROWSE_LIMIT_MAX = 1000
-
-export interface BrowseSeller {
-  id: string
-  full_name: string | null
-  avatar_url: string | null
-  role: string | null
-  trust_score: number | null
-}
-
-export interface BrowseListing {
-  id: string
-  title: string
-  price: number
-  condition: Condition
-  city: string | null
-  published_at: string
-  image_url: string | null
-  image_count: number
-  seller: BrowseSeller | null
-}
-
-interface RawListingRow {
-  id: string
-  title: string
-  price: number
-  condition: Condition
-  city: string | null
-  published_at: string
-  seller: BrowseSeller[] | null
-  images: ListingImage[] | null
-}
-
-export interface FormatPriceOptions {
-  maxFractionDigits?: number
-}
-
-export function formatPrice(
-  price: number | string,
-  opts: FormatPriceOptions = {}
-): string {
-  const n = typeof price === "number" ? price : Number(price)
-  if (Number.isNaN(n)) return "ETB —"
-  const maxFractionDigits = opts.maxFractionDigits ?? 0
-  try {
-    return new Intl.NumberFormat("en-ET", {
-      style: "currency",
-      currency: "ETB",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: maxFractionDigits,
-    }).format(n)
-  } catch {
-    return `ETB ${Math.round(n)}`
-  }
-}
-
-const CONDITION_LABELS: Record<Condition, string> = {
-  "Brand New": "Brand new",
-  "Lightly Used": "Lightly used",
-  Fair: "Fair",
-}
-
-export function formatCondition(condition: Condition): string {
-  return CONDITION_LABELS[condition] ?? condition
-}
-
-export const CONDITION_COLORS: Record<Condition, string> = {
-  "Brand New": "bg-green-100 text-green-800",
-  "Lightly Used": "bg-blue-100 text-blue-800",
-  Fair: "bg-amber-100 text-amber-800",
-}
-
 // Public, paginated browse of published listings (anon-readable via RLS).
 export async function fetchListings(opts: {
   limit?: number
@@ -368,6 +215,99 @@ export async function fetchListings(opts: {
 
   const hasMore = typeof count === "number" ? offset + listings.length < count : false
   return { listings, count, hasMore, error: null }
+}
+
+export interface SearchOptions {
+  q?: string
+  categorySlug?: string
+  minPrice?: number
+  maxPrice?: number
+  condition?: Condition
+  city?: string
+  sort?: SearchSort
+  offset?: number
+}
+
+export interface SearchResult {
+  listings: BrowseListing[]
+  totalCount: number
+  hasMore: boolean
+  error: string | null
+}
+
+/** Row shape returned by the `search_listings` RPC (see migrations). */
+interface SearchListingRow {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  city: string | null
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller_id: string | null
+  seller_full_name: string | null
+  seller_avatar_url: string | null
+  seller_role: string | null
+  seller_trust_score: number | null
+  total_count: number
+}
+
+// Keyword + filters + sort + count in one round trip via the search_listings
+// RPC (T06, Search Service). Paging mirrors fetchListings: one PAGE_SIZE window
+// that never crosses the 1000-row ceiling, with `hasMore` derived from the
+// exact count the RPC returns alongside the slice.
+export async function searchListings(
+  opts: SearchOptions = {}
+): Promise<SearchResult> {
+  const supabase = await createClient()
+  const offset = Math.min(Math.max(opts.offset ?? 0, 0), BROWSE_LIMIT_MAX - 1)
+
+  const { data, error } = await supabase.rpc("search_listings", {
+    p_query: opts.q || null,
+    p_category_slug: opts.categorySlug || null,
+    p_min_price: opts.minPrice ?? null,
+    p_max_price: opts.maxPrice ?? null,
+    p_condition: opts.condition ?? null,
+    p_city: opts.city || null,
+    p_sort: opts.sort ?? "newest",
+    p_limit: PAGE_SIZE,
+    p_offset: offset,
+  })
+
+  if (error) {
+    console.error("searchListings:", error.message)
+    return { listings: [], totalCount: 0, hasMore: false, error: error.message }
+  }
+
+  const rows = (data ?? []) as SearchListingRow[]
+  const listings: BrowseListing[] = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    price: row.price,
+    condition: row.condition,
+    city: row.city,
+    published_at: row.published_at,
+    image_url: row.image_url,
+    image_count: row.image_count,
+    seller: row.seller_id
+      ? {
+          id: row.seller_id,
+          full_name: row.seller_full_name,
+          avatar_url: row.seller_avatar_url,
+          role: row.seller_role,
+          trust_score: row.seller_trust_score,
+        }
+      : null,
+  }))
+
+  const totalCount = rows.length > 0 ? rows[0].total_count : 0
+  return {
+    listings,
+    totalCount,
+    hasMore: offset + listings.length < totalCount,
+    error: null,
+  }
 }
 
 // ---- Writes (called by server actions; DB access centralized here, §17) ----

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -29,6 +29,7 @@ import type {
   ListingWithRelations,
 } from "./listings/constants"
 import type { SearchSort } from "@/lib/search"
+import { MAX_PAGING_OFFSET } from "@/lib/pagination"
 
 // Re-export the pure value objects so imports from "@/lib/listings" keep
 // resolving. Definitions live in ./listings/constants (server-free).
@@ -213,7 +214,10 @@ export async function fetchListings(opts: {
     }
   )
 
-  const hasMore = typeof count === "number" ? offset + listings.length < count : false
+  const hasMore =
+    typeof count === "number"
+      ? offset + listings.length < count && offset + listings.length < BROWSE_LIMIT_MAX
+      : false
   return { listings, count, hasMore, error: null }
 }
 
@@ -230,7 +234,7 @@ export interface SearchOptions {
 
 export interface SearchResult {
   listings: BrowseListing[]
-  totalCount: number
+  count: number
   hasMore: boolean
   error: string | null
 }
@@ -261,7 +265,7 @@ export async function searchListings(
   opts: SearchOptions = {}
 ): Promise<SearchResult> {
   const supabase = await createClient()
-  const offset = Math.min(Math.max(opts.offset ?? 0, 0), BROWSE_LIMIT_MAX - 1)
+  const offset = Math.min(Math.max(opts.offset ?? 0, 0), MAX_PAGING_OFFSET)
 
   const { data, error } = await supabase.rpc("search_listings", {
     p_query: opts.q || null,
@@ -277,7 +281,7 @@ export async function searchListings(
 
   if (error) {
     console.error("searchListings:", error.message)
-    return { listings: [], totalCount: 0, hasMore: false, error: error.message }
+    return { listings: [], count: 0, hasMore: false, error: error.message }
   }
 
   const rows = (data ?? []) as SearchListingRow[]
@@ -301,11 +305,12 @@ export async function searchListings(
       : null,
   }))
 
-  const totalCount = rows.length > 0 ? rows[0].total_count : 0
+  const count = rows.length > 0 ? rows[0].total_count : 0
   return {
     listings,
-    totalCount,
-    hasMore: offset + listings.length < totalCount,
+    count,
+    hasMore:
+      offset + listings.length < count && offset + listings.length < BROWSE_LIMIT_MAX,
     error: null,
   }
 }

--- a/app/lib/listings/constants.ts
+++ b/app/lib/listings/constants.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure listing domain value objects.
+ *
+ * Framework-agnostic constants, types and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/listings` re-exports everything
+ * here (`export *`) so existing server-side imports keep resolving.
+ */
+
+export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
+export const MAX_IMAGES = 10
+
+export type Condition = (typeof CONDITIONS)[number]
+export type ListingStatus = (typeof STATUSES)[number] | "archived"
+
+export interface ListingStatusOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "sold", label: "Sold" },
+  { value: "archived", label: "Archived", disabled: true },
+]
+
+export interface Category {
+  id: string
+  name: string
+  slug: string
+  parent_id: string | null
+}
+
+export interface ListingImage {
+  id: string
+  listing_id: string
+  image_url: string
+  display_order: number
+  alt_text: string | null
+}
+
+export interface Listing {
+  id: string
+  seller_id: string
+  category_id: string | null
+  title: string
+  description: string | null
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  address: string | null
+  status: ListingStatus
+  view_count: number
+  favorite_count: number
+  published_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ListingWithRelations {
+  listing: Listing
+  images: ListingImage[]
+  category: Category | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+    role: string | null
+    trust_score: number | null
+  } | null
+}
+
+export interface ListingPayload {
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  photos?: File[]
+}
+
+export interface ListingEditPayload {
+  id: string
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  status?: ListingStatus
+}
+
+export const LISTING_COLUMNS =
+  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+
+export const PAGE_SIZE = 12
+// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
+// windowed: each request fetches PAGE_SIZE rows and we never page past the
+// 1000-row ceiling (T05, NFR-COMP-003).
+export const BROWSE_LIMIT_MAX = 1000
+
+export interface BrowseSeller {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+export interface BrowseListing {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  city: string | null
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller: BrowseSeller | null
+}
+
+export interface FormatPriceOptions {
+  maxFractionDigits?: number
+}
+
+export function formatPrice(
+  price: number | string,
+  opts: FormatPriceOptions = {}
+): string {
+  const n = typeof price === "number" ? price : Number(price)
+  if (Number.isNaN(n)) return "ETB \u2014"
+  const maxFractionDigits = opts.maxFractionDigits ?? 0
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
+    }).format(n)
+  } catch {
+    return `ETB ${Math.round(n)}`
+  }
+}
+
+const CONDITION_LABELS: Record<Condition, string> = {
+  "Brand New": "Brand new",
+  "Lightly Used": "Lightly used",
+  "Fair": "Fair",
+}
+
+export function formatCondition(condition: Condition): string {
+  return CONDITION_LABELS[condition] ?? condition
+}
+
+export const CONDITION_COLORS: Record<Condition, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  "Fair": "bg-amber-100 text-amber-800",
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isValidUuid(id: string): boolean {
+  return UUID_RE.test(id)
+}

--- a/app/lib/pagination.ts
+++ b/app/lib/pagination.ts
@@ -1,0 +1,24 @@
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+
+// The highest offset a windowed page may start from. Browse and search both
+// fetch PAGE_SIZE rows per request and never page past the PostgREST 1000-row
+// ceiling, so a page that starts at or beyond this offset would run past the
+// end of the window (T05/T06, NFR-COMP-003).
+export const MAX_PAGING_OFFSET = BROWSE_LIMIT_MAX - PAGE_SIZE
+
+/** Parse + clamp an untrusted offset from the URL into the paging window.
+ *
+ * Shared by `lib/browse` and `lib/search` so the two read seams can never
+ * drift apart on what a valid offset looks like. The clamp guarantees
+ * `offset + PAGE_SIZE <= BROWSE_LIMIT_MAX`, which is what makes "Load more"
+ * terminate instead of re-clamping to the same page forever. (§15.) */
+export function parseOffset(raw: string | undefined): number {
+  const parsed = Number(raw ?? "")
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.min(parsed, MAX_PAGING_OFFSET)
+    : 0
+}
+
+export function nextOffset(offset: number): number {
+  return offset + PAGE_SIZE
+}

--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -1,14 +1,12 @@
-import {
-  BROWSE_LIMIT_MAX,
-  CONDITIONS,
-  PAGE_SIZE,
-  type Condition,
-} from "@/lib/listings/constants"
+import { CONDITIONS, type Condition } from "@/lib/listings/constants"
+import { nextOffset, parseOffset } from "@/lib/pagination"
+
+export { nextOffset }
 
 export const SEARCH_SORTS = ["newest", "oldest", "price_asc", "price_desc"] as const
 export type SearchSort = (typeof SEARCH_SORTS)[number]
 
-export interface SearchFilters {
+export interface SearchQuery {
   q: string
   categorySlug: string | undefined
   minPrice: number | undefined
@@ -36,7 +34,7 @@ export function parseSearchParams(params: {
   city?: SearchParamValue
   sort?: SearchParamValue
   offset?: SearchParamValue
-}): SearchFilters {
+}): SearchQuery {
   const single = (v: SearchParamValue): string | undefined =>
     typeof v === "string" ? v : undefined
 
@@ -57,14 +55,16 @@ export function parseSearchParams(params: {
     ? (rawSort as SearchSort)
     : "newest"
 
-  const rawOffset = single(params.offset) ?? ""
-  const parsedOffset = Number(rawOffset)
-  const offset =
-    Number.isFinite(parsedOffset) && parsedOffset > 0
-      ? Math.min(parsedOffset, BROWSE_LIMIT_MAX - 1)
-      : 0
-
-  return { q, categorySlug, minPrice, maxPrice, condition, city, sort, offset }
+  return {
+    q,
+    categorySlug,
+    minPrice,
+    maxPrice,
+    condition,
+    city,
+    sort,
+    offset: parseOffset(single(params.offset)),
+  }
 }
 
 function parsePrice(v: string | undefined): number | undefined {
@@ -73,21 +73,17 @@ function parsePrice(v: string | undefined): number | undefined {
   return Number.isFinite(n) && n >= 0 ? n : undefined
 }
 
-/** Build the search URL from a filters object, omitting empty/zero params. */
-export function buildSearchUrl(filters: SearchFilters): string {
+/** Build the search URL from a query object, omitting empty/zero params. */
+export function buildSearchUrl(query: SearchQuery): string {
   const params = new URLSearchParams()
-  if (filters.q) params.set("q", filters.q)
-  if (filters.categorySlug) params.set("category", filters.categorySlug)
-  if (filters.minPrice !== undefined) params.set("min", String(filters.minPrice))
-  if (filters.maxPrice !== undefined) params.set("max", String(filters.maxPrice))
-  if (filters.condition) params.set("condition", filters.condition)
-  if (filters.city) params.set("city", filters.city)
-  if (filters.sort !== "newest") params.set("sort", filters.sort)
-  if (filters.offset) params.set("offset", String(filters.offset))
+  if (query.q) params.set("q", query.q)
+  if (query.categorySlug) params.set("category", query.categorySlug)
+  if (query.minPrice !== undefined) params.set("min", String(query.minPrice))
+  if (query.maxPrice !== undefined) params.set("max", String(query.maxPrice))
+  if (query.condition) params.set("condition", query.condition)
+  if (query.city) params.set("city", query.city)
+  if (query.sort !== "newest") params.set("sort", query.sort)
+  if (query.offset) params.set("offset", String(query.offset))
   const qs = params.toString()
   return qs ? `/search?${qs}` : "/search"
-}
-
-export function nextOffset(offset: number): number {
-  return offset + PAGE_SIZE
 }

--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -1,0 +1,93 @@
+import {
+  BROWSE_LIMIT_MAX,
+  CONDITIONS,
+  PAGE_SIZE,
+  type Condition,
+} from "@/lib/listings/constants"
+
+export const SEARCH_SORTS = ["newest", "oldest", "price_asc", "price_desc"] as const
+export type SearchSort = (typeof SEARCH_SORTS)[number]
+
+export interface SearchFilters {
+  q: string
+  categorySlug: string | undefined
+  minPrice: number | undefined
+  maxPrice: number | undefined
+  condition: Condition | undefined
+  city: string
+  sort: SearchSort
+  offset: number
+}
+
+type SearchParamValue = string | string[] | undefined
+
+/** Parse + clamp the search/filter query from untrusted URL search params.
+ *
+ * Mirrors `lib/browse`: every input is validated so a hand-edited URL can never
+ * inject an invalid sort/condition/price or an out-of-window offset. The parsed
+ * shape is the single source of truth for the server page, the client filter
+ * form and "Load more". (§15: validate external input.) */
+export function parseSearchParams(params: {
+  q?: SearchParamValue
+  category?: SearchParamValue
+  min?: SearchParamValue
+  max?: SearchParamValue
+  condition?: SearchParamValue
+  city?: SearchParamValue
+  sort?: SearchParamValue
+  offset?: SearchParamValue
+}): SearchFilters {
+  const single = (v: SearchParamValue): string | undefined =>
+    typeof v === "string" ? v : undefined
+
+  const q = (single(params.q) ?? "").trim()
+  const categorySlug = single(params.category)?.trim() || undefined
+  const minPrice = parsePrice(single(params.min))
+  const maxPrice = parsePrice(single(params.max))
+
+  const rawCondition = single(params.condition)
+  const condition = (CONDITIONS as readonly string[]).includes(rawCondition ?? "")
+    ? (rawCondition as Condition)
+    : undefined
+
+  const city = (single(params.city) ?? "").trim()
+
+  const rawSort = single(params.sort) ?? ""
+  const sort = (SEARCH_SORTS as readonly string[]).includes(rawSort)
+    ? (rawSort as SearchSort)
+    : "newest"
+
+  const rawOffset = single(params.offset) ?? ""
+  const parsedOffset = Number(rawOffset)
+  const offset =
+    Number.isFinite(parsedOffset) && parsedOffset > 0
+      ? Math.min(parsedOffset, BROWSE_LIMIT_MAX - 1)
+      : 0
+
+  return { q, categorySlug, minPrice, maxPrice, condition, city, sort, offset }
+}
+
+function parsePrice(v: string | undefined): number | undefined {
+  if (v === undefined) return undefined
+  const n = Number(v)
+  return Number.isFinite(n) && n >= 0 ? n : undefined
+}
+
+/** Build the search URL from a filters object, omitting empty/zero params. */
+export function buildSearchUrl(filters: SearchFilters): string {
+  const params = new URLSearchParams()
+  if (filters.q) params.set("q", filters.q)
+  if (filters.categorySlug) params.set("category", filters.categorySlug)
+  if (filters.minPrice !== undefined) params.set("min", String(filters.minPrice))
+  if (filters.maxPrice !== undefined) params.set("max", String(filters.maxPrice))
+  if (filters.condition) params.set("condition", filters.condition)
+  if (filters.city) params.set("city", filters.city)
+  if (filters.sort !== "newest") params.set("sort", filters.sort)
+  if (filters.offset) params.set("offset", String(filters.offset))
+  const qs = params.toString()
+  return qs ? `/search?${qs}` : "/search"
+}
+
+export function nextOffset(offset: number): number {
+  return offset + PAGE_SIZE
+}

--- a/app/supabase/migrations/20260813000000_search_listings_rpc.sql
+++ b/app/supabase/migrations/20260813000000_search_listings_rpc.sql
@@ -1,0 +1,119 @@
+-- T06 - Intelligent search & filters
+-- Implements the Search Service (docs/02-architecture/00-system-architecture.md):
+-- keyword full-text + category/price/condition/city filters + sort + pagination,
+-- on top of the T04 generated `search_vector` column and its GIN + pg_trgm
+-- indexes.
+--
+-- Search contract (per DB spec §19 and #3):
+--   * keyword  -> websearch_to_tsquery('simple') over the generated search_vector
+--                 (quoted phrases + AND/OR), with a pg_trgm similarity fallback
+--                 on title for typo-tolerant matches
+--   * filters  -> category slug, price range, condition enum, city substring
+--   * sort     -> newest (default) | oldest | price_asc | price_desc
+--   * paging   -> p_limit capped at 1000 (PostgREST ceiling), p_offset >= 0,
+--                 exact count via count(*) over ()
+--   * security -> SECURITY DEFINER with a hardened search_path; the WHERE clause
+--                 mirrors the public-read RLS policy (status = 'published' AND
+--                 deleted_at IS NULL) so the definer never leaks draft/sold or
+--                 soft-deleted rows; EXECUTE granted only to anon + authenticated.
+
+create or replace function public.search_listings(
+  p_query text default null,
+  p_category_slug text default null,
+  p_min_price numeric default null,
+  p_max_price numeric default null,
+  p_condition public.listing_condition default null,
+  p_city text default null,
+  p_sort text default 'newest',
+  p_limit int default 12,
+  p_offset int default 0
+)
+returns table (
+  id uuid,
+  title text,
+  price numeric,
+  condition public.listing_condition,
+  city text,
+  published_at timestamptz,
+  image_url text,
+  image_count bigint,
+  category_name text,
+  category_slug text,
+  seller_id uuid,
+  seller_full_name text,
+  seller_avatar_url text,
+  seller_role text,
+  seller_trust_score int,
+  total_count bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_tsq tsquery;
+begin
+  if p_query is not null and btrim(p_query) <> '' then
+    v_tsq := websearch_to_tsquery('simple', btrim(p_query));
+  else
+    v_tsq := null;
+  end if;
+
+  return query
+  select
+    l.id,
+    l.title,
+    l.price,
+    l.condition,
+    l.city,
+    l.published_at,
+    im.image_url,
+    coalesce(ic.image_count, 0)::bigint,
+    c.name,
+    c.slug,
+    u.id,
+    u.full_name,
+    u.avatar_url,
+    u.role,
+    u.trust_score::int,
+    count(*) over ()::bigint
+  from public.listings l
+  left join public.categories c on c.id = l.category_id
+  left join public.profiles u on u.id = l.seller_id
+  left join lateral (
+    select i.image_url
+    from public.listing_images i
+    where i.listing_id = l.id
+    order by i.display_order asc
+    limit 1
+  ) im on true
+  left join lateral (
+    select count(*) as image_count
+    from public.listing_images i
+    where i.listing_id = l.id
+  ) ic on true
+  where l.status = 'published'
+    and l.deleted_at is null
+    and (p_category_slug is null or c.slug = p_category_slug)
+    and (p_min_price is null or l.price >= p_min_price)
+    and (p_max_price is null or l.price <= p_max_price)
+    and (p_condition is null or l.condition = p_condition)
+    and (p_city is null or l.city ilike '%' || p_city || '%')
+    and (
+      v_tsq is null
+      or l.search_vector @@ v_tsq
+      or l.title % p_query
+    )
+  order by
+    case when p_sort = 'price_asc' then l.price end asc nulls last,
+    case when p_sort = 'price_desc' then l.price end desc nulls last,
+    case when p_sort = 'oldest' then l.published_at end asc nulls last,
+    l.published_at desc
+  limit least(greatest(p_limit, 0), 1000)
+  offset greatest(p_offset, 0);
+end;
+$$;
+
+revoke all on function public.search_listings(text, text, numeric, numeric, public.listing_condition, text, text, int, int) from public;
+grant execute on function public.search_listings(text, text, numeric, numeric, public.listing_condition, text, text, int, int) to anon, authenticated;

--- a/app/supabase/migrations/20260813000000_search_listings_rpc.sql
+++ b/app/supabase/migrations/20260813000000_search_listings_rpc.sql
@@ -10,12 +10,15 @@
 --                 on title for typo-tolerant matches
 --   * filters  -> category slug, price range, condition enum, city substring
 --   * sort     -> newest (default) | oldest | price_asc | price_desc
---   * paging   -> p_limit capped at 1000 (PostgREST ceiling), p_offset >= 0,
---                 exact count via count(*) over ()
+--   * paging   -> p_limit and p_offset both clamped to the 1000-row PostgREST
+--                 window (offset + limit <= 1000), exact count via count(*) over ()
 --   * security -> SECURITY DEFINER with a hardened search_path; the WHERE clause
 --                 mirrors the public-read RLS policy (status = 'published' AND
 --                 deleted_at IS NULL) so the definer never leaks draft/sold or
---                 soft-deleted rows; EXECUTE granted only to anon + authenticated.
+--                 soft-deleted rows. The joined profile/category/image fields
+--                 are all publicly readable under RLS too (profiles: T03 public
+--                 read policy), so the definer exposes nothing the anon browse
+--                 path already exposes. EXECUTE granted only to anon/authenticated.
 
 create or replace function public.search_listings(
   p_query text default null,
@@ -53,7 +56,16 @@ set search_path = public
 as $$
 declare
   v_tsq tsquery;
+  v_limit int;
+  v_offset int;
 begin
+  if p_sort not in ('newest', 'oldest', 'price_asc', 'price_desc') then
+    p_sort := 'newest';
+  end if;
+
+  v_limit := least(greatest(p_limit, 0), 1000);
+  v_offset := least(greatest(p_offset, 0), 1000 - v_limit);
+
   if p_query is not null and btrim(p_query) <> '' then
     v_tsq := websearch_to_tsquery('simple', btrim(p_query));
   else
@@ -110,8 +122,8 @@ begin
     case when p_sort = 'price_desc' then l.price end desc nulls last,
     case when p_sort = 'oldest' then l.published_at end asc nulls last,
     l.published_at desc
-  limit least(greatest(p_limit, 0), 1000)
-  offset greatest(p_offset, 0);
+  limit v_limit
+  offset v_offset;
 end;
 $$;
 

--- a/app/tests/unit/browse.test.ts
+++ b/app/tests/unit/browse.test.ts
@@ -8,8 +8,10 @@ describe("browse.parseBrowseParams", () => {
     expect(parseBrowseParams({})).toEqual({ categorySlug: undefined, offset: 0 })
   })
 
-  it("clamps a huge offset to the 1000-row ceiling", () => {
-    expect(parseBrowseParams({ offset: "99999" }).offset).toBe(BROWSE_LIMIT_MAX - 1)
+  it("clamps a huge offset to the top of the 1000-row window", () => {
+    expect(parseBrowseParams({ offset: "99999" }).offset).toBe(
+      BROWSE_LIMIT_MAX - PAGE_SIZE
+    )
   })
 
   it("rejects a negative offset", () => {

--- a/app/tests/unit/pagination.test.ts
+++ b/app/tests/unit/pagination.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+import { MAX_PAGING_OFFSET, nextOffset, parseOffset } from "@/lib/pagination"
+
+describe("pagination.parseOffset", () => {
+  it("defaults to 0 when absent", () => {
+    expect(parseOffset(undefined)).toBe(0)
+    expect(parseOffset("")).toBe(0)
+  })
+
+  it("keeps a valid offset", () => {
+    expect(parseOffset("24")).toBe(24)
+  })
+
+  it("clamps a huge offset to the top of the 1000-row window", () => {
+    expect(parseOffset("99999")).toBe(MAX_PAGING_OFFSET)
+  })
+
+  it("rejects a negative or non-numeric offset", () => {
+    expect(parseOffset("-3")).toBe(0)
+    expect(parseOffset("abc")).toBe(0)
+  })
+
+  it("guarantees a page never crosses the 1000-row ceiling", () => {
+    expect(MAX_PAGING_OFFSET + PAGE_SIZE).toBe(BROWSE_LIMIT_MAX)
+  })
+})
+
+describe("pagination.nextOffset", () => {
+  it("advances by one page", () => {
+    expect(nextOffset(0)).toBe(PAGE_SIZE)
+    expect(nextOffset(PAGE_SIZE)).toBe(PAGE_SIZE * 2)
+  })
+})

--- a/app/tests/unit/search.test.ts
+++ b/app/tests/unit/search.test.ts
@@ -57,9 +57,15 @@ describe("search.parseSearchParams", () => {
     })
   })
 
-  it("clamps a huge offset to the 1000-row ceiling", () => {
+  it("clamps a huge offset to the top of the 1000-row window", () => {
     expect(parseSearchParams({ offset: "99999" }).offset).toBe(
-      BROWSE_LIMIT_MAX - 1
+      BROWSE_LIMIT_MAX - PAGE_SIZE
+    )
+  })
+
+  it("keeps an offset that already fills the window", () => {
+    expect(parseSearchParams({ offset: String(BROWSE_LIMIT_MAX - PAGE_SIZE) }).offset).toBe(
+      BROWSE_LIMIT_MAX - PAGE_SIZE
     )
   })
 

--- a/app/tests/unit/search.test.ts
+++ b/app/tests/unit/search.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+import { buildSearchUrl, nextOffset, parseSearchParams } from "@/lib/search"
+
+describe("search.parseSearchParams", () => {
+  it("returns fully-defaulted filters for empty params", () => {
+    expect(parseSearchParams({})).toEqual({
+      q: "",
+      categorySlug: undefined,
+      minPrice: undefined,
+      maxPrice: undefined,
+      condition: undefined,
+      city: "",
+      sort: "newest",
+      offset: 0,
+    })
+  })
+
+  it("parses the keyword and trims whitespace", () => {
+    expect(parseSearchParams({ q: "  laptop  " }).q).toBe("laptop")
+  })
+
+  it("drops a keyword when it is an array", () => {
+    expect(parseSearchParams({ q: ["a", "b"] }).q).toBe("")
+  })
+
+  it("parses a condition from the allow-list", () => {
+    expect(parseSearchParams({ condition: "Brand New" }).condition).toBe(
+      "Brand New"
+    )
+  })
+
+  it("drops a condition that is not in the allow-list", () => {
+    expect(parseSearchParams({ condition: "Mint" }).condition).toBeUndefined()
+  })
+
+  it("parses a valid sort", () => {
+    expect(parseSearchParams({ sort: "price_asc" }).sort).toBe("price_asc")
+  })
+
+  it("falls back to newest for an unknown sort", () => {
+    expect(parseSearchParams({ sort: "popular" }).sort).toBe("newest")
+  })
+
+  it("parses non-negative prices", () => {
+    expect(parseSearchParams({ min: "100", max: "5000" })).toMatchObject({
+      minPrice: 100,
+      maxPrice: 5000,
+    })
+  })
+
+  it("rejects negative and non-numeric prices", () => {
+    expect(parseSearchParams({ min: "-5", max: "abc" })).toMatchObject({
+      minPrice: undefined,
+      maxPrice: undefined,
+    })
+  })
+
+  it("clamps a huge offset to the 1000-row ceiling", () => {
+    expect(parseSearchParams({ offset: "99999" }).offset).toBe(
+      BROWSE_LIMIT_MAX - 1
+    )
+  })
+
+  it("rejects a negative or non-numeric offset", () => {
+    expect(parseSearchParams({ offset: "-3" }).offset).toBe(0)
+    expect(parseSearchParams({ offset: "nope" }).offset).toBe(0)
+  })
+})
+
+describe("search.buildSearchUrl", () => {
+  const base = {
+    q: "",
+    categorySlug: undefined,
+    minPrice: undefined,
+    maxPrice: undefined,
+    condition: undefined,
+    city: "",
+    sort: "newest" as const,
+    offset: 0,
+  }
+
+  it("returns bare /search when nothing is set", () => {
+    expect(buildSearchUrl(base)).toBe("/search")
+  })
+
+  it("omits the default sort and zero offset", () => {
+    expect(buildSearchUrl({ ...base, q: "phone" })).toBe("/search?q=phone")
+  })
+
+  it("includes every non-default param", () => {
+    expect(
+      buildSearchUrl({
+        q: "table",
+        categorySlug: "furniture",
+        minPrice: 500,
+        maxPrice: 5000,
+        condition: "Lightly Used",
+        city: "Bole",
+        sort: "price_desc",
+        offset: PAGE_SIZE,
+      })
+    ).toBe(
+      "/search?q=table&category=furniture&min=500&max=5000&condition=Lightly+Used&city=Bole&sort=price_desc&offset=12"
+    )
+  })
+})
+
+describe("search.nextOffset", () => {
+  it("advances by one page", () => {
+    expect(nextOffset(0)).toBe(PAGE_SIZE)
+    expect(nextOffset(PAGE_SIZE)).toBe(PAGE_SIZE * 2)
+  })
+})

--- a/docs/02-architecture/00-system-architecture.md
+++ b/docs/02-architecture/00-system-architecture.md
@@ -153,7 +153,7 @@ Database
 
 **Responsibilities:** Keyword Search, Filtering, Sorting, Pagination
 
-**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `lib/searchListings`.
+**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `searchListings` in `app/lib/listings.ts`.
 
 **Future:** Relevance ranking (`ts_rank`)
 

--- a/docs/02-architecture/00-system-architecture.md
+++ b/docs/02-architecture/00-system-architecture.md
@@ -153,7 +153,9 @@ Database
 
 **Responsibilities:** Keyword Search, Filtering, Sorting, Pagination
 
-**Future:** Full-text search
+**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `lib/searchListings`.
+
+**Future:** Relevance ranking (`ts_rank`)
 
 ## Trust Service
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`).
+Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`), `lib/search` (`parseSearchParams` filter validation + paging clamp, `buildSearchUrl`, `nextOffset`).
 
 ## Integration Testing
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`), `lib/search` (`parseSearchParams` filter validation + paging clamp, `buildSearchUrl`, `nextOffset`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`).
 
 ## Integration Testing
 


### PR DESCRIPTION
Implements T06 (search & filters) on top of fm/ugm-t05-browse.

## Summary
- **search_listings RPC** (app/supabase/migrations/20260813000000_search_listings_rpc.sql): keyword full-text via websearch_to_tsquery('simple') over the T04 generated search_vector (tsvector GIN) with a pg_trgm % similarity fallback on title for typo-tolerant matches; category/price/condition/city filters; newest/oldest/price asc/desc sort; paging capped at 1000 with exact count(*) over (). SECURITY DEFINER with set search_path = public; WHERE mirrors the public-read RLS policy (status='published' AND deleted_at IS NULL) so the definer never leaks draft/sold/soft-deleted rows. EXECUTE granted to anon/authenticated only.
- **lib/search.ts** pure seam — parseSearchParams/buildSearchUrl/nextOffset — with unit tests (tests/unit/search.test.ts); shared by the server page and the client filter form.
- **searchListings** caller in lib/listings.ts mapping RPC rows to BrowseListing.
- **/search page**: filter controls (keyword, category, condition, min/max price, city, sort), results grid, empty/error/load-more states, skeleton loading.tsx. Homepage 'Browse listings' CTA points at /search.

Note: carries the lib/listings value-object split (server-free lib/listings/constants.ts) from the working tree, per decision to branch from the dirty t05 tree.

## Verification
- npm run typecheck / npm run lint / npm run build pass; npm test 40/40.

## Related
T06 ticket #10 on the tracker.