### PR TITLE
Favorites: T07 save & manage favorites

### DIFF
--- a/app/app/actions/favorites.ts
+++ b/app/app/actions/favorites.ts
@@ -1,0 +1,21 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { requireUser } from "@/lib/auth"
+import { toggleFavoriteRow } from "@/lib/favorites"
+
+export async function toggleFavorite(formData: FormData): Promise<void> {
+  const user = await requireUser()
+  const listingId = formData.get("listingId")
+  if (typeof listingId !== "string" || listingId.length === 0) return
+
+  await toggleFavoriteRow(user.id, listingId)
+
+  // Re-sync the optimistic heart regardless of outcome: on success the DB
+  // changed; on failure it did not, but the flipped frame must revert either
+  // way. Revalidation re-renders the route with fresh server state.
+  revalidatePath("/")
+  revalidatePath(`/listings/${listingId}`)
+  revalidatePath("/favorites")
+}

--- a/app/app/favorites/loading.tsx
+++ b/app/app/favorites/loading.tsx
@@ -1,0 +1,16 @@
+export default function FavoritesLoading() {
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <div className="mb-8 h-7 w-48 animate-pulse rounded bg-muted" />
+      <div className="grid grid-cols-1 gap-x-6 gap-y-8 animate-pulse sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i}>
+            <div className="aspect-[4/3] w-full rounded-lg bg-muted" />
+            <div className="mt-2 h-4 w-3/4 rounded bg-muted" />
+            <div className="mt-2 h-4 w-1/4 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/favorites/page.tsx
+++ b/app/app/favorites/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link"
+import { Heart } from "lucide-react"
+
+import { requireUser } from "@/lib/auth"
+import { fetchFavoriteListings } from "@/lib/favorites"
+import { Button } from "@/components/ui/button"
+import { ListingCard } from "@/components/listings/listing-card"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
+
+export const dynamic = "force-dynamic"
+
+export default async function FavoritesPage() {
+  const user = await requireUser()
+  const listings = await fetchFavoriteListings(user.id)
+
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <h1 className="font-heading mb-8 text-2xl font-semibold text-foreground">
+        Your favorites
+      </h1>
+
+      {listings.length === 0 ? (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <Heart className="size-6 text-muted-foreground" />
+          </div>
+          <h2 className="font-heading text-lg font-semibold">
+            No favorites yet
+          </h2>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            Tap the heart on any listing to save it here and find it again
+            later.
+          </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link href="/">Browse listings</Link>
+          </Button>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {listings.map((l) => (
+            <li key={l.id}>
+              <ListingCard
+                listing={l}
+                favoriteButton={
+                  <FavoriteButton listingId={l.id} initial={true} />
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -3,9 +3,11 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { MapPinIcon, TagIcon } from "lucide-react"
 
-import { ROLE_LABELS } from "@/lib/auth"
+import { ROLE_LABELS, getCurrentUser } from "@/lib/auth"
 import type { UserRole } from "@/lib/auth/types"
 import { fetchListing, formatCondition, formatPrice } from "@/lib/listings"
+import { fetchFavoriteIds } from "@/lib/favorites"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -42,6 +44,11 @@ export default async function ListingPage({
   const { id } = await params
   const data = await fetchListing(id)
   if (!data) notFound()
+
+  const user = await getCurrentUser()
+  const favorited = user
+    ? (await fetchFavoriteIds(user.id)).includes(id)
+    : null
 
   const { listing: l, images, category, seller } = data
   const cover = images[0]?.image_url
@@ -87,6 +94,7 @@ export default async function ListingPage({
               {l.title}
             </h1>
             <Badge variant="secondary">{formatCondition(l.condition)}</Badge>
+            <FavoriteButton listingId={l.id} initial={favorited} />
           </div>
 
           <p className="text-2xl font-semibold text-foreground">

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
+import { getCurrentUser } from "@/lib/auth"
 import { fetchCategories, fetchListings, PAGE_SIZE } from "@/lib/listings"
+import { fetchFavoriteIds } from "@/lib/favorites"
 import { buildBrowseUrl, nextOffset, parseBrowseParams } from "@/lib/browse"
 import { CategoryCard } from "@/components/categories/category-card"
 import { ListingCard } from "@/components/listings/listing-card"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
 
 function NoResultsIcon({ className }: { className?: string }) {
   return (
@@ -42,12 +45,19 @@ export default async function HomePage({
   const sp = await searchParams
   const { categorySlug, offset } = parseBrowseParams(sp)
 
+  // Favorites state is per-user: kick the (cached) session read off up front,
+  // then fetch favorite ids only for signed-in visitors. Anonymous browsing
+  // adds no favorites round-trip.
+  const userPromise = getCurrentUser()
   const categoriesPromise = fetchCategories()
-  const { listings, hasMore, error } = await fetchListings({
+  const browsePromise = fetchListings({
     limit: PAGE_SIZE,
     offset,
     categorySlug,
   })
+  const user = await userPromise
+  const favoriteIds = user ? new Set(await fetchFavoriteIds(user.id)) : null
+  const { listings, hasMore, error } = await browsePromise
   const categories = await categoriesPromise
 
   return (
@@ -142,7 +152,15 @@ export default async function HomePage({
             <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {listings.map((l) => (
                 <li key={l.id}>
-                  <ListingCard listing={l} />
+                  <ListingCard
+                    listing={l}
+                    favoriteButton={
+                      <FavoriteButton
+                        listingId={l.id}
+                        initial={favoriteIds?.has(l.id) ?? null}
+                      />
+                    }
+                  />
                 </li>
               ))}
             </ul>

--- a/app/components/favorites/favorite-button.tsx
+++ b/app/components/favorites/favorite-button.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import Link from "next/link"
+import { useOptimistic, useRef } from "react"
+import { usePathname } from "next/navigation"
+import { Heart } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  buildLoginUrl,
+  toggleFavoriteState,
+} from "@/lib/favorites/constants"
+import { toggleFavorite } from "@/app/actions/favorites"
+
+function heartClasses(active: boolean): string {
+  return cn(
+    "inline-flex size-8 items-center justify-center rounded-full",
+    "bg-white/90 text-slate-700 shadow-sm ring-1 ring-black/5",
+    "transition-colors hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2",
+    active && "text-primary"
+  )
+}
+
+export function FavoriteButton({
+  listingId,
+  initial,
+}: {
+  listingId: string
+  /** Server truth: true = favorited, false = not, null = signed out. */
+  initial: boolean | null
+}) {
+  const [favorite, setFavorite] = useOptimistic(initial === true)
+  const pathname = usePathname()
+  const formRef = useRef<HTMLFormElement>(null)
+
+  // Signed-out visitors get a heart that routes through login (with a ?next=
+  // back to this listing) instead of a form that would just redirect.
+  if (initial === null) {
+    return (
+      <Link
+        href={buildLoginUrl(pathname)}
+        aria-label="Sign in to save this listing"
+        className={heartClasses(false)}
+      >
+        <Heart className="size-4" />
+      </Link>
+    )
+  }
+
+  return (
+    <form ref={formRef} action={toggleFavorite}>
+      <input type="hidden" name="listingId" value={listingId} />
+      <button
+        type="submit"
+        onClick={() => {
+          // Flip the heart on the current frame via the shared reducer, then
+          // let the form submit run the server action (revalidatePath re-syncs
+          // this optimistic frame with DB truth when the transition settles).
+          setFavorite(toggleFavoriteState)
+          formRef.current?.requestSubmit()
+        }}
+        aria-label={favorite ? "Remove from favorites" : "Save to favorites"}
+        aria-pressed={favorite}
+        className={heartClasses(favorite)}
+      >
+        <Heart className={cn("size-4", favorite && "fill-current")} />
+      </button>
+    </form>
+  )
+}

--- a/app/components/favorites/favorite-button.tsx
+++ b/app/components/favorites/favorite-button.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useOptimistic, useRef } from "react"
+import { useOptimistic } from "react"
 import { usePathname } from "next/navigation"
 import { Heart } from "lucide-react"
 
@@ -31,7 +31,6 @@ export function FavoriteButton({
 }) {
   const [favorite, setFavorite] = useOptimistic(initial === true)
   const pathname = usePathname()
-  const formRef = useRef<HTMLFormElement>(null)
 
   // Signed-out visitors get a heart that routes through login (with a ?next=
   // back to this listing) instead of a form that would just redirect.
@@ -47,18 +46,19 @@ export function FavoriteButton({
     )
   }
 
+  // Client wrapper around the server action: flip the heart on the current
+  // frame via the shared reducer, then run the action. Revalidation re-syncs
+  // this optimistic frame with DB truth when the transition settles.
+  const submitFavorite = async (formData: FormData) => {
+    setFavorite(toggleFavoriteState)
+    await toggleFavorite(formData)
+  }
+
   return (
-    <form ref={formRef} action={toggleFavorite}>
+    <form action={submitFavorite}>
       <input type="hidden" name="listingId" value={listingId} />
       <button
         type="submit"
-        onClick={() => {
-          // Flip the heart on the current frame via the shared reducer, then
-          // let the form submit run the server action (revalidatePath re-syncs
-          // this optimistic frame with DB truth when the transition settles).
-          setFavorite(toggleFavoriteState)
-          formRef.current?.requestSubmit()
-        }}
         aria-label={favorite ? "Remove from favorites" : "Save to favorites"}
         aria-pressed={favorite}
         className={heartClasses(favorite)}

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,30 +1,48 @@
 import Link from "next/link"
+import type { ReactNode } from "react"
 
 import type { BrowseListing } from "@/lib/listings"
 import { formatPrice } from "@/lib/listings/constants"
 import { ConditionChip } from "@/components/listings/condition-chip"
 import { SellerBadge } from "@/components/listings/seller-badge"
 
-export function ListingCard({ listing }: { listing: BrowseListing }) {
+export function ListingCard({
+  listing,
+  favoriteButton,
+}: {
+  listing: BrowseListing
+  /** Optional per-card action overlay (e.g. the favorites heart). */
+  favoriteButton?: ReactNode
+}) {
+  const href = `/listings/${listing.id}`
   return (
-    <Link href={`/listings/${listing.id}`} className="group block w-full">
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
-        {listing.image_url ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={listing.image_url}
-            alt={listing.title}
-            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
-            No photo
+    <div className="group w-full">
+      <div className="relative">
+        <Link href={href} aria-label={listing.title}>
+          <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
+            {listing.image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={listing.image_url}
+                alt=""
+                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                loading="lazy"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+                No photo
+              </div>
+            )}
           </div>
-        )}
+        </Link>
+        {favoriteButton ? (
+          <div className="absolute right-2 top-2">{favoriteButton}</div>
+        ) : null}
       </div>
       <div className="mt-2 space-y-1">
-        <p className="line-clamp-1 font-medium">{listing.title}</p>
+        <Link href={href} className="block">
+          <p className="line-clamp-1 font-medium">{listing.title}</p>
+        </Link>
         <p className="font-semibold">{formatPrice(listing.price)}</p>
         <div className="flex items-center gap-2">
           <ConditionChip condition={listing.condition} />
@@ -34,6 +52,6 @@ export function ListingCard({ listing }: { listing: BrowseListing }) {
         </div>
         <SellerBadge listing={listing} />
       </div>
-    </Link>
+    </div>
   )
 }

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -39,10 +39,8 @@ export function ListingCard({
           <div className="absolute right-2 top-2">{favoriteButton}</div>
         ) : null}
       </div>
-      <div className="mt-2 space-y-1">
-        <Link href={href} className="block">
-          <p className="line-clamp-1 font-medium">{listing.title}</p>
-        </Link>
+      <Link href={href} className="mt-2 block space-y-1">
+        <p className="line-clamp-1 font-medium">{listing.title}</p>
         <p className="font-semibold">{formatPrice(listing.price)}</p>
         <div className="flex items-center gap-2">
           <ConditionChip condition={listing.condition} />
@@ -51,7 +49,7 @@ export function ListingCard({
           ) : null}
         </div>
         <SellerBadge listing={listing} />
-      </div>
+      </Link>
     </div>
   )
 }

--- a/app/lib/favorites.ts
+++ b/app/lib/favorites.ts
@@ -82,17 +82,6 @@ export async function toggleFavoriteRow(
   }
   const supabase = await createClient()
 
-  // Only published, non-deleted listings can be favorited (RLS would also
-  // return null for anything else, but the explicit check keeps the write
-  // from silently toggling against a stale favorite of an unreadable row).
-  const { data: listing } = await supabase
-    .from("listings")
-    .select("id")
-    .eq("id", listingId)
-    .eq("status", "published")
-    .maybeSingle()
-  if (!listing) return { ok: false, error: "listing not found" }
-
   const { data: existing } = await supabase
     .from("favorites")
     .select("id")
@@ -101,6 +90,22 @@ export async function toggleFavoriteRow(
     .maybeSingle()
   const shouldFavor = toggleFavoriteState(Boolean(existing))
 
+  if (shouldFavor) {
+    // A new favorite requires a published, non-deleted listing (RLS would also
+    // return null for anything else, but the explicit check keeps the write
+    // from inserting a row for an unreadable listing).
+    const { data: listing } = await supabase
+      .from("listings")
+      .select("id")
+      .eq("id", listingId)
+      .eq("status", "published")
+      .maybeSingle()
+    if (!listing) return { ok: false, error: "listing not found" }
+  }
+
+  // Deleting is always allowed: a favorite can outlive its listing's
+  // publish status (a listing sold or unpublished while saved), and the
+  // owner must still be able to clear that stale row.
   const result = shouldFavor
     ? await supabase.from("favorites").insert({
         user_id: userId,

--- a/app/lib/favorites.ts
+++ b/app/lib/favorites.ts
@@ -1,0 +1,120 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+import {
+  isValidUuid,
+  mapBrowseListing,
+  type BrowseListing,
+  type RawListingRow,
+} from "@/lib/listings"
+import { toggleFavoriteState } from "@/lib/favorites/constants"
+
+export * from "@/lib/favorites/constants"
+
+// ---- Reads ----
+
+export async function fetchFavoriteIds(userId: string): Promise<string[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("favorites")
+    .select("listing_id")
+    .eq("user_id", userId)
+  if (error) {
+    console.error("fetchFavoriteIds:", error.message)
+    return []
+  }
+  return (data ?? []).map((row) => row.listing_id)
+}
+
+// The favorites feed: rows are joined against listings, so RLS already drops
+// listings that are no longer readable (unpublished, deleted, sold). Only
+// still-available favorites are returned, most recently favorited first.
+export async function fetchFavoriteListings(
+  userId: string
+): Promise<BrowseListing[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("favorites")
+    .select(
+      `created_at,
+       listing:listings(id, title, price, condition, city, published_at,
+         seller:profiles(id, full_name, avatar_url, role, trust_score),
+         images:listing_images(id, image_url, display_order))`
+    )
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchFavoriteListings:", error.message)
+    return []
+  }
+
+  // supabase-js without generated types types embedded resources as arrays,
+  // but listing_id -> listings is a to-one join: PostgREST returns a single
+  // row (or null when the listing is no longer readable under RLS).
+  const rows = (data ?? []) as unknown as {
+    listing: RawListingRow | null
+  }[]
+
+  return rows
+    .map((row) => row.listing)
+    .filter((listing): listing is RawListingRow => listing !== null)
+    .map(mapBrowseListing)
+}
+
+// ---- Writes (called by the toggle server action) ----
+
+export interface ToggleFavoriteResult {
+  ok: boolean
+  error: string | null
+}
+
+// Persists the toggle: reads the current row state, applies the shared
+// toggleFavoriteState reducer, then inserts or deletes to reach the target.
+// The reducer is the same one the client's useOptimistic applies, so the
+// optimistic frame and the final server state always agree.
+export async function toggleFavoriteRow(
+  userId: string,
+  listingId: string
+): Promise<ToggleFavoriteResult> {
+  if (!isValidUuid(listingId)) {
+    return { ok: false, error: "invalid listing id" }
+  }
+  const supabase = await createClient()
+
+  // Only published, non-deleted listings can be favorited (RLS would also
+  // return null for anything else, but the explicit check keeps the write
+  // from silently toggling against a stale favorite of an unreadable row).
+  const { data: listing } = await supabase
+    .from("listings")
+    .select("id")
+    .eq("id", listingId)
+    .eq("status", "published")
+    .maybeSingle()
+  if (!listing) return { ok: false, error: "listing not found" }
+
+  const { data: existing } = await supabase
+    .from("favorites")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("listing_id", listingId)
+    .maybeSingle()
+  const shouldFavor = toggleFavoriteState(Boolean(existing))
+
+  const result = shouldFavor
+    ? await supabase.from("favorites").insert({
+        user_id: userId,
+        listing_id: listingId,
+      })
+    : await supabase
+        .from("favorites")
+        .delete()
+        .eq("user_id", userId)
+        .eq("listing_id", listingId)
+
+  if (result.error) {
+    console.error("toggleFavoriteRow:", result.error.message)
+    return { ok: false, error: result.error.message }
+  }
+  return { ok: true, error: null }
+}

--- a/app/lib/favorites/constants.ts
+++ b/app/lib/favorites/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure favorites domain value objects.
+ *
+ * Framework-agnostic helpers shared by Server and Client modules. This module
+ * intentionally has NO `server-only` import and imports no Supabase client, so
+ * Client Components can consume it directly without pulling the server seam
+ * into the client graph. `@/lib/favorites` re-exports everything here.
+ */
+
+export type FavoriteState = boolean
+
+/**
+ * The toggle reducer. One definition serves both sides of the optimistic
+ * round-trip: the Client Component calls it in `useOptimistic` to flip the
+ * heart on the current frame, and the Server Action's persistence step (and
+ * the DB write it wraps) must compute the same next state, so the re-rendered
+ * server state and the optimistic frame can never disagree.
+ */
+export function toggleFavoriteState(state: FavoriteState): FavoriteState {
+  return !state
+}
+
+/**
+ * The login redirect target for the heart button. Login honors a `?next=`
+ * query param (see app/login/page.tsx), so a signed-out visitor who taps a
+ * heart lands back on the exact listing after signing in. Kept here so the
+ * Client Component needs no URL-building logic.
+ */
+export function buildLoginUrl(pathname: string): string {
+  return `/login?next=${encodeURIComponent(pathname)}`
+}

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -37,7 +37,7 @@ export * from "./listings/constants"
 
 // ---- Internal row shape (server-only; not part of the public value object) ----
 
-interface RawListingRow {
+export interface RawListingRow {
   id: string
   title: string
   price: number
@@ -46,6 +46,36 @@ interface RawListingRow {
   published_at: string
   seller: BrowseSeller[] | null
   images: ListingImage[] | null
+}
+
+// Shared row mapper for browse-shaped listing selects. Used by the public
+// browse feed and the favorites feed so both render cards identically.
+export function mapBrowseListing(l: RawListingRow): BrowseListing {
+  const images = l.images ?? []
+  const cover =
+    [...images]
+      .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
+    null
+  const seller = l.seller?.[0] ?? null
+  return {
+    id: l.id,
+    title: l.title,
+    price: l.price,
+    condition: l.condition,
+    city: l.city,
+    published_at: l.published_at,
+    image_url: cover,
+    image_count: images.length,
+    seller: seller
+      ? {
+          id: seller.id,
+          full_name: seller.full_name,
+          avatar_url: seller.avatar_url,
+          role: seller.role,
+          trust_score: seller.trust_score,
+        }
+      : null,
+  }
 }
 
 // ---- Reads ----
@@ -185,33 +215,7 @@ export async function fetchListings(opts: {
   }
 
   const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
-    (l) => {
-      const images = l.images ?? []
-      const cover =
-        [...images]
-          .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
-        null
-      const seller = l.seller?.[0] ?? null
-      return {
-        id: l.id,
-        title: l.title,
-        price: l.price,
-        condition: l.condition,
-        city: l.city,
-        published_at: l.published_at,
-        image_url: cover,
-        image_count: images.length,
-        seller: seller
-          ? {
-              id: seller.id,
-              full_name: seller.full_name,
-              avatar_url: seller.avatar_url,
-              role: seller.role,
-              trust_score: seller.trust_score,
-            }
-          : null,
-      }
-    }
+    mapBrowseListing
   )
 
   const hasMore =

--- a/app/supabase/migrations/20260813090000_create_favorites.sql
+++ b/app/supabase/migrations/20260813090000_create_favorites.sql
@@ -1,0 +1,62 @@
+-- T07 - Favorites service
+-- favorites join table (user_id -> listing_id), per docs/02-architecture/03-database-design-specification.md
+-- §11 (favorites), §18 (unique (user_id, listing_id)), §20 (RLS: "Users can only access their own favorites"),
+-- §22 (migration naming). Keeps listings.favorite_count in sync via trigger.
+
+create table if not exists public.favorites (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  listing_id uuid not null references public.listings (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  -- §18: a user can favorite a listing at most once.
+  constraint favorites_user_listing_unique unique (user_id, listing_id)
+);
+
+-- Listing-side lookups (counts, "who favorited this") and delete-by-listing cleanup.
+create index if not exists favorites_listing_id_idx on public.favorites (listing_id);
+
+-- Keep listings.favorite_count (denormalized, DB spec §8) in sync so later
+-- "popular first" sorting never reads stale counters.
+create or replace function public.sync_favorite_count()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update public.listings set favorite_count = favorite_count + 1 where id = new.listing_id;
+    return new;
+  elsif tg_op = 'DELETE' then
+    update public.listings set favorite_count = greatest(favorite_count - 1, 0) where id = old.listing_id;
+    return old;
+  end if;
+  return null;
+end;
+$$;
+
+create trigger if not exists favorites_sync_listing_count
+  after insert or delete on public.favorites
+  for each row execute function public.sync_favorite_count();
+
+-----------------------------------------------------------------------------
+-- RLS (DB spec §20 Favorites): a user only sees and writes their own rows.
+-- No update policy: a favorite is created or removed, never edited.
+-----------------------------------------------------------------------------
+alter table public.favorites enable row level security;
+
+create policy if not exists "Favorites are readable by the owner"
+  on public.favorites for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+create policy if not exists "Favorites are insertable by the owner"
+  on public.favorites for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create policy if not exists "Favorites are deletable by the owner"
+  on public.favorites for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+grant usage on schema public to anon, authenticated;
+grant select, insert, delete on public.favorites to authenticated;

--- a/app/tests/unit/favorites.test.ts
+++ b/app/tests/unit/favorites.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  buildLoginUrl,
+  toggleFavoriteState,
+} from "@/lib/favorites/constants"
+
+describe("favorites.toggleFavoriteState", () => {
+  it("flips a false favorite to true", () => {
+    expect(toggleFavoriteState(false)).toBe(true)
+  })
+
+  it("flips a true favorite to false", () => {
+    expect(toggleFavoriteState(true)).toBe(false)
+  })
+})
+
+describe("favorites.buildLoginUrl", () => {
+  it("builds the login URL with the current path as next", () => {
+    expect(buildLoginUrl("/listings/abc-123")).toBe(
+      "/login?next=%2Flistings%2Fabc-123"
+    )
+  })
+
+  it("encodes a query string inside the next param", () => {
+    expect(buildLoginUrl("/?category=books&offset=12")).toContain(
+      "next=%2F%3Fcategory%3Dbooks%26offset%3D12"
+    )
+  })
+})

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`).
 
 ## Integration Testing
 


### PR DESCRIPTION
## T07 — Favorites

Users can favorite any published listing and manage their saved listings from /favorites.

### What changed
- **Migration** \20260813090000_create_favorites.sql\: \avorites\ join table (unique (user_id, listing_id)), owner-only RLS (select/insert/delete), and a trigger keeping \listings.favorite_count\ in sync.
- **Pure seam** \lib/favorites/constants.ts\: \	oggleFavoriteState\ (the reducer shared by the client's \useOptimistic\ and the server's persistence step) and \uildLoginUrl\ (honors login's \?next=\ contract). Unit-tested.
- **Server module** \lib/favorites.ts\: \etchFavoriteIds\, \etchFavoriteListings\ (drops favorites whose listing is no longer readable under RLS), \	oggleFavoriteRow\. Reuses \mapBrowseListing\, extracted from \etchListings\ so both feeds render cards identically.
- **Server action** \	oggleFavorite\: auth-guarded, validates uuid + published listing, revalidates /, /listings/[id], /favorites on every outcome so the optimistic heart always re-syncs with DB truth.
- **UI**: \FavoriteButton\ (optimistic heart, signed-out visitors get a heart linking to /login?next=...), heart overlay on \ListingCard\ + detail page, \/favorites\ page with empty state + loading skeleton.

### Verified
- typecheck, lint, tests (29 passing incl. 4 new), production build — all green.