### PR TITLE
dashboard: T09 seller dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate:
-    name: Lint, Typecheck & Build
+    name: Lint, Typecheck, Tests & Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -36,6 +36,9 @@ jobs:
 
       - name: Type check
         run: npm run typecheck
+
+      - name: Run unit tests
+        run: npm test
 
       - name: Build
         run: npm run build

--- a/app/app/actions/favorites.ts
+++ b/app/app/actions/favorites.ts
@@ -1,0 +1,21 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { requireUser } from "@/lib/auth"
+import { toggleFavoriteRow } from "@/lib/favorites"
+
+export async function toggleFavorite(formData: FormData): Promise<void> {
+  const user = await requireUser()
+  const listingId = formData.get("listingId")
+  if (typeof listingId !== "string" || listingId.length === 0) return
+
+  await toggleFavoriteRow(user.id, listingId)
+
+  // Re-sync the optimistic heart regardless of outcome: on success the DB
+  // changed; on failure it did not, but the flipped frame must revert either
+  // way. Revalidation re-renders the route with fresh server state.
+  revalidatePath("/")
+  revalidatePath(`/listings/${listingId}`)
+  revalidatePath("/favorites")
+}

--- a/app/app/actions/listings.ts
+++ b/app/app/actions/listings.ts
@@ -186,6 +186,9 @@ export async function deleteListing(
 
   const user = await getCurrentUser()
   if (!user) redirect("/login")
+  if (user.role !== "seller" && user.role !== "admin") {
+    redirect("/profile")
+  }
 
   try {
     const result = await softDeleteListing(id, user.id)

--- a/app/app/actions/offers.ts
+++ b/app/app/actions/offers.ts
@@ -1,0 +1,127 @@
+"use server"
+
+import { z } from "zod"
+import { revalidatePath } from "next/cache"
+
+import { requireUser } from "@/lib/auth"
+import {
+  acceptOfferRow,
+  counterOfferRow,
+  declineOfferRow,
+  submitOfferRow,
+  OFFER_AMOUNT_MAX,
+  OFFER_MESSAGE_MAX,
+} from "@/lib/offers"
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
+
+// One amount rule for submitting an offer and countering it, so both paths
+// validate (and reject) identically.
+const amountSchema = z.coerce
+  .number({ message: "Enter an amount" })
+  .gt(0, "Amount must be greater than 0")
+  .max(OFFER_AMOUNT_MAX, "Amount is too large")
+
+const submitOfferSchema = z.object({
+  listingId: z.string().uuid(),
+  amount: amountSchema,
+  message: z.string().max(OFFER_MESSAGE_MAX, "Keep the message under 500 characters").optional(),
+})
+
+export type SubmitOfferState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+export async function submitOffer(
+  _prevState: SubmitOfferState,
+  formData: FormData
+): Promise<SubmitOfferState> {
+  const parsed = submitOfferSchema.safeParse({
+    listingId: formValue(formData, "listingId"),
+    amount: formData.get("amount"),
+    message: formValue(formData, "message"),
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await requireUser()
+  const result = await submitOfferRow({
+    userId: user.id,
+    listingId: parsed.data.listingId,
+    amount: parsed.data.amount,
+    message: parsed.data.message ?? null,
+  })
+
+  if (!result.ok) {
+    return { message: result.error ?? "Could not submit your offer" }
+  }
+
+  revalidatePath("/")
+  revalidatePath(`/listings/${parsed.data.listingId}`)
+  revalidatePath("/offers")
+  revalidatePath("/offers/seller")
+  return { ok: true }
+}
+
+const offerActionSchema = z.object({
+  action: z.enum(["accept", "decline", "counter"]),
+  offerId: z.string().uuid(),
+  listingId: z.string().uuid(),
+  amount: amountSchema.optional(),
+})
+
+export type OfferActionState = {
+  message?: string
+  ok?: boolean
+}
+
+// Seller-side status transition: accept, decline, or counter an incoming offer.
+// The route is chosen server-side so the form stays a plain progressive-enhancement
+// form; the RPC itself re-checks that the caller owns the offer's listing.
+export async function offerAction(
+  _prevState: OfferActionState,
+  formData: FormData
+): Promise<OfferActionState> {
+  const parsed = offerActionSchema.safeParse({
+    action: formValue(formData, "action"),
+    offerId: formValue(formData, "offerId"),
+    listingId: formValue(formData, "listingId"),
+    amount: formData.get("amount") ?? undefined,
+  })
+
+  if (!parsed.success) {
+    const amountErrors = parsed.error.flatten().fieldErrors.amount
+    return { message: amountErrors?.[0] ?? "Invalid offer request" }
+  }
+
+  if (parsed.data.action === "counter" && parsed.data.amount === undefined) {
+    return { message: "Enter a counter amount" }
+  }
+
+  // Gate on a signed-in session before reaching the RPC; the RPC itself
+  // re-checks that the caller owns the offer's listing.
+  await requireUser()
+
+  const result =
+    parsed.data.action === "accept"
+      ? await acceptOfferRow(parsed.data.offerId)
+      : parsed.data.action === "decline"
+        ? await declineOfferRow(parsed.data.offerId)
+        : await counterOfferRow(parsed.data.offerId, parsed.data.amount as number)
+
+  if (!result.ok) {
+    return { message: result.error ?? "Could not update the offer" }
+  }
+
+  revalidatePath(`/listings/${parsed.data.listingId}`)
+  revalidatePath("/offers")
+  revalidatePath("/offers/seller")
+  return { ok: true }
+}

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import { HeartIcon, LayoutDashboardIcon, PlusIcon, UserRoundIcon } from "lucide-react"
+import { HeartIcon, InboxIcon, HandshakeIcon, LayoutDashboardIcon, PlusIcon, UserRoundIcon } from "lucide-react"
 
 import { requireUser, ROLE_LABELS } from "@/lib/auth"
 import { Button } from "@/components/ui/button"
@@ -61,6 +61,40 @@ export default async function DashboardPage() {
           <CardContent>
             <Button asChild variant="outline">
               <Link href="/favorites">View favorites</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <HandshakeIcon className="size-5 text-primary" />
+              My offers
+            </CardTitle>
+            <CardDescription>
+              Track the offers you have made and any counter-offers.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline">
+              <Link href="/offers">View my offers</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <InboxIcon className="size-5 text-primary" />
+              Incoming offers
+            </CardTitle>
+            <CardDescription>
+              Accept, decline, or counter offers on your listings.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline">
+              <Link href="/offers/seller">Manage offers</Link>
             </Button>
           </CardContent>
         </Card>

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -3,6 +3,9 @@ import Link from "next/link"
 import { HeartIcon, InboxIcon, HandshakeIcon, LayoutDashboardIcon, PlusIcon, UserRoundIcon } from "lucide-react"
 
 import { requireUser, ROLE_LABELS } from "@/lib/auth"
+import { fetchSellerListings } from "@/lib/listings"
+import { countIncomingOffers } from "@/lib/offers"
+import { ListingManager } from "@/components/dashboard/listing-manager"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -14,6 +17,10 @@ export const metadata: Metadata = {
 
 export default async function DashboardPage() {
   const user = await requireUser()
+  const [listings, openOfferCount] = await Promise.all([
+    fetchSellerListings(user.id),
+    countIncomingOffers(user.id),
+  ])
 
   const firstName = user.fullName?.split(" ")[0] ?? "there"
 
@@ -25,42 +32,48 @@ export default async function DashboardPage() {
           Welcome back, {firstName}
         </h1>
         <p className="mt-2 max-w-xl text-muted-foreground">
-          Manage your marketplace activity from here. List management tools arrive as
-          the platform grows.
+          This is your selling home: manage your listings, watch their stats, and
+          keep on top of incoming offers.
         </p>
       </div>
+
+      <section className="mb-10">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="font-heading text-xl font-semibold">Your listings</h2>
+            <p className="text-sm text-muted-foreground">
+              {listings.length === 0
+                ? "Nothing on sale yet."
+                : `${listings.length} listing${listings.length === 1 ? "" : "s"} — edit, archive, or track views and favorites.`}
+            </p>
+          </div>
+          <Button asChild size="sm">
+            <Link href="/sell">
+              <PlusIcon className="mr-1.5 size-4" />
+              Create a listing
+            </Link>
+          </Button>
+        </div>
+        <ListingManager listings={listings} />
+      </section>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <PlusIcon className="size-5 text-primary" />
-              Sell an item
+              <InboxIcon className="size-5 text-primary" />
+              Incoming offers
+              {openOfferCount > 0 ? (
+                <Badge variant="secondary">{openOfferCount} open</Badge>
+              ) : null}
             </CardTitle>
             <CardDescription>
-              Create a listing and reach buyers across the marketplace.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button asChild>
-              <Link href="/sell">Create a listing</Link>
-            </Button>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <HeartIcon className="size-5 text-primary" />
-              Favorites
-            </CardTitle>
-            <CardDescription>
-              Review the listings you have saved for later.
+              Accept, decline, or counter offers on your listings.
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Button asChild variant="outline">
-              <Link href="/favorites">View favorites</Link>
+              <Link href="/offers/seller">Manage offers</Link>
             </Button>
           </CardContent>
         </Card>
@@ -85,16 +98,16 @@ export default async function DashboardPage() {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <InboxIcon className="size-5 text-primary" />
-              Incoming offers
+              <HeartIcon className="size-5 text-primary" />
+              Favorites
             </CardTitle>
             <CardDescription>
-              Accept, decline, or counter offers on your listings.
+              Review the listings you have saved for later.
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Button asChild variant="outline">
-              <Link href="/offers/seller">Manage offers</Link>
+              <Link href="/favorites">View favorites</Link>
             </Button>
           </CardContent>
         </Card>

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -17,8 +17,12 @@ export const metadata: Metadata = {
 
 export default async function DashboardPage() {
   const user = await requireUser()
+  // The seller home only makes sense for users who can sell; buyers land on the
+  // profile gate instead of a dead-end /sell redirect (issue #13 AC5).
+  const canSell = user.role === "seller" || user.role === "admin"
+
   const [listings, openOfferCount] = await Promise.all([
-    fetchSellerListings(user.id),
+    canSell ? fetchSellerListings(user.id) : Promise.resolve([]),
     countIncomingOffers(user.id),
   ])
 
@@ -32,30 +36,47 @@ export default async function DashboardPage() {
           Welcome back, {firstName}
         </h1>
         <p className="mt-2 max-w-xl text-muted-foreground">
-          This is your selling home: manage your listings, watch their stats, and
-          keep on top of incoming offers.
+          Manage your marketplace activity from here — track offers and
+          favorites, and keep on top of your listings.
         </p>
       </div>
 
-      <section className="mb-10">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="font-heading text-xl font-semibold">Your listings</h2>
-            <p className="text-sm text-muted-foreground">
-              {listings.length === 0
-                ? "Nothing on sale yet."
-                : `${listings.length} listing${listings.length === 1 ? "" : "s"} — edit, archive, or track views and favorites.`}
-            </p>
+      {canSell ? (
+        <section className="mb-10">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="font-heading text-xl font-semibold">Your listings</h2>
+              <p className="text-sm text-muted-foreground">
+                Edit, archive, or track views and favorites on your listings.
+              </p>
+            </div>
+            <Button asChild size="sm">
+              <Link href="/sell">
+                <PlusIcon className="mr-1.5 size-4" />
+                Create a listing
+              </Link>
+            </Button>
           </div>
-          <Button asChild size="sm">
-            <Link href="/sell">
-              <PlusIcon className="mr-1.5 size-4" />
-              Create a listing
-            </Link>
-          </Button>
-        </div>
-        <ListingManager listings={listings} />
-      </section>
+          <ListingManager listings={listings} />
+        </section>
+      ) : (
+        <Card className="mb-10">
+          <CardContent className="flex flex-col items-start gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="font-heading text-lg font-semibold">
+                Sell on the marketplace
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                When you start selling, your listings, their stats, and incoming
+                offers will live here.
+              </p>
+            </div>
+            <Button asChild variant="outline">
+              <Link href="/profile">Get started</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <Card>

--- a/app/app/favorites/loading.tsx
+++ b/app/app/favorites/loading.tsx
@@ -1,0 +1,16 @@
+export default function FavoritesLoading() {
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <div className="mb-8 h-7 w-48 animate-pulse rounded bg-muted" />
+      <div className="grid grid-cols-1 gap-x-6 gap-y-8 animate-pulse sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i}>
+            <div className="aspect-[4/3] w-full rounded-lg bg-muted" />
+            <div className="mt-2 h-4 w-3/4 rounded bg-muted" />
+            <div className="mt-2 h-4 w-1/4 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/favorites/page.tsx
+++ b/app/app/favorites/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link"
+import { Heart } from "lucide-react"
+
+import { requireUser } from "@/lib/auth"
+import { fetchFavoriteListings } from "@/lib/favorites"
+import { Button } from "@/components/ui/button"
+import { ListingCard } from "@/components/listings/listing-card"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
+
+export const dynamic = "force-dynamic"
+
+export default async function FavoritesPage() {
+  const user = await requireUser()
+  const listings = await fetchFavoriteListings(user.id)
+
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <h1 className="font-heading mb-8 text-2xl font-semibold text-foreground">
+        Your favorites
+      </h1>
+
+      {listings.length === 0 ? (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <Heart className="size-6 text-muted-foreground" />
+          </div>
+          <h2 className="font-heading text-lg font-semibold">
+            No favorites yet
+          </h2>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            Tap the heart on any listing to save it here and find it again
+            later.
+          </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link href="/">Browse listings</Link>
+          </Button>
+        </div>
+      ) : (
+        <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {listings.map((l) => (
+            <li key={l.id}>
+              <ListingCard
+                listing={l}
+                favoriteButton={
+                  <FavoriteButton listingId={l.id} initial={true} />
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -8,6 +8,7 @@ import type { UserRole } from "@/lib/auth/types"
 import { fetchListing, formatCondition, formatPrice } from "@/lib/listings"
 import { fetchFavoriteIds } from "@/lib/favorites"
 import { FavoriteButton } from "@/components/favorites/favorite-button"
+import { MakeOfferButton } from "@/components/offers/make-offer-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -101,6 +102,14 @@ export default async function ListingPage({
             {formatPrice(l.price, { maxFractionDigits: 2 })}
             {l.negotiable ? " (or best offer)" : null}
           </p>
+
+          <MakeOfferButton
+            listingId={l.id}
+            listingPrice={l.price}
+            isOwner={Boolean(user && user.id === l.seller_id)}
+            available={l.status === "published"}
+            signedIn={Boolean(user)}
+          />
 
           {category ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -3,9 +3,11 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { MapPinIcon, TagIcon } from "lucide-react"
 
-import { ROLE_LABELS } from "@/lib/auth"
+import { ROLE_LABELS, getCurrentUser } from "@/lib/auth"
 import type { UserRole } from "@/lib/auth/types"
 import { fetchListing, formatCondition, formatPrice } from "@/lib/listings"
+import { fetchFavoriteIds } from "@/lib/favorites"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -42,6 +44,11 @@ export default async function ListingPage({
   const { id } = await params
   const data = await fetchListing(id)
   if (!data) notFound()
+
+  const user = await getCurrentUser()
+  const favorited = user
+    ? (await fetchFavoriteIds(user.id)).includes(id)
+    : null
 
   const { listing: l, images, category, seller } = data
   const cover = images[0]?.image_url
@@ -87,6 +94,7 @@ export default async function ListingPage({
               {l.title}
             </h1>
             <Badge variant="secondary">{formatCondition(l.condition)}</Badge>
+            <FavoriteButton listingId={l.id} initial={favorited} />
           </div>
 
           <p className="text-2xl font-semibold text-foreground">

--- a/app/app/offers/loading.tsx
+++ b/app/app/offers/loading.tsx
@@ -1,0 +1,21 @@
+export default function OffersLoading() {
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 h-7 w-40 animate-pulse rounded bg-muted" />
+      <div className="flex flex-col gap-4 animate-pulse">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-32 rounded-lg border bg-background">
+            <div className="flex items-start gap-4 p-4">
+              <div className="size-20 shrink-0 rounded-md bg-muted" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-3/4 rounded bg-muted" />
+                <div className="h-4 w-1/3 rounded bg-muted" />
+                <div className="h-3 w-1/2 rounded bg-muted" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/offers/page.tsx
+++ b/app/app/offers/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { SendIcon } from "lucide-react"
+
+import { requireUser } from "@/lib/auth"
+import { fetchBuyerOffers } from "@/lib/offers"
+import { formatPrice } from "@/lib/listings"
+import { formatShortDate } from "@/lib/utils"
+import { OfferStatusBadge } from "@/components/offers/offer-status-badge"
+import { BuyerOfferActions } from "@/components/offers/buyer-offer-actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+  title: "My offers",
+  description: "Offers you have made on the VinTech Marketplace.",
+}
+
+export default async function OffersPage() {
+  const user = await requireUser()
+  const offers = await fetchBuyerOffers(user.id)
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
+        <h1 className="font-heading text-2xl font-semibold text-foreground">
+          My offers
+        </h1>
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/offers/seller">View incoming offers →</Link>
+        </Button>
+      </div>
+
+      {offers.length === 0 ? (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <SendIcon className="size-6 text-muted-foreground" />
+          </div>
+          <h2 className="font-heading text-lg font-semibold">No offers yet</h2>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            When you make an offer on a listing it shows up here, where you can
+            see whether the seller accepted, declined, or countered it.
+          </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link href="/">Browse listings</Link>
+          </Button>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {offers.map((offer) => (
+            <li key={offer.id}>
+              <Card>
+                <CardContent className="p-4">
+                  <div className="flex items-start gap-4">
+                    <div className="size-20 shrink-0 overflow-hidden rounded-md border bg-muted">
+                      {offer.listing?.image_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={offer.listing.image_url}
+                          alt=""
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                          No photo
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      {offer.listing ? (
+                        <Link
+                          href={`/listings/${offer.listing.id}`}
+                          className="line-clamp-1 font-medium hover:underline"
+                        >
+                          {offer.listing.title}
+                        </Link>
+                      ) : (
+                        <p className="font-medium text-muted-foreground">
+                          Listing no longer available
+                        </p>
+                      )}
+                      <p className="mt-1 text-sm font-semibold">
+                        Your offer:{" "}
+                        {formatPrice(offer.amount, { maxFractionDigits: 2 })}
+                      </p>
+                      {offer.message ? (
+                        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                          {offer.message}
+                        </p>
+                      ) : null}
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Submitted {formatShortDate(offer.created_at)}
+                      </p>
+                    </div>
+
+                    <OfferStatusBadge status={offer.status} />
+                  </div>
+
+                  {offer.status === "countered" ? (
+                    <div className="mt-4 border-t pt-3">
+                      <BuyerOfferActions offer={offer} />
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/app/app/offers/seller/loading.tsx
+++ b/app/app/offers/seller/loading.tsx
@@ -1,0 +1,26 @@
+export default function SellerOffersLoading() {
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 h-7 w-48 animate-pulse rounded bg-muted" />
+      <div className="flex flex-col gap-4 animate-pulse">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-40 rounded-lg border bg-background">
+            <div className="flex items-start gap-3 p-4">
+              <div className="size-10 shrink-0 rounded-full bg-muted" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-2/3 rounded bg-muted" />
+                <div className="h-4 w-1/2 rounded bg-muted" />
+                <div className="h-3 w-1/3 rounded bg-muted" />
+              </div>
+            </div>
+            <div className="mx-4 border-t" />
+            <div className="flex gap-2 px-4 pt-3">
+              <div className="h-8 w-20 rounded bg-muted" />
+              <div className="h-8 w-20 rounded bg-muted" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/offers/seller/page.tsx
+++ b/app/app/offers/seller/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { InboxIcon } from "lucide-react"
+
+import { requireUser } from "@/lib/auth"
+import { fetchSellerOffers } from "@/lib/offers"
+import { formatPrice } from "@/lib/listings"
+import { formatShortDate, initials } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { OfferStatusBadge } from "@/components/offers/offer-status-badge"
+import { SellerOfferActions } from "@/components/offers/seller-offer-actions"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+  title: "Incoming offers",
+  description: "Offers buyers have made on your listings.",
+}
+
+export default async function SellerOffersPage() {
+  const user = await requireUser()
+  const offers = await fetchSellerOffers(user.id)
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-2 flex flex-wrap items-end justify-between gap-3">
+        <h1 className="font-heading text-2xl font-semibold text-foreground">
+          Incoming offers
+        </h1>
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/offers">← View my offers</Link>
+        </Button>
+      </div>
+      <p className="mb-8 text-sm text-muted-foreground">
+        Offers from buyers on your listings. Accept the right price and the
+        listing is marked sold.
+      </p>
+
+      {offers.length === 0 ? (
+        <div className="flex flex-col items-center py-16 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <InboxIcon className="size-6 text-muted-foreground" />
+          </div>
+          <h2 className="font-heading text-lg font-semibold">No offers yet</h2>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            When a buyer makes an offer on one of your listings it appears here
+            for you to accept, decline, or counter.
+          </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link href="/dashboard">Go to dashboard</Link>
+          </Button>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {offers.map((offer) => (
+            <li key={offer.id}>
+              <Card>
+                <CardContent className="p-4">
+                  <div className="flex items-start gap-3">
+                    <Avatar className="size-10">
+                      <AvatarImage
+                        src={offer.buyer?.avatar_url ?? undefined}
+                        alt={offer.buyer?.full_name ?? "Buyer"}
+                      />
+                      <AvatarFallback className="text-sm">
+                        {initials(offer.buyer?.full_name ?? "")}
+                      </AvatarFallback>
+                    </Avatar>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="font-medium">
+                          {offer.buyer?.full_name ?? "Anonymous buyer"}
+                        </p>
+                        <OfferStatusBadge status={offer.status} />
+                      </div>
+
+                      <p className="mt-1 text-sm font-semibold">
+                        {formatPrice(offer.amount, { maxFractionDigits: 2 })}
+                        {" for "}
+                        {offer.listing ? (
+                          <Link
+                            href={`/listings/${offer.listing.id}`}
+                            className="text-primary hover:underline"
+                          >
+                            {offer.listing.title}
+                          </Link>
+                        ) : (
+                          <span className="text-muted-foreground">
+                            a listing that is no longer available
+                          </span>
+                        )}
+                      </p>
+
+                      {offer.message ? (
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {offer.message}
+                        </p>
+                      ) : null}
+
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Offered {formatShortDate(offer.created_at)}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 border-t pt-3">
+                    <SellerOfferActions offer={offer} />
+                  </div>
+                </CardContent>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -61,7 +61,7 @@ export default async function HomePage({
         </p>
         <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
           <Button asChild size="lg">
-            <Link href="#listings">Browse listings</Link>
+            <Link href="/search">Browse listings</Link>
           </Button>
           <Button asChild variant="outline" size="lg">
             <Link href="/sell">Start selling</Link>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
+import { getCurrentUser } from "@/lib/auth"
 import { fetchCategories, fetchListings, PAGE_SIZE } from "@/lib/listings"
+import { fetchFavoriteIds } from "@/lib/favorites"
 import { buildBrowseUrl, nextOffset, parseBrowseParams } from "@/lib/browse"
 import { CategoryCard } from "@/components/categories/category-card"
 import { ListingCard } from "@/components/listings/listing-card"
+import { FavoriteButton } from "@/components/favorites/favorite-button"
 
 function NoResultsIcon({ className }: { className?: string }) {
   return (
@@ -42,12 +45,19 @@ export default async function HomePage({
   const sp = await searchParams
   const { categorySlug, offset } = parseBrowseParams(sp)
 
+  // Favorites state is per-user: kick the (cached) session read off up front,
+  // then fetch favorite ids only for signed-in visitors. Anonymous browsing
+  // adds no favorites round-trip.
+  const userPromise = getCurrentUser()
   const categoriesPromise = fetchCategories()
-  const { listings, hasMore, error } = await fetchListings({
+  const browsePromise = fetchListings({
     limit: PAGE_SIZE,
     offset,
     categorySlug,
   })
+  const user = await userPromise
+  const favoriteIds = user ? new Set(await fetchFavoriteIds(user.id)) : null
+  const { listings, hasMore, error } = await browsePromise
   const categories = await categoriesPromise
 
   return (
@@ -142,7 +152,15 @@ export default async function HomePage({
             <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {listings.map((l) => (
                 <li key={l.id}>
-                  <ListingCard listing={l} />
+                  <ListingCard
+                    listing={l}
+                    favoriteButton={
+                      <FavoriteButton
+                        listingId={l.id}
+                        initial={favoriteIds?.has(l.id) ?? null}
+                      />
+                    }
+                  />
                 </li>
               ))}
             </ul>

--- a/app/app/search/loading.tsx
+++ b/app/app/search/loading.tsx
@@ -1,0 +1,25 @@
+export default function SearchLoading() {
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <div className="mb-8 space-y-3">
+        <div className="h-9 w-72 animate-pulse rounded-lg bg-muted" />
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+      </div>
+
+      <div className="animate-pulse rounded-lg border bg-card p-4">
+        <div className="h-9 w-full rounded-md bg-muted" />
+        <div className="mt-4 h-9 w-full rounded-md bg-muted" />
+      </div>
+
+      <div className="mt-8 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {Array.from({ length: 8 }, (_, i) => (
+          <div key={i} className="animate-pulse">
+            <div className="aspect-[4/3] rounded-lg bg-muted" />
+            <div className="mt-3 h-4 w-3/4 rounded bg-muted" />
+            <div className="mt-2 h-4 w-1/3 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/app/app/search/page.tsx
+++ b/app/app/search/page.tsx
@@ -43,7 +43,7 @@ export default async function SearchPage({
   const filters = parseSearchParams(sp)
 
   const categoriesPromise = fetchCategories()
-  const { listings, totalCount, hasMore, error } = await searchListings({
+  const { listings, count, hasMore, error } = await searchListings({
     q: filters.q || undefined,
     categorySlug: filters.categorySlug,
     minPrice: filters.minPrice,
@@ -64,7 +64,7 @@ export default async function SearchPage({
         <p className="mt-2 text-muted-foreground">
           {error
             ? "We could not run your search."
-            : `${totalCount} ${totalCount === 1 ? "listing" : "listings"}`}
+            : `${count} ${count === 1 ? "listing" : "listings"}`}
         </p>
       </section>
 

--- a/app/app/search/page.tsx
+++ b/app/app/search/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link"
+
+import { Button } from "@/components/ui/button"
+import { fetchCategories, searchListings } from "@/lib/listings"
+import { buildSearchUrl, nextOffset, parseSearchParams } from "@/lib/search"
+import { ListingCard } from "@/components/listings/listing-card"
+import { SearchFilters } from "@/components/search/search-filters"
+
+function SearchIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M21 21l-4.35-4.35M9.5 18a8.5 8.5 0 110-17 8.5 8.5 0 010 17z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="7.5"
+        cy="7.5"
+        r="1.25"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const sp = await searchParams
+  const filters = parseSearchParams(sp)
+
+  const categoriesPromise = fetchCategories()
+  const { listings, totalCount, hasMore, error } = await searchListings({
+    q: filters.q || undefined,
+    categorySlug: filters.categorySlug,
+    minPrice: filters.minPrice,
+    maxPrice: filters.maxPrice,
+    condition: filters.condition,
+    city: filters.city || undefined,
+    sort: filters.sort,
+    offset: filters.offset,
+  })
+  const categories = await categoriesPromise
+
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <section className="mb-8">
+        <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+          {filters.q ? `Results for “${filters.q}”` : "Browse listings"}
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          {error
+            ? "We could not run your search."
+            : `${totalCount} ${totalCount === 1 ? "listing" : "listings"}`}
+        </p>
+      </section>
+
+      <SearchFilters categories={categories} filters={filters} />
+
+      <section aria-label="Search results" className="mt-8">
+        {error ? (
+          <div className="py-16 text-center">
+            <p className="text-sm text-muted-foreground">
+              We could not load listings.
+            </p>
+            <Link
+              href={buildSearchUrl(filters)}
+              className="mt-2 inline-block text-sm font-medium text-primary underline"
+            >
+              Retry
+            </Link>
+          </div>
+        ) : listings.length === 0 ? (
+          <div className="flex flex-col items-center py-16 text-center">
+            <SearchIcon className="mb-3 h-10 w-10 text-muted-foreground/60" />
+            <h2 className="font-heading text-lg font-semibold">
+              No results found.
+            </h2>
+            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+              Try a different keyword, or widen your filters.
+            </p>
+            <Button asChild size="sm" className="mt-4">
+              <Link href="/search">Clear all filters</Link>
+            </Button>
+          </div>
+        ) : (
+          <>
+            <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {listings.map((l) => (
+                <li key={l.id}>
+                  <ListingCard listing={l} />
+                </li>
+              ))}
+            </ul>
+            {hasMore ? (
+              <div className="mt-10 flex justify-center">
+                <Link
+                  href={buildSearchUrl({
+                    ...filters,
+                    offset: nextOffset(filters.offset),
+                  })}
+                  className="text-sm font-medium underline"
+                >
+                  Load more
+                </Link>
+              </div>
+            ) : null}
+          </>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/app/components/dashboard/listing-manager.tsx
+++ b/app/components/dashboard/listing-manager.tsx
@@ -1,29 +1,33 @@
 "use client"
 
 import Link from "next/link"
-import { useActionState } from "react"
+import { useActionState, useState } from "react"
 import { EyeIcon, HeartIcon, PackageOpenIcon, PencilIcon, PlusIcon, XIcon } from "lucide-react"
 
 import { deleteListing } from "@/app/actions/listings"
-import { formatPrice, type SellerListingRow } from "@/lib/listings"
+import type { SellerListingRow } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings/constants"
 import { ListingStatusBadge } from "@/components/dashboard/listing-status-badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 
 function ListingRow({ listing }: { listing: SellerListingRow }) {
   const [state, action, pending] = useActionState(deleteListing, {})
+  const [imgError, setImgError] = useState(false)
 
   return (
     <li>
       <Card>
         <CardContent className="flex flex-wrap items-center gap-4 p-4">
           <div className="size-16 shrink-0 overflow-hidden rounded-md border bg-muted">
-            {listing.cover_image_url ? (
+            {listing.cover_image_url && !imgError ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={listing.cover_image_url}
                 alt=""
                 className="h-full w-full object-cover"
+                loading="lazy"
+                onError={() => setImgError(true)}
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
@@ -67,7 +71,7 @@ function ListingRow({ listing }: { listing: SellerListingRow }) {
             <form
               action={action}
               onSubmit={(e) => {
-                if (!confirm("Archive this listing? You can republish it later."))
+                if (!confirm("Archive this listing? It will no longer be visible."))
                   e.preventDefault()
               }}
             >

--- a/app/components/dashboard/listing-manager.tsx
+++ b/app/components/dashboard/listing-manager.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import Link from "next/link"
+import { useActionState } from "react"
+import { EyeIcon, HeartIcon, PackageOpenIcon, PencilIcon, PlusIcon, XIcon } from "lucide-react"
+
+import { deleteListing } from "@/app/actions/listings"
+import { formatPrice, type SellerListingRow } from "@/lib/listings"
+import { ListingStatusBadge } from "@/components/dashboard/listing-status-badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+function ListingRow({ listing }: { listing: SellerListingRow }) {
+  const [state, action, pending] = useActionState(deleteListing, {})
+
+  return (
+    <li>
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-4 p-4">
+          <div className="size-16 shrink-0 overflow-hidden rounded-md border bg-muted">
+            {listing.cover_image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={listing.cover_image_url}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                No photo
+              </div>
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <Link
+              href={`/listings/${listing.id}`}
+              className="line-clamp-1 font-medium hover:underline"
+            >
+              {listing.title}
+            </Link>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <ListingStatusBadge status={listing.status} />
+              <span className="text-sm font-semibold">
+                {formatPrice(listing.price)}
+              </span>
+            </div>
+            <div className="mt-1 flex items-center gap-4 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <EyeIcon className="size-3.5" />
+                {listing.view_count} views
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <HeartIcon className="size-3.5" />
+                {listing.favorite_count} favorites
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/listings/${listing.id}/edit`}>
+                <PencilIcon className="mr-1.5 size-3.5" />
+                Edit
+              </Link>
+            </Button>
+            <form
+              action={action}
+              onSubmit={(e) => {
+                if (!confirm("Archive this listing? You can republish it later."))
+                  e.preventDefault()
+              }}
+            >
+              <input type="hidden" name="id" value={listing.id} readOnly />
+              <Button type="submit" variant="ghost" size="sm" disabled={pending}>
+                <XIcon className="mr-1.5 size-3.5" />
+                {pending ? "Archiving…" : "Archive"}
+              </Button>
+            </form>
+          </div>
+
+          {state.message ? (
+            <p role="alert" className="w-full text-sm text-destructive">
+              {state.message}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+    </li>
+  )
+}
+
+export function ListingManager({ listings }: { listings: SellerListingRow[] }) {
+  if (listings.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center py-14 text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
+            <PackageOpenIcon className="size-6 text-muted-foreground" />
+          </div>
+          <h3 className="font-heading text-lg font-semibold">
+            You have no listings yet
+          </h3>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            Add your first item with a few photos and a price — buyers can start
+            finding it right away.
+          </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link href="/sell">
+              <PlusIcon className="mr-1.5 size-4" />
+              Create a listing
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {listings.map((listing) => (
+        <ListingRow key={listing.id} listing={listing} />
+      ))}
+    </ul>
+  )
+}

--- a/app/components/dashboard/listing-status-badge.tsx
+++ b/app/components/dashboard/listing-status-badge.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import {
+  LISTING_STATUS_COLORS,
+  LISTING_STATUS_LABELS,
+  type ListingStatus,
+} from "@/lib/listings/constants"
+import { Badge } from "@/components/ui/badge"
+
+export function ListingStatusBadge({ status }: { status: ListingStatus }) {
+  return (
+    <Badge className={cn(LISTING_STATUS_COLORS[status])}>
+      {LISTING_STATUS_LABELS[status]}
+    </Badge>
+  )
+}

--- a/app/components/dashboard/listing-status-badge.tsx
+++ b/app/components/dashboard/listing-status-badge.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { cn } from "@/lib/utils"
 import {
   LISTING_STATUS_COLORS,

--- a/app/components/favorites/favorite-button.tsx
+++ b/app/components/favorites/favorite-button.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import Link from "next/link"
+import { useOptimistic, useRef } from "react"
+import { usePathname } from "next/navigation"
+import { Heart } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  buildLoginUrl,
+  toggleFavoriteState,
+} from "@/lib/favorites/constants"
+import { toggleFavorite } from "@/app/actions/favorites"
+
+function heartClasses(active: boolean): string {
+  return cn(
+    "inline-flex size-8 items-center justify-center rounded-full",
+    "bg-white/90 text-slate-700 shadow-sm ring-1 ring-black/5",
+    "transition-colors hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2",
+    active && "text-primary"
+  )
+}
+
+export function FavoriteButton({
+  listingId,
+  initial,
+}: {
+  listingId: string
+  /** Server truth: true = favorited, false = not, null = signed out. */
+  initial: boolean | null
+}) {
+  const [favorite, setFavorite] = useOptimistic(initial === true)
+  const pathname = usePathname()
+  const formRef = useRef<HTMLFormElement>(null)
+
+  // Signed-out visitors get a heart that routes through login (with a ?next=
+  // back to this listing) instead of a form that would just redirect.
+  if (initial === null) {
+    return (
+      <Link
+        href={buildLoginUrl(pathname)}
+        aria-label="Sign in to save this listing"
+        className={heartClasses(false)}
+      >
+        <Heart className="size-4" />
+      </Link>
+    )
+  }
+
+  return (
+    <form ref={formRef} action={toggleFavorite}>
+      <input type="hidden" name="listingId" value={listingId} />
+      <button
+        type="submit"
+        onClick={() => {
+          // Flip the heart on the current frame via the shared reducer, then
+          // let the form submit run the server action (revalidatePath re-syncs
+          // this optimistic frame with DB truth when the transition settles).
+          setFavorite(toggleFavoriteState)
+          formRef.current?.requestSubmit()
+        }}
+        aria-label={favorite ? "Remove from favorites" : "Save to favorites"}
+        aria-pressed={favorite}
+        className={heartClasses(favorite)}
+      >
+        <Heart className={cn("size-4", favorite && "fill-current")} />
+      </button>
+    </form>
+  )
+}

--- a/app/components/favorites/favorite-button.tsx
+++ b/app/components/favorites/favorite-button.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useOptimistic, useRef } from "react"
+import { useOptimistic } from "react"
 import { usePathname } from "next/navigation"
 import { Heart } from "lucide-react"
 
@@ -31,7 +31,6 @@ export function FavoriteButton({
 }) {
   const [favorite, setFavorite] = useOptimistic(initial === true)
   const pathname = usePathname()
-  const formRef = useRef<HTMLFormElement>(null)
 
   // Signed-out visitors get a heart that routes through login (with a ?next=
   // back to this listing) instead of a form that would just redirect.
@@ -47,18 +46,19 @@ export function FavoriteButton({
     )
   }
 
+  // Client wrapper around the server action: flip the heart on the current
+  // frame via the shared reducer, then run the action. Revalidation re-syncs
+  // this optimistic frame with DB truth when the transition settles.
+  const submitFavorite = async (formData: FormData) => {
+    setFavorite(toggleFavoriteState)
+    await toggleFavorite(formData)
+  }
+
   return (
-    <form ref={formRef} action={toggleFavorite}>
+    <form action={submitFavorite}>
       <input type="hidden" name="listingId" value={listingId} />
       <button
         type="submit"
-        onClick={() => {
-          // Flip the heart on the current frame via the shared reducer, then
-          // let the form submit run the server action (revalidatePath re-syncs
-          // this optimistic frame with DB truth when the transition settles).
-          setFavorite(toggleFavoriteState)
-          formRef.current?.requestSubmit()
-        }}
         aria-label={favorite ? "Remove from favorites" : "Save to favorites"}
         aria-pressed={favorite}
         className={heartClasses(favorite)}

--- a/app/components/listings/condition-chip.tsx
+++ b/app/components/listings/condition-chip.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge"
 
-import { CONDITION_COLORS } from "@/lib/listings"
+import { CONDITION_COLORS } from "@/lib/listings/constants"
 import type { Condition } from "@/lib/listings"
 
 export function ConditionChip({ condition }: { condition: Condition }) {

--- a/app/components/listings/create-listing-form.tsx
+++ b/app/components/listings/create-listing-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { XIcon, UploadIcon } from "lucide-react"
 
 import { createListing } from "@/app/actions/listings"
-import { CONDITIONS } from "@/lib/listings"
+import { CONDITIONS } from "@/lib/listings/constants"
 import type { Category } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -4,7 +4,7 @@ import { useActionState } from "react"
 import { XIcon } from "lucide-react"
 
 import { updateListing, deleteListing } from "@/app/actions/listings"
-import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings"
+import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings/constants"
 import type { Category, Listing } from "@/lib/listings"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"

--- a/app/components/listings/edit-listing-form.tsx
+++ b/app/components/listings/edit-listing-form.tsx
@@ -186,7 +186,7 @@ export function EditListingForm({
             disabled={deletePending}
             onClick={() => {
               if (
-                !confirm("Archive this listing? You can republish it later.")
+                !confirm("Archive this listing? It will no longer be visible.")
               )
                 return false
             }}
@@ -202,7 +202,7 @@ export function EditListingForm({
         action={deleteAction}
         onSubmit={(e) => {
           if (
-            !confirm("Archive this listing? You can republish it later.")
+            !confirm("Archive this listing? It will no longer be visible.")
           )
             e.preventDefault()
         }}

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,30 +1,48 @@
 import Link from "next/link"
+import type { ReactNode } from "react"
 
 import type { BrowseListing } from "@/lib/listings"
 import { formatPrice } from "@/lib/listings/constants"
 import { ConditionChip } from "@/components/listings/condition-chip"
 import { SellerBadge } from "@/components/listings/seller-badge"
 
-export function ListingCard({ listing }: { listing: BrowseListing }) {
+export function ListingCard({
+  listing,
+  favoriteButton,
+}: {
+  listing: BrowseListing
+  /** Optional per-card action overlay (e.g. the favorites heart). */
+  favoriteButton?: ReactNode
+}) {
+  const href = `/listings/${listing.id}`
   return (
-    <Link href={`/listings/${listing.id}`} className="group block w-full">
-      <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
-        {listing.image_url ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={listing.image_url}
-            alt={listing.title}
-            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
-            No photo
+    <div className="group w-full">
+      <div className="relative">
+        <Link href={href} aria-label={listing.title}>
+          <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
+            {listing.image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={listing.image_url}
+                alt=""
+                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                loading="lazy"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+                No photo
+              </div>
+            )}
           </div>
-        )}
+        </Link>
+        {favoriteButton ? (
+          <div className="absolute right-2 top-2">{favoriteButton}</div>
+        ) : null}
       </div>
       <div className="mt-2 space-y-1">
-        <p className="line-clamp-1 font-medium">{listing.title}</p>
+        <Link href={href} className="block">
+          <p className="line-clamp-1 font-medium">{listing.title}</p>
+        </Link>
         <p className="font-semibold">{formatPrice(listing.price)}</p>
         <div className="flex items-center gap-2">
           <ConditionChip condition={listing.condition} />
@@ -34,6 +52,6 @@ export function ListingCard({ listing }: { listing: BrowseListing }) {
         </div>
         <SellerBadge listing={listing} />
       </div>
-    </Link>
+    </div>
   )
 }

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 
 import type { BrowseListing } from "@/lib/listings"
-import { formatPrice } from "@/lib/listings"
+import { formatPrice } from "@/lib/listings/constants"
 import { ConditionChip } from "@/components/listings/condition-chip"
 import { SellerBadge } from "@/components/listings/seller-badge"
 

--- a/app/components/listings/listing-card.tsx
+++ b/app/components/listings/listing-card.tsx
@@ -39,10 +39,8 @@ export function ListingCard({
           <div className="absolute right-2 top-2">{favoriteButton}</div>
         ) : null}
       </div>
-      <div className="mt-2 space-y-1">
-        <Link href={href} className="block">
-          <p className="line-clamp-1 font-medium">{listing.title}</p>
-        </Link>
+      <Link href={href} className="mt-2 block space-y-1">
+        <p className="line-clamp-1 font-medium">{listing.title}</p>
         <p className="font-semibold">{formatPrice(listing.price)}</p>
         <div className="flex items-center gap-2">
           <ConditionChip condition={listing.condition} />
@@ -51,7 +49,7 @@ export function ListingCard({
           ) : null}
         </div>
         <SellerBadge listing={listing} />
-      </div>
+      </Link>
     </div>
   )
 }

--- a/app/components/offers/buyer-offer-actions.tsx
+++ b/app/components/offers/buyer-offer-actions.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useActionState } from "react"
+
+import { offerAction } from "@/app/actions/offers"
+import type { BuyerOfferRow } from "@/lib/offers"
+import { Button } from "@/components/ui/button"
+
+export function BuyerOfferActions({ offer }: { offer: BuyerOfferRow }) {
+  const [state, formAction, pending] = useActionState(offerAction, {})
+
+  // Only a countered offer needs the buyer to respond: accept it (the listing
+  // is then marked sold, ListingMarkedSold) or decline it (walk away).
+  if (offer.status !== "countered") return null
+
+  return (
+    <form action={formAction} className="flex flex-wrap items-center gap-2">
+      <input type="hidden" name="offerId" value={offer.id} />
+      <input type="hidden" name="listingId" value={offer.listing_id} />
+      <Button type="submit" name="action" value="accept" disabled={pending}>
+        Accept counter
+      </Button>
+      <Button
+        type="submit"
+        name="action"
+        value="decline"
+        variant="ghost"
+        disabled={pending}
+      >
+        Decline counter
+      </Button>
+      {state.message ? (
+        <p role="alert" className="text-sm text-destructive">
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/app/components/offers/make-offer-button.tsx
+++ b/app/components/offers/make-offer-button.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { usePathname } from "next/navigation"
+
+import { buildLoginUrl } from "@/lib/offers/constants"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
+import { OfferModal } from "@/components/offers/offer-modal"
+
+export function MakeOfferButton({
+  listingId,
+  listingPrice,
+  isOwner,
+  available,
+  signedIn,
+}: {
+  listingId: string
+  listingPrice: number
+  isOwner: boolean
+  available: boolean
+  signedIn: boolean
+}) {
+  const pathname = usePathname()
+  const [open, setOpen] = useState(false)
+
+  // You cannot offer on your own listing (INV-005), and draft or sold listings
+  // are not open to offers — even to a signed-out visitor, who must not get a
+  // CTA that would dead-end at a sold listing.
+  if (isOwner || !available) return null
+
+  // Signed-out visitors get a CTA that routes through login (with a ?next=
+  // back to this listing) instead of a form that would just redirect.
+  if (!signedIn) {
+    return (
+      <Button asChild size="lg">
+        <Link href={buildLoginUrl(pathname)}>Make an offer</Link>
+      </Button>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="lg">Make an offer</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <OfferModal
+          listingId={listingId}
+          listingPrice={listingPrice}
+          onClose={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/components/offers/offer-modal.tsx
+++ b/app/components/offers/offer-modal.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { useEffect } from "react"
+import { useActionState } from "react"
+
+import { submitOffer } from "@/app/actions/offers"
+import { formatPrice } from "@/lib/listings/constants"
+import { OFFER_MESSAGE_MAX } from "@/lib/offers/constants"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function OfferModal({
+  listingId,
+  listingPrice,
+  onClose,
+}: {
+  listingId: string
+  listingPrice: number
+  onClose: () => void
+}) {
+  const [state, formAction, pending] = useActionState(submitOffer, {})
+
+  // Close the dialog once the offer is persisted; revalidation has already
+  // refreshed the page underneath.
+  useEffect(() => {
+    if (state.ok) onClose()
+  }, [state.ok, onClose])
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Make an offer</DialogTitle>
+        <DialogDescription>
+          Offer your price for this item. The seller can accept, decline, or
+          counter your offer.
+        </DialogDescription>
+      </DialogHeader>
+
+      <form action={formAction} className="flex flex-col gap-4 px-4">
+        <input type="hidden" name="listingId" value={listingId} />
+
+        <div className="grid gap-2">
+          <Label htmlFor="offer-amount">
+            Your offer ({formatPrice(listingPrice)} asking)
+          </Label>
+          <Input
+            id="offer-amount"
+            name="amount"
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step="0.01"
+            defaultValue={String(listingPrice)}
+            aria-invalid={Boolean(state.errors?.amount)}
+            required
+          />
+          <FieldError message={state.errors?.amount?.[0]} />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="offer-message">Message (optional)</Label>
+          <textarea
+            id="offer-message"
+            name="message"
+            rows={4}
+            maxLength={OFFER_MESSAGE_MAX}
+            placeholder="e.g. I can collect this weekend, would you take…"
+            className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+          />
+          <FieldError message={state.errors?.message?.[0]} />
+        </div>
+
+        {state.message ? (
+          <p role="alert" className="text-sm text-destructive">
+            {state.message}
+          </p>
+        ) : null}
+
+        <DialogFooter>
+          <Button type="submit" disabled={pending}>
+            {pending ? "Sending…" : "Send offer"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </>
+  )
+}

--- a/app/components/offers/offer-status-badge.tsx
+++ b/app/components/offers/offer-status-badge.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import {
+  OFFER_STATUS_COLORS,
+  OFFER_STATUS_LABELS,
+  type OfferStatus,
+} from "@/lib/offers/constants"
+import { Badge } from "@/components/ui/badge"
+
+export function OfferStatusBadge({ status }: { status: OfferStatus }) {
+  return (
+    <Badge className={cn(OFFER_STATUS_COLORS[status])}>
+      {OFFER_STATUS_LABELS[status]}
+    </Badge>
+  )
+}

--- a/app/components/offers/seller-offer-actions.tsx
+++ b/app/components/offers/seller-offer-actions.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useState } from "react"
+import { useActionState } from "react"
+
+import { offerAction } from "@/app/actions/offers"
+import type { SellerOfferRow } from "@/lib/offers"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export function SellerOfferActions({ offer }: { offer: SellerOfferRow }) {
+  const [countering, setCountering] = useState(false)
+  const [state, formAction, pending] = useActionState(offerAction, {})
+
+  // Settled offers need no actions; the badge on the card carries the state.
+  if (offer.status !== "pending") {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {offer.status === "countered"
+          ? "Countered — waiting for the buyer to respond."
+          : offer.status === "accepted"
+            ? "Accepted — the listing is now sold."
+            : "Declined."}
+      </p>
+    )
+  }
+
+  // One form per offer; the pressed submit button carries name="action". The
+  // counter amount only exists in the form while the seller is countering.
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <input type="hidden" name="offerId" value={offer.id} />
+      <input type="hidden" name="listingId" value={offer.listing_id} />
+
+      {countering ? (
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="grid min-w-36 flex-1 gap-1.5">
+            <Label htmlFor={`counter-${offer.id}`} className="text-xs">
+              Counter amount
+            </Label>
+            <Input
+              id={`counter-${offer.id}`}
+              name="amount"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              defaultValue={String(offer.amount)}
+              aria-invalid={Boolean(state.message)}
+              required
+            />
+          </div>
+          <Button type="submit" name="action" value="counter" disabled={pending}>
+            Send counter
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setCountering(false)}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <Button type="submit" name="action" value="accept" disabled={pending}>
+            Accept
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setCountering(true)}
+          >
+            Counter
+          </Button>
+          <Button
+            type="submit"
+            name="action"
+            value="decline"
+            variant="ghost"
+            disabled={pending}
+          >
+            Decline
+          </Button>
+        </div>
+      )}
+
+      {state.message ? (
+        <p role="alert" className="text-sm text-destructive">
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  )
+}

--- a/app/components/search/search-filters.tsx
+++ b/app/components/search/search-filters.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { SearchIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { CONDITIONS, type Category, type Condition } from "@/lib/listings/constants"
+import { buildSearchUrl, SEARCH_SORTS, type SearchFilters as SearchFiltersState } from "@/lib/search"
+
+const fieldClass =
+  "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+
+const SELECT_SORT_LABELS: Record<(typeof SEARCH_SORTS)[number], string> = {
+  newest: "Newest first",
+  oldest: "Oldest first",
+  price_asc: "Price: low to high",
+  price_desc: "Price: high to low",
+}
+
+export function SearchFilters({
+  categories,
+  filters,
+}: {
+  categories: Category[]
+  filters: SearchFiltersState
+}) {
+  const router = useRouter()
+  const [q, setQ] = useState(filters.q)
+  const [categorySlug, setCategorySlug] = useState(filters.categorySlug ?? "")
+  const [condition, setCondition] = useState<Condition | "">(
+    filters.condition ?? ""
+  )
+  const [minPrice, setMinPrice] = useState(filters.minPrice?.toString() ?? "")
+  const [maxPrice, setMaxPrice] = useState(filters.maxPrice?.toString() ?? "")
+  const [city, setCity] = useState(filters.city)
+  const [sort, setSort] = useState(filters.sort)
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    router.push(
+      buildSearchUrl({
+        q,
+        categorySlug: categorySlug || undefined,
+        minPrice: minPrice ? Number(minPrice) : undefined,
+        maxPrice: maxPrice ? Number(maxPrice) : undefined,
+        condition: condition || undefined,
+        city,
+        sort,
+        offset: 0,
+      })
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} aria-label="Search and filter listings">
+      <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
+        <div className="relative">
+          <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            name="q"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search by keyword, e.g. “laptop”"
+            className="pl-9"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-category">Category</Label>
+            <select
+              id="search-category"
+              value={categorySlug}
+              onChange={(e) => setCategorySlug(e.target.value)}
+              className={fieldClass}
+            >
+              <option value="">All categories</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.slug}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-condition">Condition</Label>
+            <select
+              id="search-condition"
+              value={condition}
+              onChange={(e) =>
+                setCondition(e.target.value as Condition | "")
+              }
+              className={fieldClass}
+            >
+              <option value="">Any condition</option>
+              {CONDITIONS.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-min">Min price (ETB)</Label>
+            <Input
+              id="search-min"
+              type="number"
+              min="0"
+              value={minPrice}
+              onChange={(e) => setMinPrice(e.target.value)}
+              placeholder="No minimum"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-max">Max price (ETB)</Label>
+            <Input
+              id="search-max"
+              type="number"
+              min="0"
+              value={maxPrice}
+              onChange={(e) => setMaxPrice(e.target.value)}
+              placeholder="No maximum"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-city">City</Label>
+            <Input
+              id="search-city"
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="e.g. Addis Ababa"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="search-sort">Sort by</Label>
+            <select
+              id="search-sort"
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SearchFiltersState["sort"])}
+              className={fieldClass}
+            >
+              {SEARCH_SORTS.map((s) => (
+                <option key={s} value={s}>
+                  {SELECT_SORT_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push("/search")}>
+              Clear
+            </Button>
+            <Button type="submit">Search</Button>
+          </div>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/app/components/search/search-filters.tsx
+++ b/app/components/search/search-filters.tsx
@@ -8,9 +8,9 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { CONDITIONS, type Category, type Condition } from "@/lib/listings/constants"
-import { buildSearchUrl, SEARCH_SORTS, type SearchFilters as SearchFiltersState } from "@/lib/search"
+import { buildSearchUrl, SEARCH_SORTS, type SearchQuery } from "@/lib/search"
 
-const fieldClass =
+const FIELD_CLASS =
   "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
 
 const SELECT_SORT_LABELS: Record<(typeof SEARCH_SORTS)[number], string> = {
@@ -25,7 +25,7 @@ export function SearchFilters({
   filters,
 }: {
   categories: Category[]
-  filters: SearchFiltersState
+  filters: SearchQuery
 }) {
   const router = useRouter()
   const [q, setQ] = useState(filters.q)
@@ -76,7 +76,7 @@ export function SearchFilters({
               id="search-category"
               value={categorySlug}
               onChange={(e) => setCategorySlug(e.target.value)}
-              className={fieldClass}
+              className={FIELD_CLASS}
             >
               <option value="">All categories</option>
               {categories.map((c) => (
@@ -95,7 +95,7 @@ export function SearchFilters({
               onChange={(e) =>
                 setCondition(e.target.value as Condition | "")
               }
-              className={fieldClass}
+              className={FIELD_CLASS}
             >
               <option value="">Any condition</option>
               {CONDITIONS.map((c) => (
@@ -148,8 +148,8 @@ export function SearchFilters({
             <select
               id="search-sort"
               value={sort}
-              onChange={(e) => setSort(e.target.value as SearchFiltersState["sort"])}
-              className={fieldClass}
+              onChange={(e) => setSort(e.target.value as SearchQuery["sort"])}
+              className={FIELD_CLASS}
             >
               {SEARCH_SORTS.map((s) => (
                 <option key={s} value={s}>

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-full max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 bg-popover bg-clip-padding p-6 text-sm text-popover-foreground shadow-lg duration-200 ease-in-out data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close data-slot="dialog-close" asChild>
+          <Button
+            variant="ghost"
+            className="absolute top-3 right-3"
+            size="icon-sm"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </Button>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("mt-2 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/app/lib/browse.ts
+++ b/app/lib/browse.ts
@@ -1,4 +1,6 @@
-import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings"
+import { nextOffset, parseOffset } from "@/lib/pagination"
+
+export { nextOffset }
 
 export interface BrowseCursor {
   categorySlug: string | undefined
@@ -18,13 +20,8 @@ export function parseBrowseParams(params: {
 }): BrowseCursor {
   const categorySlug =
     typeof params.category === "string" ? params.category : undefined
-  const raw = typeof params.offset === "string" ? params.offset : ""
-  const parsed = Number(raw)
-  const offset =
-    Number.isFinite(parsed) && parsed > 0
-      ? Math.min(parsed, BROWSE_LIMIT_MAX - 1)
-      : 0
-  return { categorySlug, offset }
+  const raw = typeof params.offset === "string" ? params.offset : undefined
+  return { categorySlug, offset: parseOffset(raw) }
 }
 
 /** Build the paginated browse URL (replaces the inline helper in app/page.tsx). */
@@ -36,8 +33,4 @@ export function buildBrowseUrl(
   if (categorySlug) params.set("category", categorySlug)
   if (offset) params.set("offset", String(offset))
   return `/?${params.toString()}`
-}
-
-export function nextOffset(offset: number): number {
-  return offset + PAGE_SIZE
 }

--- a/app/lib/favorites.ts
+++ b/app/lib/favorites.ts
@@ -82,17 +82,6 @@ export async function toggleFavoriteRow(
   }
   const supabase = await createClient()
 
-  // Only published, non-deleted listings can be favorited (RLS would also
-  // return null for anything else, but the explicit check keeps the write
-  // from silently toggling against a stale favorite of an unreadable row).
-  const { data: listing } = await supabase
-    .from("listings")
-    .select("id")
-    .eq("id", listingId)
-    .eq("status", "published")
-    .maybeSingle()
-  if (!listing) return { ok: false, error: "listing not found" }
-
   const { data: existing } = await supabase
     .from("favorites")
     .select("id")
@@ -101,6 +90,22 @@ export async function toggleFavoriteRow(
     .maybeSingle()
   const shouldFavor = toggleFavoriteState(Boolean(existing))
 
+  if (shouldFavor) {
+    // A new favorite requires a published, non-deleted listing (RLS would also
+    // return null for anything else, but the explicit check keeps the write
+    // from inserting a row for an unreadable listing).
+    const { data: listing } = await supabase
+      .from("listings")
+      .select("id")
+      .eq("id", listingId)
+      .eq("status", "published")
+      .maybeSingle()
+    if (!listing) return { ok: false, error: "listing not found" }
+  }
+
+  // Deleting is always allowed: a favorite can outlive its listing's
+  // publish status (a listing sold or unpublished while saved), and the
+  // owner must still be able to clear that stale row.
   const result = shouldFavor
     ? await supabase.from("favorites").insert({
         user_id: userId,

--- a/app/lib/favorites.ts
+++ b/app/lib/favorites.ts
@@ -1,0 +1,120 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+import {
+  isValidUuid,
+  mapBrowseListing,
+  type BrowseListing,
+  type RawListingRow,
+} from "@/lib/listings"
+import { toggleFavoriteState } from "@/lib/favorites/constants"
+
+export * from "@/lib/favorites/constants"
+
+// ---- Reads ----
+
+export async function fetchFavoriteIds(userId: string): Promise<string[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("favorites")
+    .select("listing_id")
+    .eq("user_id", userId)
+  if (error) {
+    console.error("fetchFavoriteIds:", error.message)
+    return []
+  }
+  return (data ?? []).map((row) => row.listing_id)
+}
+
+// The favorites feed: rows are joined against listings, so RLS already drops
+// listings that are no longer readable (unpublished, deleted, sold). Only
+// still-available favorites are returned, most recently favorited first.
+export async function fetchFavoriteListings(
+  userId: string
+): Promise<BrowseListing[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("favorites")
+    .select(
+      `created_at,
+       listing:listings(id, title, price, condition, city, published_at,
+         seller:profiles(id, full_name, avatar_url, role, trust_score),
+         images:listing_images(id, image_url, display_order))`
+    )
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchFavoriteListings:", error.message)
+    return []
+  }
+
+  // supabase-js without generated types types embedded resources as arrays,
+  // but listing_id -> listings is a to-one join: PostgREST returns a single
+  // row (or null when the listing is no longer readable under RLS).
+  const rows = (data ?? []) as unknown as {
+    listing: RawListingRow | null
+  }[]
+
+  return rows
+    .map((row) => row.listing)
+    .filter((listing): listing is RawListingRow => listing !== null)
+    .map(mapBrowseListing)
+}
+
+// ---- Writes (called by the toggle server action) ----
+
+export interface ToggleFavoriteResult {
+  ok: boolean
+  error: string | null
+}
+
+// Persists the toggle: reads the current row state, applies the shared
+// toggleFavoriteState reducer, then inserts or deletes to reach the target.
+// The reducer is the same one the client's useOptimistic applies, so the
+// optimistic frame and the final server state always agree.
+export async function toggleFavoriteRow(
+  userId: string,
+  listingId: string
+): Promise<ToggleFavoriteResult> {
+  if (!isValidUuid(listingId)) {
+    return { ok: false, error: "invalid listing id" }
+  }
+  const supabase = await createClient()
+
+  // Only published, non-deleted listings can be favorited (RLS would also
+  // return null for anything else, but the explicit check keeps the write
+  // from silently toggling against a stale favorite of an unreadable row).
+  const { data: listing } = await supabase
+    .from("listings")
+    .select("id")
+    .eq("id", listingId)
+    .eq("status", "published")
+    .maybeSingle()
+  if (!listing) return { ok: false, error: "listing not found" }
+
+  const { data: existing } = await supabase
+    .from("favorites")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("listing_id", listingId)
+    .maybeSingle()
+  const shouldFavor = toggleFavoriteState(Boolean(existing))
+
+  const result = shouldFavor
+    ? await supabase.from("favorites").insert({
+        user_id: userId,
+        listing_id: listingId,
+      })
+    : await supabase
+        .from("favorites")
+        .delete()
+        .eq("user_id", userId)
+        .eq("listing_id", listingId)
+
+  if (result.error) {
+    console.error("toggleFavoriteRow:", result.error.message)
+    return { ok: false, error: result.error.message }
+  }
+  return { ok: true, error: null }
+}

--- a/app/lib/favorites/constants.ts
+++ b/app/lib/favorites/constants.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure favorites domain value objects.
+ *
+ * Framework-agnostic helpers shared by Server and Client modules. This module
+ * intentionally has NO `server-only` import and imports no Supabase client, so
+ * Client Components can consume it directly without pulling the server seam
+ * into the client graph. `@/lib/favorites` re-exports everything here.
+ */
+
+export type FavoriteState = boolean
+
+/**
+ * The toggle reducer. One definition serves both sides of the optimistic
+ * round-trip: the Client Component calls it in `useOptimistic` to flip the
+ * heart on the current frame, and the Server Action's persistence step (and
+ * the DB write it wraps) must compute the same next state, so the re-rendered
+ * server state and the optimistic frame can never disagree.
+ */
+export function toggleFavoriteState(state: FavoriteState): FavoriteState {
+  return !state
+}
+
+/**
+ * The login redirect target for the heart button. Login honors a `?next=`
+ * query param (see app/login/page.tsx), so a signed-out visitor who taps a
+ * heart lands back on the exact listing after signing in. Kept here so the
+ * Client Component needs no URL-building logic.
+ */
+export function buildLoginUrl(pathname: string): string {
+  return `/login?next=${encodeURIComponent(pathname)}`
+}

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -9,120 +9,43 @@ import {
   uploadObjects,
 } from "@/lib/media"
 
-// ---- Shared value sets (also drive the client form via literals) ----
-export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
-export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
-export const MAX_IMAGES = 10
+import {
+  BROWSE_LIMIT_MAX,
+  LISTING_COLUMNS,
+  MAX_IMAGES,
+  PAGE_SIZE,
+  isValidUuid,
+} from "./listings/constants"
+import type {
+  BrowseListing,
+  BrowseSeller,
+  Category,
+  Condition,
+  Listing,
+  ListingEditPayload,
+  ListingImage,
+  ListingPayload,
+  ListingStatus,
+  ListingWithRelations,
+} from "./listings/constants"
+import type { SearchSort } from "@/lib/search"
 
-export type Condition = (typeof CONDITIONS)[number]
-export type ListingStatus = (typeof STATUSES)[number] | "archived"
+// Re-export the pure value objects so imports from "@/lib/listings" keep
+// resolving. Definitions live in ./listings/constants (server-free).
+export * from "./listings/constants"
 
-export interface ListingStatusOption {
-  value: string
-  label: string
-  disabled?: boolean
-}
+// ---- Internal row shape (server-only; not part of the public value object) ----
 
-// Canonical status options for the edit flow: the writable statuses plus the
-// terminal "archived" state surfaced as disabled (delete-only). Kept here so
-// the form never drifts from the ListingStatus value set.
-export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
-  { value: "draft", label: "Draft" },
-  { value: "published", label: "Published" },
-  { value: "sold", label: "Sold" },
-  { value: "archived", label: "Archived", disabled: true },
-]
-
-export interface Category {
+interface RawListingRow {
   id: string
-  name: string
-  slug: string
-  parent_id: string | null
-}
-
-export interface ListingImage {
-  id: string
-  listing_id: string
-  image_url: string
-  display_order: number
-  alt_text: string | null
-}
-
-export interface Listing {
-  id: string
-  seller_id: string
-  category_id: string | null
   title: string
-  description: string | null
   price: number
   condition: Condition
-  negotiable: boolean
   city: string | null
-  sub_city: string | null
-  address: string | null
-  status: ListingStatus
-  view_count: number
-  favorite_count: number
   published_at: string
-  created_at: string
-  updated_at: string
+  seller: BrowseSeller[] | null
+  images: ListingImage[] | null
 }
-
-export interface ListingWithRelations {
-  listing: Listing
-  images: ListingImage[]
-  category: Category | null
-  seller: {
-    id: string
-    full_name: string | null
-    avatar_url: string | null
-    role: string | null
-    trust_score: number | null
-  } | null
-}
-
-export interface ListingPayload {
-  title: string
-  description?: string
-  price: number
-  condition: Condition
-  categoryId?: string
-  city: string
-  subCity?: string
-  address?: string
-  negotiable: boolean
-  photos?: File[]
-}
-
-export interface ListingEditPayload {
-  id: string
-  title: string
-  description?: string
-  price: number
-  condition: Condition
-  categoryId?: string
-  city: string
-  subCity?: string
-  address?: string
-  negotiable: boolean
-  status?: ListingStatus
-}
-
-export const LISTING_COLUMNS =
-  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
-
-// ---- Helpers ----
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-export function isValidUuid(id: string): boolean {
-  return UUID_RE.test(id)
-}
-
-// Image validation primitives (detectImageMime, ALLOWED_IMAGE_MIME,
-// MAX_IMAGE_BYTES, EXT_BY_MIME) live in the Media object module (lib/media),
-// imported at the top of this file.
 
 // ---- Reads ----
 
@@ -211,82 +134,6 @@ export async function fetchSellerListings(sellerId: string): Promise<Listing[]> 
   return data as Listing[]
 }
 
-export const PAGE_SIZE = 12
-// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
-// windowed: each request fetches PAGE_SIZE rows and we never page past the
-// 1000-row ceiling (T05, NFR-COMP-003).
-export const BROWSE_LIMIT_MAX = 1000
-
-export interface BrowseSeller {
-  id: string
-  full_name: string | null
-  avatar_url: string | null
-  role: string | null
-  trust_score: number | null
-}
-
-export interface BrowseListing {
-  id: string
-  title: string
-  price: number
-  condition: Condition
-  city: string | null
-  published_at: string
-  image_url: string | null
-  image_count: number
-  seller: BrowseSeller | null
-}
-
-interface RawListingRow {
-  id: string
-  title: string
-  price: number
-  condition: Condition
-  city: string | null
-  published_at: string
-  seller: BrowseSeller[] | null
-  images: ListingImage[] | null
-}
-
-export interface FormatPriceOptions {
-  maxFractionDigits?: number
-}
-
-export function formatPrice(
-  price: number | string,
-  opts: FormatPriceOptions = {}
-): string {
-  const n = typeof price === "number" ? price : Number(price)
-  if (Number.isNaN(n)) return "ETB —"
-  const maxFractionDigits = opts.maxFractionDigits ?? 0
-  try {
-    return new Intl.NumberFormat("en-ET", {
-      style: "currency",
-      currency: "ETB",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: maxFractionDigits,
-    }).format(n)
-  } catch {
-    return `ETB ${Math.round(n)}`
-  }
-}
-
-const CONDITION_LABELS: Record<Condition, string> = {
-  "Brand New": "Brand new",
-  "Lightly Used": "Lightly used",
-  Fair: "Fair",
-}
-
-export function formatCondition(condition: Condition): string {
-  return CONDITION_LABELS[condition] ?? condition
-}
-
-export const CONDITION_COLORS: Record<Condition, string> = {
-  "Brand New": "bg-green-100 text-green-800",
-  "Lightly Used": "bg-blue-100 text-blue-800",
-  Fair: "bg-amber-100 text-amber-800",
-}
-
 // Public, paginated browse of published listings (anon-readable via RLS).
 export async function fetchListings(opts: {
   limit?: number
@@ -368,6 +215,99 @@ export async function fetchListings(opts: {
 
   const hasMore = typeof count === "number" ? offset + listings.length < count : false
   return { listings, count, hasMore, error: null }
+}
+
+export interface SearchOptions {
+  q?: string
+  categorySlug?: string
+  minPrice?: number
+  maxPrice?: number
+  condition?: Condition
+  city?: string
+  sort?: SearchSort
+  offset?: number
+}
+
+export interface SearchResult {
+  listings: BrowseListing[]
+  totalCount: number
+  hasMore: boolean
+  error: string | null
+}
+
+/** Row shape returned by the `search_listings` RPC (see migrations). */
+interface SearchListingRow {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  city: string | null
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller_id: string | null
+  seller_full_name: string | null
+  seller_avatar_url: string | null
+  seller_role: string | null
+  seller_trust_score: number | null
+  total_count: number
+}
+
+// Keyword + filters + sort + count in one round trip via the search_listings
+// RPC (T06, Search Service). Paging mirrors fetchListings: one PAGE_SIZE window
+// that never crosses the 1000-row ceiling, with `hasMore` derived from the
+// exact count the RPC returns alongside the slice.
+export async function searchListings(
+  opts: SearchOptions = {}
+): Promise<SearchResult> {
+  const supabase = await createClient()
+  const offset = Math.min(Math.max(opts.offset ?? 0, 0), BROWSE_LIMIT_MAX - 1)
+
+  const { data, error } = await supabase.rpc("search_listings", {
+    p_query: opts.q || null,
+    p_category_slug: opts.categorySlug || null,
+    p_min_price: opts.minPrice ?? null,
+    p_max_price: opts.maxPrice ?? null,
+    p_condition: opts.condition ?? null,
+    p_city: opts.city || null,
+    p_sort: opts.sort ?? "newest",
+    p_limit: PAGE_SIZE,
+    p_offset: offset,
+  })
+
+  if (error) {
+    console.error("searchListings:", error.message)
+    return { listings: [], totalCount: 0, hasMore: false, error: error.message }
+  }
+
+  const rows = (data ?? []) as SearchListingRow[]
+  const listings: BrowseListing[] = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    price: row.price,
+    condition: row.condition,
+    city: row.city,
+    published_at: row.published_at,
+    image_url: row.image_url,
+    image_count: row.image_count,
+    seller: row.seller_id
+      ? {
+          id: row.seller_id,
+          full_name: row.seller_full_name,
+          avatar_url: row.seller_avatar_url,
+          role: row.seller_role,
+          trust_score: row.seller_trust_score,
+        }
+      : null,
+  }))
+
+  const totalCount = rows.length > 0 ? rows[0].total_count : 0
+  return {
+    listings,
+    totalCount,
+    hasMore: offset + listings.length < totalCount,
+    error: null,
+  }
 }
 
 // ---- Writes (called by server actions; DB access centralized here, §17) ----

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -151,18 +151,78 @@ export async function fetchListing(
   }
 }
 
-export async function fetchSellerListings(sellerId: string): Promise<Listing[]> {
+// A seller's own listing as shown on the dashboard manager: the full Listing
+// plus the cover image for the thumbnail. Soft-deleted rows are filtered out so
+// an archived listing disappears from the seller's manager once deleted.
+export interface SellerListingRow extends Listing {
+  cover_image_url: string | null
+}
+
+export async function fetchSellerListings(
+  sellerId: string
+): Promise<SellerListingRow[]> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from("listings")
-    .select(LISTING_COLUMNS)
+    .select(
+      `${LISTING_COLUMNS},
+       images:listing_images(image_url, display_order)`
+    )
     .eq("seller_id", sellerId)
+    .is("deleted_at", null)
     .order("created_at", { ascending: false })
+
   if (error) {
     console.error("fetchSellerListings:", error.message)
     return []
   }
-  return data as Listing[]
+
+  return (data as unknown as RawSellerListingRow[] | null ?? []).map((row) => {
+    const cover =
+      [...(row.images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]
+        ?.image_url ?? null
+    return {
+      id: row.id,
+      seller_id: row.seller_id,
+      category_id: row.category_id,
+      title: row.title,
+      description: row.description,
+      price: Number(row.price),
+      condition: row.condition,
+      negotiable: row.negotiable,
+      city: row.city,
+      sub_city: row.sub_city,
+      address: row.address,
+      status: row.status,
+      view_count: row.view_count,
+      favorite_count: row.favorite_count,
+      published_at: row.published_at,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      cover_image_url: cover,
+    }
+  })
+}
+
+interface RawSellerListingRow {
+  id: string
+  seller_id: string
+  category_id: string | null
+  title: string
+  description: string | null
+  price: number | string
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  address: string | null
+  status: ListingStatus
+  view_count: number
+  favorite_count: number
+  published_at: string
+  created_at: string
+  updated_at: string
+  images: { image_url: string; display_order: number }[] | null
 }
 
 // Public, paginated browse of published listings (anon-readable via RLS).

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -48,14 +48,21 @@ export interface RawListingRow {
   images: ListingImage[] | null
 }
 
+// Shared cover-pick: the lowest display_order image is the listing's cover.
+// One rule for every listing read shape that renders a thumbnail (browse feed,
+// favorites feed, seller dashboard) so "which image is the cover" never forks.
+function pickCoverImage(
+  images: { image_url: string; display_order: number }[] | null
+): string | null {
+  return (
+    [...(images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]
+      ?.image_url ?? null
+  )
+}
+
 // Shared row mapper for browse-shaped listing selects. Used by the public
 // browse feed and the favorites feed so both render cards identically.
 export function mapBrowseListing(l: RawListingRow): BrowseListing {
-  const images = l.images ?? []
-  const cover =
-    [...images]
-      .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
-    null
   const seller = l.seller?.[0] ?? null
   return {
     id: l.id,
@@ -64,8 +71,8 @@ export function mapBrowseListing(l: RawListingRow): BrowseListing {
     condition: l.condition,
     city: l.city,
     published_at: l.published_at,
-    image_url: cover,
-    image_count: images.length,
+    image_url: pickCoverImage(l.images),
+    image_count: (l.images ?? []).length,
     seller: seller
       ? {
           id: seller.id,
@@ -112,6 +119,7 @@ export async function fetchListing(
     .from("listings")
     .select(LISTING_COLUMNS)
     .eq("id", id)
+    .is("deleted_at", null)
     .maybeSingle()
   if (!listing) return null
 
@@ -158,6 +166,13 @@ export interface SellerListingRow extends Listing {
   cover_image_url: string | null
 }
 
+// PostgREST returns numeric as string; the row type is derived from Listing so
+// the mapper cannot drift from the contract (price is the only shape change).
+type RawSellerListingRow = Omit<Listing, "price"> & {
+  price: number | string
+  images: { image_url: string; display_order: number }[] | null
+}
+
 export async function fetchSellerListings(
   sellerId: string
 ): Promise<SellerListingRow[]> {
@@ -178,51 +193,13 @@ export async function fetchSellerListings(
   }
 
   return (data as unknown as RawSellerListingRow[] | null ?? []).map((row) => {
-    const cover =
-      [...(row.images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]
-        ?.image_url ?? null
+    const { images, ...rest } = row
     return {
-      id: row.id,
-      seller_id: row.seller_id,
-      category_id: row.category_id,
-      title: row.title,
-      description: row.description,
-      price: Number(row.price),
-      condition: row.condition,
-      negotiable: row.negotiable,
-      city: row.city,
-      sub_city: row.sub_city,
-      address: row.address,
-      status: row.status,
-      view_count: row.view_count,
-      favorite_count: row.favorite_count,
-      published_at: row.published_at,
-      created_at: row.created_at,
-      updated_at: row.updated_at,
-      cover_image_url: cover,
+      ...rest,
+      price: Number(rest.price),
+      cover_image_url: pickCoverImage(images),
     }
   })
-}
-
-interface RawSellerListingRow {
-  id: string
-  seller_id: string
-  category_id: string | null
-  title: string
-  description: string | null
-  price: number | string
-  condition: Condition
-  negotiable: boolean
-  city: string | null
-  sub_city: string | null
-  address: string | null
-  status: ListingStatus
-  view_count: number
-  favorite_count: number
-  published_at: string
-  created_at: string
-  updated_at: string
-  images: { image_url: string; display_order: number }[] | null
 }
 
 // Public, paginated browse of published listings (anon-readable via RLS).

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -29,6 +29,7 @@ import type {
   ListingWithRelations,
 } from "./listings/constants"
 import type { SearchSort } from "@/lib/search"
+import { MAX_PAGING_OFFSET } from "@/lib/pagination"
 
 // Re-export the pure value objects so imports from "@/lib/listings" keep
 // resolving. Definitions live in ./listings/constants (server-free).
@@ -213,7 +214,10 @@ export async function fetchListings(opts: {
     }
   )
 
-  const hasMore = typeof count === "number" ? offset + listings.length < count : false
+  const hasMore =
+    typeof count === "number"
+      ? offset + listings.length < count && offset + listings.length < BROWSE_LIMIT_MAX
+      : false
   return { listings, count, hasMore, error: null }
 }
 
@@ -230,7 +234,7 @@ export interface SearchOptions {
 
 export interface SearchResult {
   listings: BrowseListing[]
-  totalCount: number
+  count: number
   hasMore: boolean
   error: string | null
 }
@@ -261,7 +265,7 @@ export async function searchListings(
   opts: SearchOptions = {}
 ): Promise<SearchResult> {
   const supabase = await createClient()
-  const offset = Math.min(Math.max(opts.offset ?? 0, 0), BROWSE_LIMIT_MAX - 1)
+  const offset = Math.min(Math.max(opts.offset ?? 0, 0), MAX_PAGING_OFFSET)
 
   const { data, error } = await supabase.rpc("search_listings", {
     p_query: opts.q || null,
@@ -277,7 +281,7 @@ export async function searchListings(
 
   if (error) {
     console.error("searchListings:", error.message)
-    return { listings: [], totalCount: 0, hasMore: false, error: error.message }
+    return { listings: [], count: 0, hasMore: false, error: error.message }
   }
 
   const rows = (data ?? []) as SearchListingRow[]
@@ -301,11 +305,12 @@ export async function searchListings(
       : null,
   }))
 
-  const totalCount = rows.length > 0 ? rows[0].total_count : 0
+  const count = rows.length > 0 ? rows[0].total_count : 0
   return {
     listings,
-    totalCount,
-    hasMore: offset + listings.length < totalCount,
+    count,
+    hasMore:
+      offset + listings.length < count && offset + listings.length < BROWSE_LIMIT_MAX,
     error: null,
   }
 }

--- a/app/lib/listings.ts
+++ b/app/lib/listings.ts
@@ -37,7 +37,7 @@ export * from "./listings/constants"
 
 // ---- Internal row shape (server-only; not part of the public value object) ----
 
-interface RawListingRow {
+export interface RawListingRow {
   id: string
   title: string
   price: number
@@ -46,6 +46,36 @@ interface RawListingRow {
   published_at: string
   seller: BrowseSeller[] | null
   images: ListingImage[] | null
+}
+
+// Shared row mapper for browse-shaped listing selects. Used by the public
+// browse feed and the favorites feed so both render cards identically.
+export function mapBrowseListing(l: RawListingRow): BrowseListing {
+  const images = l.images ?? []
+  const cover =
+    [...images]
+      .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
+    null
+  const seller = l.seller?.[0] ?? null
+  return {
+    id: l.id,
+    title: l.title,
+    price: l.price,
+    condition: l.condition,
+    city: l.city,
+    published_at: l.published_at,
+    image_url: cover,
+    image_count: images.length,
+    seller: seller
+      ? {
+          id: seller.id,
+          full_name: seller.full_name,
+          avatar_url: seller.avatar_url,
+          role: seller.role,
+          trust_score: seller.trust_score,
+        }
+      : null,
+  }
 }
 
 // ---- Reads ----
@@ -185,33 +215,7 @@ export async function fetchListings(opts: {
   }
 
   const listings: BrowseListing[] = (data as RawListingRow[] | null ?? []).map(
-    (l) => {
-      const images = l.images ?? []
-      const cover =
-        [...images]
-          .sort((a, b) => a.display_order - b.display_order)[0]?.image_url ??
-        null
-      const seller = l.seller?.[0] ?? null
-      return {
-        id: l.id,
-        title: l.title,
-        price: l.price,
-        condition: l.condition,
-        city: l.city,
-        published_at: l.published_at,
-        image_url: cover,
-        image_count: images.length,
-        seller: seller
-          ? {
-              id: seller.id,
-              full_name: seller.full_name,
-              avatar_url: seller.avatar_url,
-              role: seller.role,
-              trust_score: seller.trust_score,
-            }
-          : null,
-      }
-    }
+    mapBrowseListing
   )
 
   const hasMore =

--- a/app/lib/listings/constants.ts
+++ b/app/lib/listings/constants.ts
@@ -28,6 +28,22 @@ export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
   { value: "archived", label: "Archived", disabled: true },
 ]
 
+export const LISTING_STATUS_LABELS: Record<ListingStatus, string> = {
+  draft: "Draft",
+  published: "Published",
+  sold: "Sold",
+  archived: "Archived",
+}
+
+// Mirrors the offer-badge palette: live/published is green, sold is blue,
+// archived (soft-deleted) is red, draft is neutral.
+export const LISTING_STATUS_COLORS: Record<ListingStatus, string> = {
+  draft: "bg-muted text-muted-foreground",
+  published: "bg-green-100 text-green-800",
+  sold: "bg-blue-100 text-blue-800",
+  archived: "bg-red-100 text-red-800",
+}
+
 export interface Category {
   id: string
   name: string

--- a/app/lib/listings/constants.ts
+++ b/app/lib/listings/constants.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure listing domain value objects.
+ *
+ * Framework-agnostic constants, types and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/listings` re-exports everything
+ * here (`export *`) so existing server-side imports keep resolving.
+ */
+
+export const CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+export const STATUSES = ["draft", "published", "sold"] as const // "archived" is delete-only
+export const MAX_IMAGES = 10
+
+export type Condition = (typeof CONDITIONS)[number]
+export type ListingStatus = (typeof STATUSES)[number] | "archived"
+
+export interface ListingStatusOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export const STATUSES_FOR_DISPLAY: ListingStatusOption[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Published" },
+  { value: "sold", label: "Sold" },
+  { value: "archived", label: "Archived", disabled: true },
+]
+
+export interface Category {
+  id: string
+  name: string
+  slug: string
+  parent_id: string | null
+}
+
+export interface ListingImage {
+  id: string
+  listing_id: string
+  image_url: string
+  display_order: number
+  alt_text: string | null
+}
+
+export interface Listing {
+  id: string
+  seller_id: string
+  category_id: string | null
+  title: string
+  description: string | null
+  price: number
+  condition: Condition
+  negotiable: boolean
+  city: string | null
+  sub_city: string | null
+  address: string | null
+  status: ListingStatus
+  view_count: number
+  favorite_count: number
+  published_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ListingWithRelations {
+  listing: Listing
+  images: ListingImage[]
+  category: Category | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+    role: string | null
+    trust_score: number | null
+  } | null
+}
+
+export interface ListingPayload {
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  photos?: File[]
+}
+
+export interface ListingEditPayload {
+  id: string
+  title: string
+  description?: string
+  price: number
+  condition: Condition
+  categoryId?: string
+  city: string
+  subCity?: string
+  address?: string
+  negotiable: boolean
+  status?: ListingStatus
+}
+
+export const LISTING_COLUMNS =
+  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+
+export const PAGE_SIZE = 12
+// Supabase/PostgREST caps a single select result set at 1000 rows. Browse is
+// windowed: each request fetches PAGE_SIZE rows and we never page past the
+// 1000-row ceiling (T05, NFR-COMP-003).
+export const BROWSE_LIMIT_MAX = 1000
+
+export interface BrowseSeller {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+export interface BrowseListing {
+  id: string
+  title: string
+  price: number
+  condition: Condition
+  city: string | null
+  published_at: string
+  image_url: string | null
+  image_count: number
+  seller: BrowseSeller | null
+}
+
+export interface FormatPriceOptions {
+  maxFractionDigits?: number
+}
+
+export function formatPrice(
+  price: number | string,
+  opts: FormatPriceOptions = {}
+): string {
+  const n = typeof price === "number" ? price : Number(price)
+  if (Number.isNaN(n)) return "ETB \u2014"
+  const maxFractionDigits = opts.maxFractionDigits ?? 0
+  try {
+    return new Intl.NumberFormat("en-ET", {
+      style: "currency",
+      currency: "ETB",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: maxFractionDigits,
+    }).format(n)
+  } catch {
+    return `ETB ${Math.round(n)}`
+  }
+}
+
+const CONDITION_LABELS: Record<Condition, string> = {
+  "Brand New": "Brand new",
+  "Lightly Used": "Lightly used",
+  "Fair": "Fair",
+}
+
+export function formatCondition(condition: Condition): string {
+  return CONDITION_LABELS[condition] ?? condition
+}
+
+export const CONDITION_COLORS: Record<Condition, string> = {
+  "Brand New": "bg-green-100 text-green-800",
+  "Lightly Used": "bg-blue-100 text-blue-800",
+  "Fair": "bg-amber-100 text-amber-800",
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isValidUuid(id: string): boolean {
+  return UUID_RE.test(id)
+}

--- a/app/lib/nav.ts
+++ b/app/lib/nav.ts
@@ -3,7 +3,7 @@ import {
   SearchIcon,
   PlusIcon,
   HeartIcon,
-  UserIcon,
+  HandshakeIcon,
   type LucideIcon,
 } from "lucide-react"
 
@@ -15,21 +15,22 @@ export type NavItem = {
 
 export const siteName = "VinTech Marketplace"
 
+// Component standards §12 caps primary destinations at 5. Dashboard and
+// Profile live in the account menu (components/auth/user-menu.tsx) instead.
 export const primaryNav: NavItem[] = [
   { title: "Home", href: "/" },
   { title: "Browse", href: "/search" },
   { title: "Sell", href: "/sell" },
+  { title: "Offers", href: "/offers" },
   { title: "Favorites", href: "/favorites" },
-  { title: "Dashboard", href: "/dashboard" },
-  { title: "Profile", href: "/profile" },
 ]
 
 export const mobileNav: NavItem[] = [
   { title: "Home", href: "/", icon: HomeIcon },
   { title: "Search", href: "/search", icon: SearchIcon },
   { title: "Sell", href: "/sell", icon: PlusIcon },
+  { title: "Offers", href: "/offers", icon: HandshakeIcon },
   { title: "Favorites", href: "/favorites", icon: HeartIcon },
-  { title: "Profile", href: "/profile", icon: UserIcon },
 ]
 
 export const footerNav: NavItem[] = [

--- a/app/lib/offers.ts
+++ b/app/lib/offers.ts
@@ -1,0 +1,206 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+import {
+  isValidUuid,
+  mapBrowseListing,
+  type BrowseListing,
+  type RawListingRow,
+} from "@/lib/listings"
+import type { OfferStatus } from "@/lib/offers/constants"
+
+export * from "@/lib/offers/constants"
+
+// ---- Reads ----
+
+export interface BuyerOfferRow {
+  id: string
+  listing_id: string
+  amount: number
+  message: string | null
+  status: OfferStatus
+  created_at: string
+  listing: BrowseListing | null
+}
+
+export interface SellerOfferRow extends BuyerOfferRow {
+  buyer: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+  } | null
+}
+
+// A join row from the raw PostgREST shape. The embedded `listing` may lack a
+// `seller` join (buyer dashboard never asks for it); mapBrowseListing treats a
+// missing seller as null, so the cast is safe.
+type RawOfferListingRow = Omit<RawListingRow, "seller"> & {
+  seller?: RawListingRow["seller"]
+}
+
+interface RawOfferRow {
+  id: string
+  listing_id: string
+  amount: number
+  message: string | null
+  status: OfferStatus
+  created_at: string
+}
+
+function mapOfferListing(
+  listing: RawOfferListingRow | null
+): BrowseListing | null {
+  return listing ? mapBrowseListing(listing as RawListingRow) : null
+}
+
+function mapRawOfferRow(
+  row: RawOfferRow & {
+    listing: RawOfferListingRow | null
+    buyer?: { id: string; full_name: string | null; avatar_url: string | null } | null
+  },
+  withBuyer: boolean
+): SellerOfferRow {
+  return {
+    id: row.id,
+    listing_id: row.listing_id,
+    amount: row.amount,
+    message: row.message,
+    status: row.status,
+    created_at: row.created_at,
+    listing: mapOfferListing(row.listing),
+    buyer: withBuyer ? (row.buyer ?? null) : null,
+  }
+}
+
+const OFFER_COLUMNS = "id, listing_id, amount, message, status, created_at"
+
+// The buyer's offer history, newest first. RLS keeps this to the user's own
+// offers; the listing join drops rows for listings the buyer can no longer see
+// (deleted, unpublished, or sold without an accepted offer of theirs).
+export async function fetchBuyerOffers(userId: string): Promise<BuyerOfferRow[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("offers")
+    .select(
+      `${OFFER_COLUMNS},
+       listing:listings(id, title, price, condition, city, published_at,
+         images:listing_images(id, image_url, display_order))`
+    )
+    .eq("buyer_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchBuyerOffers:", error.message)
+    return []
+  }
+
+  const rows = (data ?? []) as unknown as {
+    id: string
+    listing_id: string
+    amount: number
+    message: string | null
+    status: OfferStatus
+    created_at: string
+    listing: RawOfferListingRow | null
+  }[]
+
+  return rows.map((row) => mapRawOfferRow(row, false))
+}
+
+// The seller's incoming offers, newest first. RLS restricts this to offers on
+// the seller's own listings; the explicit seller filter is a query hint that
+// keeps PostgREST from scanning the whole table. The buyer profile join names
+// the person behind each offer.
+export async function fetchSellerOffers(userId: string): Promise<SellerOfferRow[]> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("offers")
+    .select(
+      `${OFFER_COLUMNS},
+       listing:listings(id, title, price, condition, city, published_at,
+         seller:profiles(id, full_name, avatar_url, role, trust_score),
+         images:listing_images(id, image_url, display_order)),
+       buyer:profiles(id, full_name, avatar_url)`
+    )
+    .eq("listing.seller_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchSellerOffers:", error.message)
+    return []
+  }
+
+  const rows = (data ?? []) as unknown as {
+    id: string
+    listing_id: string
+    amount: number
+    message: string | null
+    status: OfferStatus
+    created_at: string
+    listing: RawOfferListingRow | null
+    buyer: { id: string; full_name: string | null; avatar_url: string | null } | null
+  }[]
+
+  return rows.map((row) => mapRawOfferRow(row, true))
+}
+
+// ---- Writes ----
+
+export interface OfferResult {
+  ok: boolean
+  error: string | null
+}
+
+// A new offer. RLS enforces the published + not-own-listing rules (INV-005,
+// ListingMarkedSold); the explicit uuid gate keeps junk ids from reaching the DB.
+export async function submitOfferRow(input: {
+  userId: string
+  listingId: string
+  amount: number
+  message: string | null
+}): Promise<OfferResult> {
+  if (!isValidUuid(input.listingId)) {
+    return { ok: false, error: "invalid listing id" }
+  }
+  const supabase = await createClient()
+  const { error } = await supabase.from("offers").insert({
+    listing_id: input.listingId,
+    buyer_id: input.userId,
+    amount: input.amount,
+    message: input.message?.trim() || null,
+  })
+  if (error) {
+    console.error("submitOfferRow:", error.message)
+    return { ok: false, error: error.message }
+  }
+  return { ok: true, error: null }
+}
+
+async function runOfferRpc(
+  fn: "accept_offer" | "decline_offer" | "counter_offer",
+  args: Record<string, string | number>
+): Promise<OfferResult> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc(fn, args)
+  if (error) {
+    console.error(`${fn}:`, error.message)
+    return { ok: false, error: error.message }
+  }
+  const result = (data ?? {}) as { ok?: boolean; error?: string | null }
+  return { ok: result.ok === true, error: result.error ?? null }
+}
+
+export function acceptOfferRow(offerId: string): Promise<OfferResult> {
+  return runOfferRpc("accept_offer", { p_offer_id: offerId })
+}
+
+export function declineOfferRow(offerId: string): Promise<OfferResult> {
+  return runOfferRpc("decline_offer", { p_offer_id: offerId })
+}
+
+export function counterOfferRow(
+  offerId: string,
+  amount: number
+): Promise<OfferResult> {
+  return runOfferRpc("counter_offer", { p_offer_id: offerId, p_amount: amount })
+}

--- a/app/lib/offers.ts
+++ b/app/lib/offers.ts
@@ -144,6 +144,24 @@ export async function fetchSellerOffers(userId: string): Promise<SellerOfferRow[
   return rows.map((row) => mapRawOfferRow(row, true))
 }
 
+// Open offers (pending or countered) on the seller's listings, for the dashboard
+// summary. RLS scopes the count to the caller's own listings; the explicit
+// seller filter is the same PostgREST hint used by fetchSellerOffers.
+export async function countIncomingOffers(userId: string): Promise<number> {
+  const supabase = await createClient()
+  const { count, error } = await supabase
+    .from("offers")
+    .select("id", { count: "exact", head: true })
+    .eq("listing.seller_id", userId)
+    .in("status", ["pending", "countered"])
+
+  if (error) {
+    console.error("countIncomingOffers:", error.message)
+    return 0
+  }
+  return count ?? 0
+}
+
 // ---- Writes ----
 
 export interface OfferResult {

--- a/app/lib/offers.ts
+++ b/app/lib/offers.ts
@@ -7,7 +7,10 @@ import {
   type BrowseListing,
   type RawListingRow,
 } from "@/lib/listings"
-import type { OfferStatus } from "@/lib/offers/constants"
+import {
+  OPEN_OFFER_STATUSES,
+  type OfferStatus,
+} from "@/lib/offers/constants"
 
 export * from "@/lib/offers/constants"
 
@@ -153,7 +156,7 @@ export async function countIncomingOffers(userId: string): Promise<number> {
     .from("offers")
     .select("id", { count: "exact", head: true })
     .eq("listing.seller_id", userId)
-    .in("status", ["pending", "countered"])
+    .in("status", OPEN_OFFER_STATUSES)
 
   if (error) {
     console.error("countIncomingOffers:", error.message)

--- a/app/lib/offers/constants.ts
+++ b/app/lib/offers/constants.ts
@@ -12,6 +12,10 @@ export const OFFER_STATUSES = ["pending", "countered", "accepted", "declined"] a
 
 export type OfferStatus = (typeof OFFER_STATUSES)[number]
 
+// Statuses that still need a reply from the seller. The dashboard's open-offers
+// count uses these; accepted/declined are terminal for the seller.
+export const OPEN_OFFER_STATUSES: OfferStatus[] = ["pending", "countered"]
+
 export const OFFER_STATUS_LABELS: Record<OfferStatus, string> = {
   pending: "Pending",
   countered: "Countered",

--- a/app/lib/offers/constants.ts
+++ b/app/lib/offers/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure offers domain value objects.
+ *
+ * Framework-agnostic constants, types and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/offers` re-exports everything
+ * here (`export *`) so existing server-side imports keep resolving.
+ */
+
+export const OFFER_STATUSES = ["pending", "countered", "accepted", "declined"] as const
+
+export type OfferStatus = (typeof OFFER_STATUSES)[number]
+
+export const OFFER_STATUS_LABELS: Record<OfferStatus, string> = {
+  pending: "Pending",
+  countered: "Countered",
+  accepted: "Accepted",
+  declined: "Declined",
+}
+
+export const OFFER_STATUS_COLORS: Record<OfferStatus, string> = {
+  pending: "bg-amber-100 text-amber-800",
+  countered: "bg-blue-100 text-blue-800",
+  accepted: "bg-green-100 text-green-800",
+  declined: "bg-red-100 text-red-800",
+}
+
+// App-side ceiling, enforced at the DB write boundary by the offers_amount_cap
+// check (create_offers migration) and by counter_offer — a counter cannot
+// exceed the cap any more than a new offer can. Message cap mirrors the
+// offers_message_length check.
+export const OFFER_AMOUNT_MAX = 100_000_000
+export const OFFER_MESSAGE_MAX = 500
+
+/**
+ * The login redirect target for the "Make an offer" CTA. Login honors a
+ * `?next=` query param (see app/login/page.tsx), so a signed-out visitor who
+ * taps the CTA lands back on the exact listing after signing in. Kept here so
+ * the Client Component needs no URL-building logic.
+ */
+export function buildLoginUrl(pathname: string): string {
+  return `/login?next=${encodeURIComponent(pathname)}`
+}

--- a/app/lib/pagination.ts
+++ b/app/lib/pagination.ts
@@ -1,0 +1,24 @@
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+
+// The highest offset a windowed page may start from. Browse and search both
+// fetch PAGE_SIZE rows per request and never page past the PostgREST 1000-row
+// ceiling, so a page that starts at or beyond this offset would run past the
+// end of the window (T05/T06, NFR-COMP-003).
+export const MAX_PAGING_OFFSET = BROWSE_LIMIT_MAX - PAGE_SIZE
+
+/** Parse + clamp an untrusted offset from the URL into the paging window.
+ *
+ * Shared by `lib/browse` and `lib/search` so the two read seams can never
+ * drift apart on what a valid offset looks like. The clamp guarantees
+ * `offset + PAGE_SIZE <= BROWSE_LIMIT_MAX`, which is what makes "Load more"
+ * terminate instead of re-clamping to the same page forever. (§15.) */
+export function parseOffset(raw: string | undefined): number {
+  const parsed = Number(raw ?? "")
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.min(parsed, MAX_PAGING_OFFSET)
+    : 0
+}
+
+export function nextOffset(offset: number): number {
+  return offset + PAGE_SIZE
+}

--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -1,14 +1,12 @@
-import {
-  BROWSE_LIMIT_MAX,
-  CONDITIONS,
-  PAGE_SIZE,
-  type Condition,
-} from "@/lib/listings/constants"
+import { CONDITIONS, type Condition } from "@/lib/listings/constants"
+import { nextOffset, parseOffset } from "@/lib/pagination"
+
+export { nextOffset }
 
 export const SEARCH_SORTS = ["newest", "oldest", "price_asc", "price_desc"] as const
 export type SearchSort = (typeof SEARCH_SORTS)[number]
 
-export interface SearchFilters {
+export interface SearchQuery {
   q: string
   categorySlug: string | undefined
   minPrice: number | undefined
@@ -36,7 +34,7 @@ export function parseSearchParams(params: {
   city?: SearchParamValue
   sort?: SearchParamValue
   offset?: SearchParamValue
-}): SearchFilters {
+}): SearchQuery {
   const single = (v: SearchParamValue): string | undefined =>
     typeof v === "string" ? v : undefined
 
@@ -57,14 +55,16 @@ export function parseSearchParams(params: {
     ? (rawSort as SearchSort)
     : "newest"
 
-  const rawOffset = single(params.offset) ?? ""
-  const parsedOffset = Number(rawOffset)
-  const offset =
-    Number.isFinite(parsedOffset) && parsedOffset > 0
-      ? Math.min(parsedOffset, BROWSE_LIMIT_MAX - 1)
-      : 0
-
-  return { q, categorySlug, minPrice, maxPrice, condition, city, sort, offset }
+  return {
+    q,
+    categorySlug,
+    minPrice,
+    maxPrice,
+    condition,
+    city,
+    sort,
+    offset: parseOffset(single(params.offset)),
+  }
 }
 
 function parsePrice(v: string | undefined): number | undefined {
@@ -73,21 +73,17 @@ function parsePrice(v: string | undefined): number | undefined {
   return Number.isFinite(n) && n >= 0 ? n : undefined
 }
 
-/** Build the search URL from a filters object, omitting empty/zero params. */
-export function buildSearchUrl(filters: SearchFilters): string {
+/** Build the search URL from a query object, omitting empty/zero params. */
+export function buildSearchUrl(query: SearchQuery): string {
   const params = new URLSearchParams()
-  if (filters.q) params.set("q", filters.q)
-  if (filters.categorySlug) params.set("category", filters.categorySlug)
-  if (filters.minPrice !== undefined) params.set("min", String(filters.minPrice))
-  if (filters.maxPrice !== undefined) params.set("max", String(filters.maxPrice))
-  if (filters.condition) params.set("condition", filters.condition)
-  if (filters.city) params.set("city", filters.city)
-  if (filters.sort !== "newest") params.set("sort", filters.sort)
-  if (filters.offset) params.set("offset", String(filters.offset))
+  if (query.q) params.set("q", query.q)
+  if (query.categorySlug) params.set("category", query.categorySlug)
+  if (query.minPrice !== undefined) params.set("min", String(query.minPrice))
+  if (query.maxPrice !== undefined) params.set("max", String(query.maxPrice))
+  if (query.condition) params.set("condition", query.condition)
+  if (query.city) params.set("city", query.city)
+  if (query.sort !== "newest") params.set("sort", query.sort)
+  if (query.offset) params.set("offset", String(query.offset))
   const qs = params.toString()
   return qs ? `/search?${qs}` : "/search"
-}
-
-export function nextOffset(offset: number): number {
-  return offset + PAGE_SIZE
 }

--- a/app/lib/search.ts
+++ b/app/lib/search.ts
@@ -1,0 +1,93 @@
+import {
+  BROWSE_LIMIT_MAX,
+  CONDITIONS,
+  PAGE_SIZE,
+  type Condition,
+} from "@/lib/listings/constants"
+
+export const SEARCH_SORTS = ["newest", "oldest", "price_asc", "price_desc"] as const
+export type SearchSort = (typeof SEARCH_SORTS)[number]
+
+export interface SearchFilters {
+  q: string
+  categorySlug: string | undefined
+  minPrice: number | undefined
+  maxPrice: number | undefined
+  condition: Condition | undefined
+  city: string
+  sort: SearchSort
+  offset: number
+}
+
+type SearchParamValue = string | string[] | undefined
+
+/** Parse + clamp the search/filter query from untrusted URL search params.
+ *
+ * Mirrors `lib/browse`: every input is validated so a hand-edited URL can never
+ * inject an invalid sort/condition/price or an out-of-window offset. The parsed
+ * shape is the single source of truth for the server page, the client filter
+ * form and "Load more". (§15: validate external input.) */
+export function parseSearchParams(params: {
+  q?: SearchParamValue
+  category?: SearchParamValue
+  min?: SearchParamValue
+  max?: SearchParamValue
+  condition?: SearchParamValue
+  city?: SearchParamValue
+  sort?: SearchParamValue
+  offset?: SearchParamValue
+}): SearchFilters {
+  const single = (v: SearchParamValue): string | undefined =>
+    typeof v === "string" ? v : undefined
+
+  const q = (single(params.q) ?? "").trim()
+  const categorySlug = single(params.category)?.trim() || undefined
+  const minPrice = parsePrice(single(params.min))
+  const maxPrice = parsePrice(single(params.max))
+
+  const rawCondition = single(params.condition)
+  const condition = (CONDITIONS as readonly string[]).includes(rawCondition ?? "")
+    ? (rawCondition as Condition)
+    : undefined
+
+  const city = (single(params.city) ?? "").trim()
+
+  const rawSort = single(params.sort) ?? ""
+  const sort = (SEARCH_SORTS as readonly string[]).includes(rawSort)
+    ? (rawSort as SearchSort)
+    : "newest"
+
+  const rawOffset = single(params.offset) ?? ""
+  const parsedOffset = Number(rawOffset)
+  const offset =
+    Number.isFinite(parsedOffset) && parsedOffset > 0
+      ? Math.min(parsedOffset, BROWSE_LIMIT_MAX - 1)
+      : 0
+
+  return { q, categorySlug, minPrice, maxPrice, condition, city, sort, offset }
+}
+
+function parsePrice(v: string | undefined): number | undefined {
+  if (v === undefined) return undefined
+  const n = Number(v)
+  return Number.isFinite(n) && n >= 0 ? n : undefined
+}
+
+/** Build the search URL from a filters object, omitting empty/zero params. */
+export function buildSearchUrl(filters: SearchFilters): string {
+  const params = new URLSearchParams()
+  if (filters.q) params.set("q", filters.q)
+  if (filters.categorySlug) params.set("category", filters.categorySlug)
+  if (filters.minPrice !== undefined) params.set("min", String(filters.minPrice))
+  if (filters.maxPrice !== undefined) params.set("max", String(filters.maxPrice))
+  if (filters.condition) params.set("condition", filters.condition)
+  if (filters.city) params.set("city", filters.city)
+  if (filters.sort !== "newest") params.set("sort", filters.sort)
+  if (filters.offset) params.set("offset", String(filters.offset))
+  const qs = params.toString()
+  return qs ? `/search?${qs}` : "/search"
+}
+
+export function nextOffset(offset: number): number {
+  return offset + PAGE_SIZE
+}

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -19,3 +19,11 @@ export function initials(name: string | null | undefined) {
 export function isInternalPath(path: string | null | undefined): path is string {
   return typeof path === "string" && path.startsWith("/") && !path.startsWith("//")
 }
+
+// Short, locale-aware date for list rows (offers, reviews): "Aug 13".
+export function formatShortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })
+}

--- a/app/supabase/migrations/20260813000000_search_listings_rpc.sql
+++ b/app/supabase/migrations/20260813000000_search_listings_rpc.sql
@@ -1,0 +1,119 @@
+-- T06 - Intelligent search & filters
+-- Implements the Search Service (docs/02-architecture/00-system-architecture.md):
+-- keyword full-text + category/price/condition/city filters + sort + pagination,
+-- on top of the T04 generated `search_vector` column and its GIN + pg_trgm
+-- indexes.
+--
+-- Search contract (per DB spec §19 and #3):
+--   * keyword  -> websearch_to_tsquery('simple') over the generated search_vector
+--                 (quoted phrases + AND/OR), with a pg_trgm similarity fallback
+--                 on title for typo-tolerant matches
+--   * filters  -> category slug, price range, condition enum, city substring
+--   * sort     -> newest (default) | oldest | price_asc | price_desc
+--   * paging   -> p_limit capped at 1000 (PostgREST ceiling), p_offset >= 0,
+--                 exact count via count(*) over ()
+--   * security -> SECURITY DEFINER with a hardened search_path; the WHERE clause
+--                 mirrors the public-read RLS policy (status = 'published' AND
+--                 deleted_at IS NULL) so the definer never leaks draft/sold or
+--                 soft-deleted rows; EXECUTE granted only to anon + authenticated.
+
+create or replace function public.search_listings(
+  p_query text default null,
+  p_category_slug text default null,
+  p_min_price numeric default null,
+  p_max_price numeric default null,
+  p_condition public.listing_condition default null,
+  p_city text default null,
+  p_sort text default 'newest',
+  p_limit int default 12,
+  p_offset int default 0
+)
+returns table (
+  id uuid,
+  title text,
+  price numeric,
+  condition public.listing_condition,
+  city text,
+  published_at timestamptz,
+  image_url text,
+  image_count bigint,
+  category_name text,
+  category_slug text,
+  seller_id uuid,
+  seller_full_name text,
+  seller_avatar_url text,
+  seller_role text,
+  seller_trust_score int,
+  total_count bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_tsq tsquery;
+begin
+  if p_query is not null and btrim(p_query) <> '' then
+    v_tsq := websearch_to_tsquery('simple', btrim(p_query));
+  else
+    v_tsq := null;
+  end if;
+
+  return query
+  select
+    l.id,
+    l.title,
+    l.price,
+    l.condition,
+    l.city,
+    l.published_at,
+    im.image_url,
+    coalesce(ic.image_count, 0)::bigint,
+    c.name,
+    c.slug,
+    u.id,
+    u.full_name,
+    u.avatar_url,
+    u.role,
+    u.trust_score::int,
+    count(*) over ()::bigint
+  from public.listings l
+  left join public.categories c on c.id = l.category_id
+  left join public.profiles u on u.id = l.seller_id
+  left join lateral (
+    select i.image_url
+    from public.listing_images i
+    where i.listing_id = l.id
+    order by i.display_order asc
+    limit 1
+  ) im on true
+  left join lateral (
+    select count(*) as image_count
+    from public.listing_images i
+    where i.listing_id = l.id
+  ) ic on true
+  where l.status = 'published'
+    and l.deleted_at is null
+    and (p_category_slug is null or c.slug = p_category_slug)
+    and (p_min_price is null or l.price >= p_min_price)
+    and (p_max_price is null or l.price <= p_max_price)
+    and (p_condition is null or l.condition = p_condition)
+    and (p_city is null or l.city ilike '%' || p_city || '%')
+    and (
+      v_tsq is null
+      or l.search_vector @@ v_tsq
+      or l.title % p_query
+    )
+  order by
+    case when p_sort = 'price_asc' then l.price end asc nulls last,
+    case when p_sort = 'price_desc' then l.price end desc nulls last,
+    case when p_sort = 'oldest' then l.published_at end asc nulls last,
+    l.published_at desc
+  limit least(greatest(p_limit, 0), 1000)
+  offset greatest(p_offset, 0);
+end;
+$$;
+
+revoke all on function public.search_listings(text, text, numeric, numeric, public.listing_condition, text, text, int, int) from public;
+grant execute on function public.search_listings(text, text, numeric, numeric, public.listing_condition, text, text, int, int) to anon, authenticated;

--- a/app/supabase/migrations/20260813000000_search_listings_rpc.sql
+++ b/app/supabase/migrations/20260813000000_search_listings_rpc.sql
@@ -10,12 +10,15 @@
 --                 on title for typo-tolerant matches
 --   * filters  -> category slug, price range, condition enum, city substring
 --   * sort     -> newest (default) | oldest | price_asc | price_desc
---   * paging   -> p_limit capped at 1000 (PostgREST ceiling), p_offset >= 0,
---                 exact count via count(*) over ()
+--   * paging   -> p_limit and p_offset both clamped to the 1000-row PostgREST
+--                 window (offset + limit <= 1000), exact count via count(*) over ()
 --   * security -> SECURITY DEFINER with a hardened search_path; the WHERE clause
 --                 mirrors the public-read RLS policy (status = 'published' AND
 --                 deleted_at IS NULL) so the definer never leaks draft/sold or
---                 soft-deleted rows; EXECUTE granted only to anon + authenticated.
+--                 soft-deleted rows. The joined profile/category/image fields
+--                 are all publicly readable under RLS too (profiles: T03 public
+--                 read policy), so the definer exposes nothing the anon browse
+--                 path already exposes. EXECUTE granted only to anon/authenticated.
 
 create or replace function public.search_listings(
   p_query text default null,
@@ -53,7 +56,16 @@ set search_path = public
 as $$
 declare
   v_tsq tsquery;
+  v_limit int;
+  v_offset int;
 begin
+  if p_sort not in ('newest', 'oldest', 'price_asc', 'price_desc') then
+    p_sort := 'newest';
+  end if;
+
+  v_limit := least(greatest(p_limit, 0), 1000);
+  v_offset := least(greatest(p_offset, 0), 1000 - v_limit);
+
   if p_query is not null and btrim(p_query) <> '' then
     v_tsq := websearch_to_tsquery('simple', btrim(p_query));
   else
@@ -110,8 +122,8 @@ begin
     case when p_sort = 'price_desc' then l.price end desc nulls last,
     case when p_sort = 'oldest' then l.published_at end asc nulls last,
     l.published_at desc
-  limit least(greatest(p_limit, 0), 1000)
-  offset greatest(p_offset, 0);
+  limit v_limit
+  offset v_offset;
 end;
 $$;
 

--- a/app/supabase/migrations/20260813090000_create_favorites.sql
+++ b/app/supabase/migrations/20260813090000_create_favorites.sql
@@ -1,0 +1,62 @@
+-- T07 - Favorites service
+-- favorites join table (user_id -> listing_id), per docs/02-architecture/03-database-design-specification.md
+-- §11 (favorites), §18 (unique (user_id, listing_id)), §20 (RLS: "Users can only access their own favorites"),
+-- §22 (migration naming). Keeps listings.favorite_count in sync via trigger.
+
+create table if not exists public.favorites (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles (id) on delete cascade,
+  listing_id uuid not null references public.listings (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  -- §18: a user can favorite a listing at most once.
+  constraint favorites_user_listing_unique unique (user_id, listing_id)
+);
+
+-- Listing-side lookups (counts, "who favorited this") and delete-by-listing cleanup.
+create index if not exists favorites_listing_id_idx on public.favorites (listing_id);
+
+-- Keep listings.favorite_count (denormalized, DB spec §8) in sync so later
+-- "popular first" sorting never reads stale counters.
+create or replace function public.sync_favorite_count()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update public.listings set favorite_count = favorite_count + 1 where id = new.listing_id;
+    return new;
+  elsif tg_op = 'DELETE' then
+    update public.listings set favorite_count = greatest(favorite_count - 1, 0) where id = old.listing_id;
+    return old;
+  end if;
+  return null;
+end;
+$$;
+
+create trigger if not exists favorites_sync_listing_count
+  after insert or delete on public.favorites
+  for each row execute function public.sync_favorite_count();
+
+-----------------------------------------------------------------------------
+-- RLS (DB spec §20 Favorites): a user only sees and writes their own rows.
+-- No update policy: a favorite is created or removed, never edited.
+-----------------------------------------------------------------------------
+alter table public.favorites enable row level security;
+
+create policy if not exists "Favorites are readable by the owner"
+  on public.favorites for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+create policy if not exists "Favorites are insertable by the owner"
+  on public.favorites for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create policy if not exists "Favorites are deletable by the owner"
+  on public.favorites for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+grant usage on schema public to anon, authenticated;
+grant select, insert, delete on public.favorites to authenticated;

--- a/app/supabase/migrations/20260813110000_create_offers.sql
+++ b/app/supabase/migrations/20260813110000_create_offers.sql
@@ -1,0 +1,290 @@
+-- T08 - Offers service
+-- offers: buyer price proposals on published listings, with a status machine
+-- (pending/countered/accepted/declined), per
+-- docs/02-architecture/03-database-design-specification.md §10 (offers), §18
+-- (amount + message constraints), §20 (RLS: buyer sees own offers, seller sees
+-- offers on own listings, admin has full access), §22 (migration naming), and
+-- the domain model (INV-005: no offers on your own listing; ListingMarkedSold:
+-- an accepted offer closes the listing).
+--
+-- Status transitions run through SECURITY DEFINER RPCs (accept/decline/counter)
+-- instead of client-side UPDATE so the accept path atomically marks the listing
+-- sold, a buyer accepting a counter can mark a listing they don't own, and each
+-- transition re-checks the caller against the offer row. RLS below therefore
+-- only grants SELECT (participants + admins) and INSERT (the buyer), never
+-- UPDATE/DELETE.
+--
+-- T08 adds listings.sold_to_buyer_id (not in DB spec §8): accept_offer stamps
+-- the winning buyer on the listing so the sold listing stays readable to that
+-- buyer (and its images to both parties) WITHOUT an offers<->listings RLS
+-- cycle. The sold-read policies read only the stamp, while the offers SELECT
+-- policy references listings one way — no policy queries the other table, so
+-- RLS expansion cannot recurse.
+
+create type if not exists public.offer_status as enum ('pending', 'countered', 'accepted', 'declined');
+
+create table if not exists public.offers (
+  id uuid primary key default gen_random_uuid(),
+  listing_id uuid not null references public.listings (id) on delete cascade,
+  buyer_id uuid not null references public.profiles (id) on delete cascade,
+  amount numeric(12, 2) not null check (amount > 0),
+  message text,
+  status public.offer_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.offers
+  add constraint if not exists offers_message_length
+  check (message is null or char_length(message) between 1 and 500);
+
+-- App-side ceiling (app/lib/offers/constants.ts OFFER_AMOUNT_MAX), enforced at
+-- the write boundary so submit and counter both reject absurd amounts.
+alter table public.offers
+  add constraint if not exists offers_amount_cap
+  check (amount <= 100000000);
+
+-- ListingMarkedSold bookkeeping: who won the sale, stamped by accept_offer.
+-- See header note for why this lives on listings rather than a join.
+alter table public.listings
+  add column if not exists sold_to_buyer_id uuid references public.profiles (id);
+
+-- Lookup paths: the buyer's "my offers", the seller's "incoming offers", and
+-- open offers on a listing.
+create index if not exists offers_buyer_id_idx on public.offers (buyer_id);
+create index if not exists offers_listing_id_idx on public.offers (listing_id);
+create index if not exists offers_status_idx on public.offers (status);
+
+create trigger if not exists offers_set_updated_at
+  before update on public.offers
+  for each row execute function public.handle_updated_at();
+
+-----------------------------------------------------------------------------
+-- RLS (DB spec §20 Offers): a user sees their own offers or offers on
+-- listings they own (the seller dashboard); admins have full access. No one
+-- else can see an offer, so amounts and messages never leak to other buyers.
+-----------------------------------------------------------------------------
+alter table public.offers enable row level security;
+
+create policy if not exists "Offers are readable by the buyer or the listing seller"
+  on public.offers for select
+  to authenticated
+  using (
+    (select auth.uid()) = buyer_id
+    or exists (
+      select 1 from public.listings l
+      where l.id = offers.listing_id and l.seller_id = (select auth.uid())
+    )
+    or public.is_admin()
+  );
+
+-- INV-005 + ListingMarkedSold: offers only land on published, live listings the
+-- buyer does not own. Blocking the insert for non-published listings is what
+-- stops new offers once a listing is sold (its status flips to 'sold').
+create policy if not exists "Offers are insertable by the buyer"
+  on public.offers for insert
+  to authenticated
+  with check (
+    (select auth.uid()) = buyer_id
+    and exists (
+      select 1 from public.listings l
+      where l.id = offers.listing_id
+        and l.status = 'published'
+        and l.deleted_at is null
+        and l.seller_id <> (select auth.uid())
+    )
+  );
+
+-- DB spec §20: admins can read and write any offer. The transition RPCs below
+-- accept admins too (each guards on public.is_admin()).
+create policy if not exists "Offers are manageable by admins"
+  on public.offers for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-----------------------------------------------------------------------------
+-- Sold-listing readability (T08): once a listing is sold it stops matching the
+-- "readable when published" policy, which would silently drop it from the
+-- accepted-offer buyer's dashboard and from both participants' image feeds.
+-- Both policies read only the sold_to_buyer_id stamp (see header note) so they
+-- stay out of the offers policy graph.
+-----------------------------------------------------------------------------
+create policy if not exists "Sold listings are readable by the accepted-offer buyer"
+  on public.listings for select
+  to authenticated
+  using ((select auth.uid()) = sold_to_buyer_id);
+
+create policy if not exists "Listing images are readable by the seller or accepted-offer buyer"
+  on public.listing_images for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and ((select auth.uid()) in (l.seller_id, l.sold_to_buyer_id))
+    )
+  );
+
+-----------------------------------------------------------------------------
+-- Status-transition RPCs (SECURITY DEFINER; each one re-checks the caller).
+-- Bypassing RLS is deliberate: accept/decline/counter mutate the offer (and,
+-- for accept, the listing) on behalf of whichever participant is acting, and
+-- the caller check inside each function replaces the UPDATE policy. Rows are
+-- locked offer-then-listing so concurrent transitions on one offer or one
+-- listing serialize instead of lost-updating each other.
+-----------------------------------------------------------------------------
+
+create or replace function public.accept_offer(p_offer_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_listing public.listings;
+  v_is_seller boolean;
+  v_is_buyer boolean;
+begin
+  -- Lock the offer row, then the listing row. With both held, a second accept
+  -- (of this offer, or of another offer on the same listing) blocks until this
+  -- one commits, then re-reads the now-sold listing and bails — so a
+  -- double-accept really is impossible.
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  select * into v_listing from public.listings where id = v_offer.listing_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'listing not found');
+  end if;
+
+  -- The seller may accept a pending offer; the buyer may accept a counter;
+  -- admins have full access (DB spec §20).
+  v_is_seller := v_listing.seller_id = (select auth.uid());
+  v_is_buyer := v_offer.buyer_id = (select auth.uid());
+
+  if not (
+    public.is_admin()
+    or (v_is_seller and v_offer.status = 'pending')
+    or (v_is_buyer and v_offer.status = 'countered')
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  -- The listing must still be for sale. With the row locked this cannot race:
+  -- once a listing is sold the check fails for everyone else.
+  if v_listing.status <> 'published' or v_listing.deleted_at is not null then
+    return jsonb_build_object('ok', false, 'error', 'listing is no longer available');
+  end if;
+
+  update public.offers set status = 'accepted' where id = p_offer_id;
+  -- ListingMarkedSold: an accepted offer closes the listing to further offers,
+  -- and stamps the winner so the sale stays visible to both parties.
+  update public.listings
+    set status = 'sold', sold_to_buyer_id = v_offer.buyer_id
+    where id = v_listing.id;
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+create or replace function public.decline_offer(p_offer_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_is_seller boolean;
+  v_is_buyer boolean;
+begin
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  -- A pending offer is declined by the seller; a counter is declined by the
+  -- buyer (who declines = walks away from the counter); admins have full access.
+  v_is_seller := exists (
+    select 1 from public.listings l
+    where l.id = v_offer.listing_id and l.seller_id = (select auth.uid())
+  );
+  v_is_buyer := v_offer.buyer_id = (select auth.uid());
+
+  if not (
+    public.is_admin()
+    or (v_is_seller and v_offer.status = 'pending')
+    or (v_is_buyer and v_offer.status = 'countered')
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  update public.offers set status = 'declined' where id = p_offer_id;
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+create or replace function public.counter_offer(p_offer_id uuid, p_amount numeric)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_listing public.listings;
+begin
+  if p_amount is null or p_amount <= 0 then
+    return jsonb_build_object('ok', false, 'error', 'invalid amount');
+  end if;
+  if p_amount > 100000000 then
+    return jsonb_build_object('ok', false, 'error', 'amount too large');
+  end if;
+
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  -- Only the seller (or an admin) counters a pending offer, and only while the
+  -- listing is still live — countering an offer on a sold/deleted listing would
+  -- strand the buyer, whose later accept could never succeed.
+  select * into v_listing from public.listings where id = v_offer.listing_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'listing not found');
+  end if;
+
+  if not (
+    public.is_admin()
+    or v_listing.seller_id = (select auth.uid())
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_offer.status <> 'pending' then
+    return jsonb_build_object('ok', false, 'error', 'offer is no longer pending');
+  end if;
+
+  if v_listing.status <> 'published' or v_listing.deleted_at is not null then
+    return jsonb_build_object('ok', false, 'error', 'listing is no longer available');
+  end if;
+
+  update public.offers set status = 'countered', amount = p_amount where id = p_offer_id;
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+grant usage on schema public to anon, authenticated;
+grant select, insert on public.offers to authenticated;
+
+-- RPC grants: offered to authenticated only (offers are always owner-scoped),
+-- and revoking from public keeps the implicit EXECUTE grant from exposing them.
+revoke all on function public.accept_offer(uuid) from public;
+revoke all on function public.decline_offer(uuid) from public;
+revoke all on function public.counter_offer(uuid, numeric) from public;
+grant execute on function public.accept_offer(uuid) to authenticated;
+grant execute on function public.decline_offer(uuid) to authenticated;
+grant execute on function public.counter_offer(uuid, numeric) to authenticated;

--- a/app/tests/unit/browse.test.ts
+++ b/app/tests/unit/browse.test.ts
@@ -8,8 +8,10 @@ describe("browse.parseBrowseParams", () => {
     expect(parseBrowseParams({})).toEqual({ categorySlug: undefined, offset: 0 })
   })
 
-  it("clamps a huge offset to the 1000-row ceiling", () => {
-    expect(parseBrowseParams({ offset: "99999" }).offset).toBe(BROWSE_LIMIT_MAX - 1)
+  it("clamps a huge offset to the top of the 1000-row window", () => {
+    expect(parseBrowseParams({ offset: "99999" }).offset).toBe(
+      BROWSE_LIMIT_MAX - PAGE_SIZE
+    )
   })
 
   it("rejects a negative offset", () => {

--- a/app/tests/unit/favorites.test.ts
+++ b/app/tests/unit/favorites.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  buildLoginUrl,
+  toggleFavoriteState,
+} from "@/lib/favorites/constants"
+
+describe("favorites.toggleFavoriteState", () => {
+  it("flips a false favorite to true", () => {
+    expect(toggleFavoriteState(false)).toBe(true)
+  })
+
+  it("flips a true favorite to false", () => {
+    expect(toggleFavoriteState(true)).toBe(false)
+  })
+})
+
+describe("favorites.buildLoginUrl", () => {
+  it("builds the login URL with the current path as next", () => {
+    expect(buildLoginUrl("/listings/abc-123")).toBe(
+      "/login?next=%2Flistings%2Fabc-123"
+    )
+  })
+
+  it("encodes a query string inside the next param", () => {
+    expect(buildLoginUrl("/?category=books&offset=12")).toContain(
+      "next=%2F%3Fcategory%3Dbooks%26offset%3D12"
+    )
+  })
+})

--- a/app/tests/unit/listings.test.ts
+++ b/app/tests/unit/listings.test.ts
@@ -5,6 +5,10 @@ import {
   formatPrice,
   formatCondition,
   CONDITION_COLORS,
+  LISTING_STATUS_COLORS,
+  LISTING_STATUS_LABELS,
+  STATUSES,
+  type ListingStatus,
 } from "@/lib/listings"
 
 describe("listings.isValidUuid", () => {
@@ -52,5 +56,21 @@ describe("listings.CONDITION_COLORS", () => {
     expect(Object.keys(CONDITION_COLORS).sort()).toEqual(
       ["Brand New", "Lightly Used", "Fair"].sort()
     )
+  })
+})
+
+describe("listings status presentation", () => {
+  it("labels and colors cover the writable statuses plus archived", () => {
+    const statuses: ListingStatus[] = ["draft", "published", "sold", "archived"]
+    for (const status of statuses) {
+      expect(LISTING_STATUS_LABELS[status]).toBeTruthy()
+      expect(LISTING_STATUS_COLORS[status]).toMatch(/^bg-.*text-/)
+    }
+  })
+
+  it("labels every declared STATUSES value", () => {
+    for (const status of STATUSES) {
+      expect(LISTING_STATUS_LABELS[status]).toBeTruthy()
+    }
   })
 })

--- a/app/tests/unit/offers.test.ts
+++ b/app/tests/unit/offers.test.ts
@@ -7,6 +7,7 @@ import {
   OFFER_STATUS_COLORS,
   OFFER_STATUSES,
   OFFER_STATUS_LABELS,
+  OPEN_OFFER_STATUSES,
   type OfferStatus,
 } from "@/lib/offers/constants"
 
@@ -33,6 +34,17 @@ describe("offers bounds mirror the DB constraints", () => {
   it("allows a positive amount ceiling and the 500-char message cap", () => {
     expect(OFFER_AMOUNT_MAX).toBeGreaterThan(0)
     expect(OFFER_MESSAGE_MAX).toBe(500)
+  })
+})
+
+describe("offers.open statuses", () => {
+  it("marks pending and countered as the only open statuses", () => {
+    expect(OPEN_OFFER_STATUSES.sort()).toEqual(["countered", "pending"])
+  })
+
+  it("every open status is a declared status", () => {
+    const declared = new Set<string>(OFFER_STATUSES)
+    expect(OPEN_OFFER_STATUSES.every((s) => declared.has(s))).toBe(true)
   })
 })
 

--- a/app/tests/unit/offers.test.ts
+++ b/app/tests/unit/offers.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  buildLoginUrl,
+  OFFER_AMOUNT_MAX,
+  OFFER_MESSAGE_MAX,
+  OFFER_STATUS_COLORS,
+  OFFER_STATUSES,
+  OFFER_STATUS_LABELS,
+  type OfferStatus,
+} from "@/lib/offers/constants"
+
+describe("offers status machine", () => {
+  it("declares the four AC statuses", () => {
+    expect(OFFER_STATUSES).toEqual(["pending", "countered", "accepted", "declined"])
+  })
+
+  it("labels and colors cover every declared status", () => {
+    for (const status of OFFER_STATUSES) {
+      expect(OFFER_STATUS_LABELS[status]).toBeTruthy()
+      expect(OFFER_STATUS_COLORS[status]).toMatch(/^bg-.*text-/)
+    }
+  })
+
+  it("does not add labels for undeclared statuses", () => {
+    const declared = new Set<string>(OFFER_STATUSES)
+    const labeled = Object.keys(OFFER_STATUS_LABELS) as OfferStatus[]
+    expect(labeled.every((s) => declared.has(s))).toBe(true)
+  })
+})
+
+describe("offers bounds mirror the DB constraints", () => {
+  it("allows a positive amount ceiling and the 500-char message cap", () => {
+    expect(OFFER_AMOUNT_MAX).toBeGreaterThan(0)
+    expect(OFFER_MESSAGE_MAX).toBe(500)
+  })
+})
+
+describe("offers.buildLoginUrl", () => {
+  it("builds the login URL with the current path as next", () => {
+    expect(buildLoginUrl("/listings/abc-123")).toBe(
+      "/login?next=%2Flistings%2Fabc-123"
+    )
+  })
+
+  it("encodes a query string inside the next param", () => {
+    expect(buildLoginUrl("/?category=books")).toContain(
+      "next=%2F%3Fcategory%3Dbooks"
+    )
+  })
+})

--- a/app/tests/unit/pagination.test.ts
+++ b/app/tests/unit/pagination.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+import { MAX_PAGING_OFFSET, nextOffset, parseOffset } from "@/lib/pagination"
+
+describe("pagination.parseOffset", () => {
+  it("defaults to 0 when absent", () => {
+    expect(parseOffset(undefined)).toBe(0)
+    expect(parseOffset("")).toBe(0)
+  })
+
+  it("keeps a valid offset", () => {
+    expect(parseOffset("24")).toBe(24)
+  })
+
+  it("clamps a huge offset to the top of the 1000-row window", () => {
+    expect(parseOffset("99999")).toBe(MAX_PAGING_OFFSET)
+  })
+
+  it("rejects a negative or non-numeric offset", () => {
+    expect(parseOffset("-3")).toBe(0)
+    expect(parseOffset("abc")).toBe(0)
+  })
+
+  it("guarantees a page never crosses the 1000-row ceiling", () => {
+    expect(MAX_PAGING_OFFSET + PAGE_SIZE).toBe(BROWSE_LIMIT_MAX)
+  })
+})
+
+describe("pagination.nextOffset", () => {
+  it("advances by one page", () => {
+    expect(nextOffset(0)).toBe(PAGE_SIZE)
+    expect(nextOffset(PAGE_SIZE)).toBe(PAGE_SIZE * 2)
+  })
+})

--- a/app/tests/unit/search.test.ts
+++ b/app/tests/unit/search.test.ts
@@ -57,9 +57,15 @@ describe("search.parseSearchParams", () => {
     })
   })
 
-  it("clamps a huge offset to the 1000-row ceiling", () => {
+  it("clamps a huge offset to the top of the 1000-row window", () => {
     expect(parseSearchParams({ offset: "99999" }).offset).toBe(
-      BROWSE_LIMIT_MAX - 1
+      BROWSE_LIMIT_MAX - PAGE_SIZE
+    )
+  })
+
+  it("keeps an offset that already fills the window", () => {
+    expect(parseSearchParams({ offset: String(BROWSE_LIMIT_MAX - PAGE_SIZE) }).offset).toBe(
+      BROWSE_LIMIT_MAX - PAGE_SIZE
     )
   })
 

--- a/app/tests/unit/search.test.ts
+++ b/app/tests/unit/search.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+
+import { BROWSE_LIMIT_MAX, PAGE_SIZE } from "@/lib/listings/constants"
+import { buildSearchUrl, nextOffset, parseSearchParams } from "@/lib/search"
+
+describe("search.parseSearchParams", () => {
+  it("returns fully-defaulted filters for empty params", () => {
+    expect(parseSearchParams({})).toEqual({
+      q: "",
+      categorySlug: undefined,
+      minPrice: undefined,
+      maxPrice: undefined,
+      condition: undefined,
+      city: "",
+      sort: "newest",
+      offset: 0,
+    })
+  })
+
+  it("parses the keyword and trims whitespace", () => {
+    expect(parseSearchParams({ q: "  laptop  " }).q).toBe("laptop")
+  })
+
+  it("drops a keyword when it is an array", () => {
+    expect(parseSearchParams({ q: ["a", "b"] }).q).toBe("")
+  })
+
+  it("parses a condition from the allow-list", () => {
+    expect(parseSearchParams({ condition: "Brand New" }).condition).toBe(
+      "Brand New"
+    )
+  })
+
+  it("drops a condition that is not in the allow-list", () => {
+    expect(parseSearchParams({ condition: "Mint" }).condition).toBeUndefined()
+  })
+
+  it("parses a valid sort", () => {
+    expect(parseSearchParams({ sort: "price_asc" }).sort).toBe("price_asc")
+  })
+
+  it("falls back to newest for an unknown sort", () => {
+    expect(parseSearchParams({ sort: "popular" }).sort).toBe("newest")
+  })
+
+  it("parses non-negative prices", () => {
+    expect(parseSearchParams({ min: "100", max: "5000" })).toMatchObject({
+      minPrice: 100,
+      maxPrice: 5000,
+    })
+  })
+
+  it("rejects negative and non-numeric prices", () => {
+    expect(parseSearchParams({ min: "-5", max: "abc" })).toMatchObject({
+      minPrice: undefined,
+      maxPrice: undefined,
+    })
+  })
+
+  it("clamps a huge offset to the 1000-row ceiling", () => {
+    expect(parseSearchParams({ offset: "99999" }).offset).toBe(
+      BROWSE_LIMIT_MAX - 1
+    )
+  })
+
+  it("rejects a negative or non-numeric offset", () => {
+    expect(parseSearchParams({ offset: "-3" }).offset).toBe(0)
+    expect(parseSearchParams({ offset: "nope" }).offset).toBe(0)
+  })
+})
+
+describe("search.buildSearchUrl", () => {
+  const base = {
+    q: "",
+    categorySlug: undefined,
+    minPrice: undefined,
+    maxPrice: undefined,
+    condition: undefined,
+    city: "",
+    sort: "newest" as const,
+    offset: 0,
+  }
+
+  it("returns bare /search when nothing is set", () => {
+    expect(buildSearchUrl(base)).toBe("/search")
+  })
+
+  it("omits the default sort and zero offset", () => {
+    expect(buildSearchUrl({ ...base, q: "phone" })).toBe("/search?q=phone")
+  })
+
+  it("includes every non-default param", () => {
+    expect(
+      buildSearchUrl({
+        q: "table",
+        categorySlug: "furniture",
+        minPrice: 500,
+        maxPrice: 5000,
+        condition: "Lightly Used",
+        city: "Bole",
+        sort: "price_desc",
+        offset: PAGE_SIZE,
+      })
+    ).toBe(
+      "/search?q=table&category=furniture&min=500&max=5000&condition=Lightly+Used&city=Bole&sort=price_desc&offset=12"
+    )
+  })
+})
+
+describe("search.nextOffset", () => {
+  it("advances by one page", () => {
+    expect(nextOffset(0)).toBe(PAGE_SIZE)
+    expect(nextOffset(PAGE_SIZE)).toBe(PAGE_SIZE * 2)
+  })
+})

--- a/docs/02-architecture/00-system-architecture.md
+++ b/docs/02-architecture/00-system-architecture.md
@@ -153,7 +153,7 @@ Database
 
 **Responsibilities:** Keyword Search, Filtering, Sorting, Pagination
 
-**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `lib/searchListings`.
+**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `searchListings` in `app/lib/listings.ts`.
 
 **Future:** Relevance ranking (`ts_rank`)
 

--- a/docs/02-architecture/00-system-architecture.md
+++ b/docs/02-architecture/00-system-architecture.md
@@ -153,7 +153,9 @@ Database
 
 **Responsibilities:** Keyword Search, Filtering, Sorting, Pagination
 
-**Future:** Full-text search
+**Implementations:** `search_listings` RPC (T06) — Postgres full-text over the generated `search_vector` (tsvector GIN) + pg_trgm typo tolerance, category/price/condition/city filters, sort, 1000-row-capped paging; called from `lib/searchListings`.
+
+**Future:** Relevance ranking (`ts_rank`)
 
 ## Trust Service
 

--- a/docs/02-architecture/03-database-design-specification.md
+++ b/docs/02-architecture/03-database-design-specification.md
@@ -168,6 +168,7 @@ Every business table includes:
 | view_count | INTEGER DEFAULT 0 |
 | favorite_count | INTEGER DEFAULT 0 |
 | published_at | TIMESTAMPTZ |
+| sold_to_buyer_id | UUID NULL | T08: winner of an accepted offer, stamped by `accept_offer` so the sold listing stays readable to the buyer without an offers↔listings RLS cycle |
 
 **Indexes:** seller_id, category_id, city, status, price, published_at
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`).
 
 ## Integration Testing
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`), `lib/offers/constants` (`OFFER_STATUSES` status machine, `OFFER_AMOUNT_MAX`/`OFFER_MESSAGE_MAX` bounds, `buildLoginUrl`).
 
 ## Integration Testing
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`).
+Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`), `lib/search` (`parseSearchParams` filter validation + paging clamp, `buildSearchUrl`, `nextOffset`).
 
 ## Integration Testing
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` paging-window clamp, `buildBrowseUrl`, `nextOffset`), `lib/search` (`parseSearchParams` filter validation + paging clamp, `buildSearchUrl`, `nextOffset`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`).
 
 ## Integration Testing
 

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`), `lib/offers/constants` (`OFFER_STATUSES` status machine, `OFFER_AMOUNT_MAX`/`OFFER_MESSAGE_MAX` bounds, `buildLoginUrl`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`, `LISTING_STATUS_LABELS`/`LISTING_STATUS_COLORS`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`), `lib/offers/constants` (`OFFER_STATUSES` status machine, `OFFER_AMOUNT_MAX`/`OFFER_MESSAGE_MAX` bounds, `buildLoginUrl`).
 
 ## Integration Testing
 


### PR DESCRIPTION
Closes #13

Seller dashboard: manage own listings, view per-listing stats, and a summary of incoming offers — the seller's home in the app.

## What's in this PR
- \Your listings\ section on \/dashboard\ (\ListingManager\): each listing row shows cover thumb, title, status badge, price, view/favorite counts, plus **Edit** and **Archive** actions (RLS-guarded, \deleteListing\ server action with confirm + pending state)
- Empty state guides first-time sellers to create a listing
- **Incoming offers** card now shows the count of open offers (pending + countered) via new \countIncomingOffers\ and links to \/offers/seller\ (T08 surface)
- \etchSellerListings\ returns \SellerListingRow\ (Listing + cover image) and filters out soft-deleted rows
- \LISTING_STATUS_LABELS\/\LISTING_STATUS_COLORS\ pure value maps + \ListingStatusBadge\ (draft/published/sold/archived)
- Unit tests for the status maps (59 passing)

## Branch note
Stacked on \m/ugm-t08-offers\ (#38) because the dashboard already gained T08 offer cards; the diff vs that base contains only T09 work.