### PR TITLE
T10: reviews & ratings

### DIFF
--- a/app/app/actions/reviews.ts
+++ b/app/app/actions/reviews.ts
@@ -1,0 +1,72 @@
+"use server"
+
+import { z } from "zod"
+import { revalidatePath } from "next/cache"
+
+import { requireUser } from "@/lib/auth"
+import { submitReviewRow } from "@/lib/reviews"
+import {
+  RATING_MAX,
+  RATING_MIN,
+  REVIEW_COMMENT_MAX,
+} from "@/lib/reviews/constants"
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
+
+const reviewSchema = z.object({
+  offerId: z.string().uuid(),
+  rating: z.coerce
+    .number({ message: "Pick a rating" })
+    .int()
+    .min(RATING_MIN, "Pick a rating from 1 to 5")
+    .max(RATING_MAX, "Pick a rating from 1 to 5"),
+  comment: z
+    .string()
+    .max(REVIEW_COMMENT_MAX, `Keep the comment under ${REVIEW_COMMENT_MAX} characters`)
+    .optional(),
+})
+
+export type ReviewState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+// Buyer reviews a completed transaction (an accepted offer). The RPC itself
+// re-checks that the caller is the accepted-offer buyer and derives the seller
+// from the offer, so the action only needs to validate shape + session.
+export async function submitReview(
+  _prevState: ReviewState,
+  formData: FormData
+): Promise<ReviewState> {
+  const parsed = reviewSchema.safeParse({
+    offerId: formValue(formData, "offerId"),
+    rating: formData.get("rating"),
+    comment: formValue(formData, "comment"),
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  // Require a session so the RPC's auth.uid() resolves; the RPC itself re-checks
+  // that the caller is the accepted-offer buyer. (Mirrors offers/offerAction.)
+  await requireUser()
+
+  const result = await submitReviewRow({
+    offerId: parsed.data.offerId,
+    rating: parsed.data.rating,
+    comment: parsed.data.comment ?? null,
+  })
+
+  if (!result.ok) {
+    return { message: result.error ?? "Could not submit your review" }
+  }
+
+  revalidatePath("/offers")
+  if (result.sellerId) revalidatePath(`/users/${result.sellerId}`)
+  return { ok: true }
+}

--- a/app/app/offers/page.tsx
+++ b/app/app/offers/page.tsx
@@ -8,6 +8,8 @@ import { formatPrice } from "@/lib/listings"
 import { formatShortDate } from "@/lib/utils"
 import { OfferStatusBadge } from "@/components/offers/offer-status-badge"
 import { BuyerOfferActions } from "@/components/offers/buyer-offer-actions"
+import { ReviewForm } from "@/components/reviews/review-form"
+import { ReviewStars } from "@/components/reviews/review-stars"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -102,6 +104,24 @@ export default async function OffersPage() {
                   {offer.status === "countered" ? (
                     <div className="mt-4 border-t pt-3">
                       <BuyerOfferActions offer={offer} />
+                    </div>
+                  ) : null}
+
+                  {offer.status === "accepted" ? (
+                    <div className="mt-4 border-t pt-3">
+                      {offer.review ? (
+                        <div className="flex items-center gap-2">
+                          <ReviewStars rating={offer.review.rating} />
+                          <span className="text-sm text-muted-foreground">
+                            You rated this transaction {offer.review.rating}/5
+                          </span>
+                        </div>
+                      ) : (
+                        <ReviewForm
+                          offerId={offer.id}
+                          listingTitle={offer.listing?.title}
+                        />
+                      )}
                     </div>
                   ) : null}
                 </CardContent>

--- a/app/app/users/[id]/page.tsx
+++ b/app/app/users/[id]/page.tsx
@@ -5,11 +5,13 @@ import { MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
 
 import { ROLE_LABELS, type UserRole } from "@/lib/auth"
 import { createClient } from "@/lib/supabase/server"
-import { initials } from "@/lib/utils"
+import { initials, formatShortDate } from "@/lib/utils"
+import { fetchSellerReviews, summarizeRating } from "@/lib/reviews"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ReviewStars } from "@/components/reviews/review-stars"
 
 type PublicProfileRow = {
   full_name: string | null
@@ -83,6 +85,9 @@ export default async function UserProfilePage({
 
   const role = (profile.role ?? "buyer") as UserRole
   const roleLabel = ROLE_LABELS[role] ?? "Buyer"
+  const reviews = await fetchSellerReviews(id)
+  const rating = summarizeRating(reviews)
+
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
@@ -166,24 +171,74 @@ export default async function UserProfilePage({
             <p className="text-sm text-muted-foreground">No bio added yet.</p>
           )}
 
-          <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">
-                Trust score
-              </dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">
-                {profile.trust_score ?? 50}
-              </dd>
+           <dl className="grid grid-cols-2 gap-4 border-t border-border pt-5">
+             <div>
+               <dt className="text-xs font-medium text-muted-foreground">
+                 Trust score
+               </dt>
+               <dd className="mt-1 text-2xl font-semibold text-foreground">
+                 {profile.trust_score ?? 50}
+               </dd>
+             </div>
+             <div>
+               <dt className="text-xs font-medium text-muted-foreground">Role</dt>
+               <dd className="mt-1 text-2xl font-semibold text-foreground">
+                 {roleLabel}
+               </dd>
+             </div>
+           </dl>
+         </CardContent>
+       </Card>
+
+      {reviews.length > 0 ? (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Reviews</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-baseline justify-between">
+              <div className="flex items-center gap-2">
+                <ReviewStars rating={rating.average ?? 0} size="md" />
+                <span className="text-sm text-muted-foreground">
+                  {rating.average?.toFixed(1) ?? "—"} out of 5 ({rating.count})
+                </span>
+              </div>
             </div>
-            <div>
-              <dt className="text-xs font-medium text-muted-foreground">Role</dt>
-              <dd className="mt-1 text-2xl font-semibold text-foreground">
-                {roleLabel}
-              </dd>
-            </div>
-          </dl>
-        </CardContent>
-      </Card>
+
+            <ul className="mt-4 flex flex-col gap-4">
+              {reviews.map((review) => (
+                <li key={review.id} className="flex items-start gap-3 text-sm">
+                  <Avatar className="size-8">
+                    {review.buyer?.avatar_url ? (
+                      <AvatarImage
+                        src={review.buyer.avatar_url}
+                        alt={review.buyer.full_name ?? "Reviewer"}
+                      />
+                    ) : null}
+                    <AvatarFallback className="text-xs">
+                      {initials(review.buyer?.full_name ?? "")}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <ReviewStars rating={review.rating} size="xs" />
+                      <span className="text-xs text-muted-foreground">
+                        {formatShortDate(review.created_at)}
+                      </span>
+                    </div>
+                    {review.comment ? (
+                      <p className="mt-1 text-sm text-foreground/80">
+                        {review.comment}
+                      </p>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ) : null}
+
 
       <div className="mt-6 text-center">
         <Button asChild variant="link">

--- a/app/components/reviews/review-form.tsx
+++ b/app/components/reviews/review-form.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { useActionState, useState } from "react"
+import { StarIcon } from "lucide-react"
+
+import { submitReview, type ReviewState } from "@/app/actions/reviews"
+import { RATING_MAX, REVIEW_COMMENT_MAX } from "@/lib/reviews/constants"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function ReviewForm({
+  offerId,
+  listingTitle,
+}: {
+  offerId: string
+  listingTitle?: string
+}) {
+  const [rating, setRating] = useState<number>(0)
+  const [state, formAction, pending] = useActionState(submitReview, {} as ReviewState)
+
+  // Once the review is persisted the server action revalidates /offers and the
+  // seller profile; here we just swap the form for a thank-you line.
+  if (state.ok) {
+    return (
+      <div className="text-center text-sm text-muted-foreground">
+        Thanks for your review{listingTitle ? ` of “${listingTitle}”` : ""}.
+      </div>
+    )
+  }
+
+  return (
+    <form action={formAction} className="flex flex-col gap-4">
+      <input type="hidden" name="offerId" value={offerId} />
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Your rating</label>
+        <div className="flex items-center gap-1">
+          {Array.from({ length: RATING_MAX }, (_, i) => {
+            const value = i + 1
+            return (
+              <label key={value} htmlFor={`review-rating-${offerId}-${value}`}>
+                <input
+                  type="radio"
+                  name="rating"
+                  id={`review-rating-${offerId}-${value}`}
+                  value={value}
+                  checked={rating === value}
+                  onChange={() => setRating(value)}
+                  required
+                  className="sr-only"
+                  aria-label={`${value} star${value === 1 ? "" : "s"}`}
+                />
+                <StarIcon
+                  className={cn(
+                    "size-6 shrink-0 cursor-pointer transition-colors",
+                    value <= rating
+                      ? "fill-amber-400 text-amber-400"
+                      : "text-muted-foreground/40 hover:text-muted-foreground/70"
+                  )}
+                />
+              </label>
+            )
+          })}
+        </div>
+        <FieldError message={state.errors?.rating?.[0]} />
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor={`review-comment-${offerId}`} className="block text-sm font-medium">
+          Comment (optional)
+        </label>
+        <textarea
+          id={`review-comment-${offerId}`}
+          name="comment"
+          rows={4}
+          maxLength={REVIEW_COMMENT_MAX}
+          placeholder="What was the transaction like?"
+          className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+        />
+        <FieldError message={state.errors?.comment?.[0]} />
+      </div>
+
+      {state.message ? (
+        <p role="alert" className="text-sm text-destructive">
+          {state.message}
+        </p>
+      ) : null}
+
+      <Button type="submit" disabled={pending || rating === 0}>
+        {pending ? "Sending…" : "Submit review"}
+      </Button>
+    </form>
+  )
+}

--- a/app/components/reviews/review-stars.tsx
+++ b/app/components/reviews/review-stars.tsx
@@ -1,0 +1,45 @@
+import { StarIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { RATING_MAX } from "@/lib/reviews/constants"
+
+function boundedRating(rating: number): number {
+  const n = Math.round(rating)
+  return n < 1 ? 1 : n > RATING_MAX ? RATING_MAX : n
+}
+
+// Read-only star display used wherever a rating is surfaced: the profile review
+// list, the profile header aggregate, and the "you rated X" line on the offers
+// page. Pure (no "use client") so a Server Component can render it directly.
+export function ReviewStars({
+  rating,
+  size = "sm",
+  className,
+}: {
+  rating: number
+  size?: "xs" | "sm" | "md"
+  className?: string
+}) {
+  const filled = boundedRating(rating)
+  const sizeClass = {
+    xs: "size-3",
+    sm: "size-4",
+    md: "size-5",
+  }[size]
+  return (
+    <div className={cn("flex items-center gap-0.5", className)} aria-label={`Rating ${rating} out of ${RATING_MAX}`}>
+      {Array.from({ length: RATING_MAX }, (_, i) => (
+        <StarIcon
+          key={i}
+          className={cn(
+            "shrink-0",
+            sizeClass,
+            i < filled
+              ? "fill-amber-400 text-amber-400"
+              : "text-muted-foreground/40"
+          )}
+        />
+      ))}
+    </div>
+  )
+}

--- a/app/lib/offers.ts
+++ b/app/lib/offers.ts
@@ -24,6 +24,8 @@ export interface BuyerOfferRow {
   status: OfferStatus
   created_at: string
   listing: BrowseListing | null
+  // The review on this offer, if the buyer has already rated the seller (T10).
+  review: { id: string; rating: number } | null
 }
 
 export interface SellerOfferRow extends BuyerOfferRow {
@@ -60,6 +62,7 @@ function mapRawOfferRow(
   row: RawOfferRow & {
     listing: RawOfferListingRow | null
     buyer?: { id: string; full_name: string | null; avatar_url: string | null } | null
+    review?: { id: string; rating: number } | null
   },
   withBuyer: boolean
 ): SellerOfferRow {
@@ -71,6 +74,7 @@ function mapRawOfferRow(
     status: row.status,
     created_at: row.created_at,
     listing: mapOfferListing(row.listing),
+    review: row.review ?? null,
     buyer: withBuyer ? (row.buyer ?? null) : null,
   }
 }
@@ -87,7 +91,8 @@ export async function fetchBuyerOffers(userId: string): Promise<BuyerOfferRow[]>
     .select(
       `${OFFER_COLUMNS},
        listing:listings(id, title, price, condition, city, published_at,
-         images:listing_images(id, image_url, display_order))`
+         images:listing_images(id, image_url, display_order)),
+       review:reviews(id, rating)`
     )
     .eq("buyer_id", userId)
     .order("created_at", { ascending: false })
@@ -105,6 +110,7 @@ export async function fetchBuyerOffers(userId: string): Promise<BuyerOfferRow[]>
     status: OfferStatus
     created_at: string
     listing: RawOfferListingRow | null
+    review: { id: string; rating: number } | null
   }[]
 
   return rows.map((row) => mapRawOfferRow(row, false))

--- a/app/lib/reviews.ts
+++ b/app/lib/reviews.ts
@@ -1,0 +1,115 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+import { isValidUuid } from "@/lib/listings"
+
+export * from "@/lib/reviews/constants"
+
+// ---- Reads ----
+
+export interface SellerReviewRow {
+  id: string
+  rating: number
+  comment: string | null
+  created_at: string
+  buyer: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+  } | null
+}
+
+export interface SellerRatingSummary {
+  average: number | null
+  count: number
+}
+
+// PostgREST returns every embedded relation as an array, even a singular one,
+// so `buyer:profiles(...)` arrives as `{...}[] | null`. Flatten to a single row.
+interface RawReviewRow {
+  id: string
+  rating: number
+  comment: string | null
+  created_at: string
+  buyer:
+    | { id: string; full_name: string | null; avatar_url: string | null }[]
+    | null
+}
+
+const REVIEW_COLUMNS =
+  "id, rating, comment, created_at, buyer:profiles(id, full_name, avatar_url)"
+
+// The seller's reviews, newest first, with the reviewer's public identity.
+// RLS exposes every review to the public, so any visitor can render the list.
+export async function fetchSellerReviews(
+  sellerId: string
+): Promise<SellerReviewRow[]> {
+  if (!isValidUuid(sellerId)) return []
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("reviews")
+    .select(REVIEW_COLUMNS)
+    .eq("seller_id", sellerId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchSellerReviews:", error.message)
+    return []
+  }
+  const rows = (data as RawReviewRow[] | null) ?? []
+  return rows.map((row) => ({
+    id: row.id,
+    rating: Number(row.rating),
+    comment: row.comment,
+    created_at: row.created_at,
+    buyer: row.buyer?.[0] ?? null,
+  }))
+}
+
+// Aggregate rating for the profile header. Computed from the same rows the
+// review list renders, so the summary and list can never disagree.
+export function summarizeRating(reviews: SellerReviewRow[]): SellerRatingSummary {
+  if (reviews.length === 0) return { average: null, count: 0 }
+  const total = reviews.reduce((sum, r) => sum + r.rating, 0)
+  return { average: total / reviews.length, count: reviews.length }
+}
+
+// ---- Writes ----
+
+export interface ReviewResult {
+  ok: boolean
+  error: string | null
+  sellerId: string | null
+}
+
+// A new review, written by the buyer of an accepted offer. The RPC derives the
+// seller from the offer and recomputes the seller's trust score (AC5).
+export async function submitReviewRow(input: {
+  offerId: string
+  rating: number
+  comment: string | null
+}): Promise<ReviewResult> {
+  if (!isValidUuid(input.offerId)) {
+    return { ok: false, error: "invalid offer id", sellerId: null }
+  }
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc("submit_review", {
+    p_offer_id: input.offerId,
+    p_rating: input.rating,
+    p_comment: input.comment?.trim() || null,
+  })
+  if (error) {
+    console.error("submitReviewRow:", error.message)
+    return { ok: false, error: error.message, sellerId: null }
+  }
+  const result = (data ?? {}) as {
+    ok?: boolean
+    error?: string | null
+    seller_id?: string | null
+  }
+  return {
+    ok: result.ok === true,
+    error: result.error ?? null,
+    sellerId: result.seller_id ?? null,
+  }
+}

--- a/app/lib/reviews/constants.ts
+++ b/app/lib/reviews/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure reviews domain value objects.
+ *
+ * Framework-agnostic constants and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/reviews` re-exports everything
+ * here (`export *`) so existing server-side imports keep resolving.
+ */
+
+// Rating range mirrors the DB check (rating between 1 and 5).
+export const RATING_MIN = 1
+export const RATING_MAX = 5
+
+// Comment cap mirrors the reviews_comment_length check.
+export const REVIEW_COMMENT_MAX = 1000
+
+// A review is only possible once the offer is accepted (INV-008).
+export const REVIEWABLE_OFFER_STATUS = "accepted" as const
+
+// Trust Score reflects the seller's average rating on a 0-100 scale
+// (rating 1-5 -> score 20-100). Kept here so the SQL formula and any client
+// preview of it cannot drift.
+export function ratingAverageToTrustScore(average: number | null): number {
+  if (average === null) return 50
+  return Math.round((Math.min(Math.max(average, RATING_MIN), RATING_MAX) / RATING_MAX) * 100)
+}

--- a/app/supabase/migrations/20260813120000_create_reviews.sql
+++ b/app/supabase/migrations/20260813120000_create_reviews.sql
@@ -1,0 +1,115 @@
+-- T10 - Reviews & ratings
+-- reviews: post-transaction buyer rating of the seller, one per accepted offer
+-- (INV-008), per docs/02-architecture/03-database-design-specification.md §12
+-- (schema), §20 (RLS Reviews), and docs/02-architecture/02-domain-model.md
+-- (INV-008, ReviewSubmitted event, Trust Score Service).
+--
+-- Writes go through the SECURITY DEFINER submit_review RPC (the same pattern as
+-- the offer transitions in T08) so seller_id is derived from the offer instead
+-- of client input, the reviewer is verified as the accepted-offer buyer, and the
+-- seller's trust_score is recomputed from ratings atomically with the insert.
+
+create table if not exists public.reviews (
+  id uuid primary key default gen_random_uuid(),
+  offer_id uuid not null unique references public.offers (id) on delete cascade,
+  seller_id uuid not null references public.profiles (id) on delete cascade,
+  buyer_id uuid not null references public.profiles (id) on delete cascade,
+  rating smallint not null check (rating between 1 and 5),
+  comment text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.reviews
+  add constraint if not exists reviews_comment_length
+  check (comment is null or char_length(comment) between 1 and 1000);
+
+-- Lookup paths: the seller's profile review list and "recent first".
+create index if not exists reviews_seller_id_idx on public.reviews (seller_id);
+create index if not exists reviews_seller_created_idx on public.reviews (seller_id, created_at desc);
+
+------------------------------------------------------------------------------
+-- RLS (DB spec §20 Reviews): public can read; the only write path is the
+-- submit_review RPC, so no INSERT/UPDATE/DELETE policies are granted to the
+-- client at all — a row can only arrive as the accepted-offer buyer, with
+-- seller_id taken from the offer.
+------------------------------------------------------------------------------
+alter table public.reviews enable row level security;
+
+create policy if not exists "Reviews are publicly readable"
+  on public.reviews for select
+  to authenticated, anon
+  using (true);
+
+------------------------------------------------------------------------------
+-- submit_review: only the buyer of an ACCEPTED offer may review (INV-008).
+-- The UNIQUE(offer_id) constraint enforces "one review per completed
+-- transaction"; the `on conflict do nothing` guard turns the constraint into a
+-- clean "already reviewed" response instead of a thrown unique violation.
+-- After insert, the seller's trust_score is recomputed from their average
+-- rating on a 0-100 scale (rating 1-5 -> score 20-100), which is what makes
+-- the rating visible as the seller badge's Trust score (AC5, INV-007).
+------------------------------------------------------------------------------
+create or replace function public.submit_review(p_offer_id uuid, p_rating smallint, p_comment text)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_listing public.listings;
+  v_seller_id uuid;
+  v_rows integer;
+begin
+  if p_rating is null or p_rating < 1 or p_rating > 5 then
+    return jsonb_build_object('ok', false, 'error', 'rating must be between 1 and 5');
+  end if;
+  if p_comment is not null and char_length(p_comment) > 1000 then
+    return jsonb_build_object('ok', false, 'error', 'comment is too long');
+  end if;
+
+  select * into v_offer from public.offers where id = p_offer_id;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  -- INV-008: a review must reference a completed transaction (an accepted
+  -- offer), and only the transaction's buyer may write it.
+  if v_offer.status <> 'accepted' or v_offer.buyer_id <> (select auth.uid()) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  select * into v_listing from public.listings where id = v_offer.listing_id;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'listing not found');
+  end if;
+  v_seller_id := v_listing.seller_id;
+
+  insert into public.reviews (offer_id, seller_id, buyer_id, rating, comment)
+  values (p_offer_id, v_seller_id, v_offer.buyer_id, p_rating, nullif(p_comment, ''))
+  on conflict (offer_id) do nothing;
+  get diagnostics v_rows = row_count;
+
+  if v_rows = 0 then
+    return jsonb_build_object('ok', false, 'error', 'offer already reviewed');
+  end if;
+
+  -- ReviewSubmitted -> Recalculate Trust Score (domain model §9).
+  update public.profiles
+    set trust_score = (
+      select round(avg(rating) * 20)::smallint
+      from public.reviews where seller_id = v_seller_id
+    )
+    where id = v_seller_id;
+
+  return jsonb_build_object('ok', true, 'error', null, 'seller_id', v_seller_id);
+end;
+$$;
+
+grant usage on schema public to anon, authenticated;
+grant select on public.reviews to authenticated, anon;
+
+-- RPC grant: authenticated only; revoking from public keeps the implicit
+-- EXECUTE grant from exposing it.
+revoke all on function public.submit_review(uuid, smallint, text) from public;
+grant execute on function public.submit_review(uuid, smallint, text) to authenticated;

--- a/app/tests/unit/reviews.test.ts
+++ b/app/tests/unit/reviews.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  RATING_MAX,
+  RATING_MIN,
+  REVIEW_COMMENT_MAX,
+  REVIEWABLE_OFFER_STATUS,
+  ratingAverageToTrustScore,
+} from "@/lib/reviews/constants"
+
+describe("reviews rating bounds", () => {
+  it("exposes a 1-5 rating range", () => {
+    expect(RATING_MIN).toBe(1)
+    expect(RATING_MAX).toBe(5)
+  })
+
+  it("only allows a review on an accepted offer", () => {
+    expect(REVIEWABLE_OFFER_STATUS).toBe("accepted")
+  })
+})
+
+describe("reviews comment cap", () => {
+  it("caps the review comment length", () => {
+    expect(REVIEW_COMMENT_MAX).toBe(1000)
+  })
+})
+
+describe("reviews.ratingAverageToTrustScore", () => {
+  it("maps a perfect average to 100", () => {
+    expect(ratingAverageToTrustScore(5)).toBe(100)
+  })
+
+  it("maps the minimum average to 20", () => {
+    expect(ratingAverageToTrustScore(1)).toBe(20)
+  })
+
+  it("scales linearly: a 4.0 average is 80", () => {
+    expect(ratingAverageToTrustScore(4)).toBe(80)
+  })
+
+  it("rounds a 2.5 average to 50", () => {
+    expect(ratingAverageToTrustScore(2.5)).toBe(50)
+  })
+
+  it("treats a null average as the neutral 50 default", () => {
+    expect(ratingAverageToTrustScore(null)).toBe(50)
+  })
+
+  it("clamps values above 5 to the 100 ceiling", () => {
+    expect(ratingAverageToTrustScore(5.5)).toBe(100)
+  })
+
+  it("clamps values below 1 to the 20 floor", () => {
+    expect(ratingAverageToTrustScore(-3)).toBe(20)
+  })
+})

--- a/docs/03-engineering/01-testing-strategy.md
+++ b/docs/03-engineering/01-testing-strategy.md
@@ -66,7 +66,7 @@ Tools:
 | Imports | Use `@/lib/...` aliases in tests, not `../lib/...` — relative specifiers resolve incorrectly under the Node env on Windows |
 | Coverage | `npm run test:ci` emits `coverage/` (gitignored) via the v8 provider |
 
-Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`, `LISTING_STATUS_LABELS`/`LISTING_STATUS_COLORS`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`), `lib/offers/constants` (`OFFER_STATUSES` status machine, `OFFER_AMOUNT_MAX`/`OFFER_MESSAGE_MAX` bounds, `buildLoginUrl`).
+Pure seam surfaces covered: `lib/listings/constants` (`isValidUuid`, `formatPrice`, `formatCondition`, `LISTING_STATUS_LABELS`/`LISTING_STATUS_COLORS`), `lib/media` (`detectImageMime`, `uploadObjects` validation gate), `lib/browse` (`parseBrowseParams` window clamp, `buildBrowseUrl`), `lib/search` (`parseSearchParams` filter validation, `buildSearchUrl`), `lib/pagination` (`parseOffset` window clamp, `nextOffset`), `lib/favorites/constants` (`toggleFavoriteState`, `buildLoginUrl`), `lib/offers/constants` (`OFFER_STATUSES` status machine, `OFFER_AMOUNT_MAX`/`OFFER_MESSAGE_MAX` bounds, `buildLoginUrl`), `lib/reviews/constants` (`RATING_MIN`/`RATING_MAX`, `REVIEW_COMMENT_MAX`, `REVIEWABLE_OFFER_STATUS`, `ratingAverageToTrustScore`).
 
 ## Integration Testing
 


### PR DESCRIPTION
Seller reviews & ratings.

- reviews table + RLS (public read; only the accepted-offer buyer can create); submit_review RPC derives seller_id from the offer and recomputes profiles.trust_score.
- BuyerOfferRow.review embed on fetchBuyerOffers; /offers page shows a ReviewForm for accepted offers w/o a review and a read-only summary once reviewed.
- /users/[id] renders the seller review list + aggregate rating.
- submitReview server action: zod validation (rating 1-5, comment <=1000), one-review-per-accepted-offer enforced by the UNIQUE(offer_id) constraint.
- lib/reviews/constants pure seams (RATING_MIN/MAX, REVIEW_COMMENT_MAX, ratingAverageToTrustScore); unit tests added; testing-strategy seam list updated.

Closes #14.