### PR TITLE
T11: Reports & admin moderation

### DIFF
--- a/app/app/actions/reports.ts
+++ b/app/app/actions/reports.ts
@@ -54,10 +54,11 @@ export async function submitReport(
     return { errors: parsed.error.flatten().fieldErrors }
   }
 
-  const user = await requireUser()
+  // Gate on a signed-in session before reaching the RPC; the RPC itself
+  // resolves the reporter from auth.uid() and enforces rate limiting.
+  await requireUser()
 
   const result = await createReportRow({
-    reporterId: user.id,
     listingId: parsed.data.listingId ?? null,
     sellerId: parsed.data.sellerId ?? null,
     reason: parsed.data.reason,

--- a/app/app/actions/reports.ts
+++ b/app/app/actions/reports.ts
@@ -1,0 +1,121 @@
+"use server"
+
+import { z } from "zod"
+import { revalidatePath } from "next/cache"
+
+import { requireUser } from "@/lib/auth"
+import {
+  createReport as createReportRow,
+  resolveReport as resolveReportRow,
+  REPORT_REASONS,
+  REPORT_NOTE_MAX,
+} from "@/lib/reports"
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
+
+const submitReportSchema = z.object({
+  listingId: z.string().uuid().optional(),
+  sellerId: z.string().uuid().optional(),
+  reason: z.enum(REPORT_REASONS),
+  note: z
+    .string()
+    .max(REPORT_NOTE_MAX, `Keep the note under ${REPORT_NOTE_MAX} characters`)
+    .optional(),
+}).refine(
+  (data) => {
+    const hasListing = data.listingId !== undefined && data.listingId !== null
+    const hasSeller = data.sellerId !== undefined && data.sellerId !== null
+    return hasListing || hasSeller
+  },
+  { message: "A report must target a listing or a seller" }
+)
+
+export type SubmitReportState = {
+  errors?: Record<string, string[] | undefined>
+  message?: string
+  ok?: boolean
+}
+
+export async function submitReport(
+  _prevState: SubmitReportState,
+  formData: FormData
+): Promise<SubmitReportState> {
+  const parsed = submitReportSchema.safeParse({
+    listingId: formValue(formData, "listingId"),
+    sellerId: formValue(formData, "sellerId"),
+    reason: formValue(formData, "reason"),
+    note: formValue(formData, "note"),
+  })
+
+  if (!parsed.success) {
+    return { errors: parsed.error.flatten().fieldErrors }
+  }
+
+  const user = await requireUser()
+
+  const result = await createReportRow({
+    reporterId: user.id,
+    listingId: parsed.data.listingId ?? null,
+    sellerId: parsed.data.sellerId ?? null,
+    reason: parsed.data.reason,
+    note: parsed.data.note ?? null,
+  })
+
+  if (!result.ok) {
+    return { message: result.error ?? "Could not submit your report" }
+  }
+
+  return { ok: true }
+}
+
+const resolveSchema = z.object({
+  reportId: z.string().uuid(),
+  action: z.enum(["remove_listing", "block_seller", "reject"]),
+  adminNote: z
+    .string()
+    .max(REPORT_NOTE_MAX, `Keep the note under ${REPORT_NOTE_MAX} characters`)
+    .optional(),
+})
+
+export type ResolveReportState = {
+  message?: string
+  ok?: boolean
+  resolvedId?: string
+}
+
+export async function adminResolveReport(
+  _prevState: ResolveReportState,
+  formData: FormData
+): Promise<ResolveReportState> {
+  const parsed = resolveSchema.safeParse({
+    reportId: formValue(formData, "reportId"),
+    action: formValue(formData, "action"),
+    adminNote: formValue(formData, "adminNote"),
+  })
+
+  if (!parsed.success) {
+    return { message: "Invalid report request" }
+  }
+
+  const user = await requireUser()
+  if (user.role !== "admin") {
+    return { message: "Not allowed" }
+  }
+
+  const result = await resolveReportRow(
+    parsed.data.reportId,
+    parsed.data.action,
+    parsed.data.adminNote ?? null
+  )
+
+  if (!result.ok) {
+    return { message: result.error ?? "Could not resolve the report" }
+  }
+
+  revalidatePath("/admin/reports")
+  revalidatePath("/dashboard")
+  return { ok: true, resolvedId: parsed.data.reportId }
+}

--- a/app/app/admin/reports/page.tsx
+++ b/app/app/admin/reports/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ShieldIcon } from "lucide-react"
+
+import { requireAdmin } from "@/lib/auth"
+import { fetchAdminReports } from "@/lib/reports"
+import { AdminReportCard } from "@/components/reports/admin-report-card"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+  title: "Admin — Reports",
+  description: "Moderation queue for reported listings and sellers.",
+}
+
+export default async function AdminReportsPage() {
+  const user = await requireAdmin()
+  const reports = await fetchAdminReports()
+
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold text-foreground">
+            Moderation queue
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {user.fullName
+              ? `Signed in as ${user.fullName}`
+              : "Signed in as admin"}
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/dashboard">← Back to dashboard</Link>
+        </Button>
+      </div>
+
+      {reports.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12">
+            <ShieldIcon className="size-8 text-muted-foreground" />
+            <h2 className="font-heading text-lg font-semibold">
+              All caught up
+            </h2>
+            <p className="max-w-sm text-center text-sm text-muted-foreground">
+              There are no open reports to review right now.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {reports.map((report) => (
+            <li key={report.id}>
+              <AdminReportCard report={report} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
-import { HeartIcon, InboxIcon, HandshakeIcon, LayoutDashboardIcon, PlusIcon, UserRoundIcon } from "lucide-react"
+import { HeartIcon, InboxIcon, HandshakeIcon, LayoutDashboardIcon, PlusIcon, ShieldIcon, UserRoundIcon } from "lucide-react"
 
 import { requireUser, ROLE_LABELS } from "@/lib/auth"
 import { fetchSellerListings } from "@/lib/listings"
@@ -149,6 +149,25 @@ export default async function DashboardPage() {
             </Button>
           </CardContent>
         </Card>
+
+        {user.role === "admin" ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldIcon className="size-5 text-primary" />
+                Moderation
+              </CardTitle>
+              <CardDescription>
+                Review reported listings and sellers in the moderation queue.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild variant="outline">
+                <Link href="/admin/reports">Open reports</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
 
         <Card>
           <CardHeader>

--- a/app/app/listings/[id]/page.tsx
+++ b/app/app/listings/[id]/page.tsx
@@ -9,6 +9,7 @@ import { fetchListing, formatCondition, formatPrice } from "@/lib/listings"
 import { fetchFavoriteIds } from "@/lib/favorites"
 import { FavoriteButton } from "@/components/favorites/favorite-button"
 import { MakeOfferButton } from "@/components/offers/make-offer-button"
+import { ReportButton } from "@/components/reports/report-button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -96,6 +97,10 @@ export default async function ListingPage({
             </h1>
             <Badge variant="secondary">{formatCondition(l.condition)}</Badge>
             <FavoriteButton listingId={l.id} initial={favorited} />
+            <ReportButton
+              target={{ type: "listing", listingId: l.id }}
+              signedIn={Boolean(user)}
+            />
           </div>
 
           <p className="text-2xl font-semibold text-foreground">
@@ -171,6 +176,11 @@ export default async function ListingPage({
               View seller profile
             </Link>
           </Button>
+
+          <ReportButton
+            target={{ type: "seller", sellerId: l.seller_id }}
+            signedIn={Boolean(user)}
+          />
         </div>
       </div>
 

--- a/app/components/reports/admin-report-card.tsx
+++ b/app/components/reports/admin-report-card.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useActionState } from "react"
+import { ExternalLinkIcon, TrashIcon, XIcon } from "lucide-react"
+
+import { adminResolveReport } from "@/app/actions/reports"
+import type { ReportWithRelations } from "@/lib/reports"
+import { REPORT_REASON_LABELS } from "@/lib/reports/constants"
+import { ReportStatusBadge } from "@/components/reports/report-status-badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+function ReportTarget({ report }: { report: ReportWithRelations }) {
+  const listing = report.listing
+  const seller = report.seller
+
+  if (listing) {
+    return (
+      <div className="flex items-start gap-3">
+        <div className="size-14 shrink-0 overflow-hidden rounded-md border bg-muted">
+          {listing.image_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={listing.image_url}
+              alt={listing.title}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+              No photo
+            </div>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <a
+            href={`/listings/${listing.id}`}
+            className="line-clamp-1 font-medium hover:underline"
+          >
+            {listing.title}
+          </a>
+          <p className="text-sm text-muted-foreground">
+            Price: {listing.price} ETB
+          </p>
+          {listing.seller ? (
+            <p className="text-xs text-muted-foreground">
+              Seller: {listing.seller.full_name ?? "Unnamed"}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    )
+  }
+
+  if (seller) {
+    return (
+      <div className="flex items-start gap-3">
+        <div className="flex size-14 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium">
+          {(seller.full_name?.[0] ?? seller.id[0].toUpperCase()).toUpperCase()}
+        </div>
+        <div className="min-w-0 flex-1">
+          <a
+            href={`/users/${seller.id}`}
+            className="font-medium hover:underline"
+          >
+            {seller.full_name ?? "Unnamed seller"}
+          </a>
+          <p className="text-sm text-muted-foreground">
+            Role: {seller.role ?? "buyer"} · Trust: {seller.trust_score ?? 0}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      Target no longer available
+    </p>
+  )
+}
+
+export function AdminReportCard({
+  report,
+}: {
+  report: ReportWithRelations
+}) {
+  const [state, action, pending] = useActionState(adminResolveReport, {})
+
+  const canRemoveListing = report.reported_listing_id !== null
+  const canBlockSeller = report.reported_seller_id !== null
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle>
+            <span className="font-medium">
+              {REPORT_REASON_LABELS[report.reason]}
+            </span>
+          </CardTitle>
+          <ReportStatusBadge status={report.status} />
+        </div>
+        <CardDescription>
+          Reported by{" "}
+          <span className="font-medium">
+            {report.reporter?.full_name ?? "Unknown"}
+          </span>{" "}
+          · {new Date(report.created_at).toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        <ReportTarget report={report} />
+
+        {report.note ? (
+          <p className="mt-3 text-sm text-foreground/80">{report.note}</p>
+        ) : null}
+
+        {state?.message && state.ok !== true ? (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {state.message}
+          </p>
+        ) : null}
+
+        <div className="mt-4 flex flex-col flex-wrap gap-2 sm:flex-row sm:items-center sm:justify-end">
+          {canRemoveListing && report.listing ? (
+            <Button asChild variant="outline" size="sm">
+              <a href={`/listings/${report.listing.id}`}>
+                <ExternalLinkIcon className="mr-1.5 size-3.5" />
+                View listing
+              </a>
+            </Button>
+          ) : null}
+
+          {canBlockSeller ? (
+            <form action={action}>
+              <input type="hidden" name="reportId" value={report.id} readOnly />
+              <input type="hidden" name="action" value="block_seller" readOnly />
+              <Button
+                type="submit"
+                variant="outline"
+                size="sm"
+                disabled={pending}
+                className="border-orange-200 text-orange-800 hover:bg-orange-50"
+              >
+                Block seller
+              </Button>
+            </form>
+          ) : null}
+
+          {canRemoveListing ? (
+            <form action={action}>
+              <input type="hidden" name="reportId" value={report.id} readOnly />
+              <input type="hidden" name="action" value="remove_listing" readOnly />
+              <Button
+                type="submit"
+                variant="outline"
+                size="sm"
+                disabled={pending}
+                className="border-red-200 text-red-800 hover:bg-red-50"
+              >
+                <TrashIcon className="mr-1.5 size-3.5" />
+                Remove listing
+              </Button>
+            </form>
+          ) : null}
+
+          <form action={action}>
+            <input type="hidden" name="reportId" value={report.id} readOnly />
+            <input type="hidden" name="action" value="reject" readOnly />
+            <Button type="submit" variant="ghost" size="sm" disabled={pending}>
+              <XIcon className="mr-1.5 size-3.5" />
+              Reject
+            </Button>
+          </form>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/components/reports/report-button.tsx
+++ b/app/components/reports/report-button.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { FlagIcon } from "lucide-react"
+
+import { buildLoginUrl } from "@/lib/reports/constants"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
+import { ReportDialog } from "@/components/reports/report-dialog"
+
+type Target =
+  | { type: "listing"; listingId: string }
+  | { type: "seller"; sellerId: string }
+
+export function ReportButton({
+  target,
+  signedIn,
+}: {
+  target: Target
+  signedIn: boolean
+}) {
+  const [open, setOpen] = useState(false)
+
+  const label = target.type === "listing" ? "Report listing" : "Report seller"
+  const href =
+    target.type === "listing"
+      ? `/listings/${target.listingId}`
+      : `/users/${target.sellerId}`
+
+  // Signed-out visitors route through login (with a ?next= back to the page).
+  if (!signedIn) {
+    return (
+      <Button asChild variant="outline" size="sm">
+        <Link href={buildLoginUrl(href)}>
+          <FlagIcon className="mr-1.5 size-4" />
+          {label}
+        </Link>
+      </Button>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <FlagIcon className="mr-1.5 size-4" />
+          {label}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <ReportDialog
+          listingId={target.type === "listing" ? target.listingId : null}
+          sellerId={target.type === "seller" ? target.sellerId : null}
+          onClose={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/components/reports/report-button.tsx
+++ b/app/components/reports/report-button.tsx
@@ -21,6 +21,15 @@ export function ReportButton({
   signedIn: boolean
 }) {
   const [open, setOpen] = useState(false)
+  // Incrementing the key on each open forces ReportDialog to remount, which
+  // resets its useActionState — otherwise a successful submission's state
+  // persists and the "report received" view shows on every reopen.
+  const [openKey, setOpenKey] = useState(0)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (nextOpen) setOpenKey((k) => k + 1)
+  }
 
   const label = target.type === "listing" ? "Report listing" : "Report seller"
   const href =
@@ -41,7 +50,7 @@ export function ReportButton({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
           <FlagIcon className="mr-1.5 size-4" />
@@ -50,6 +59,7 @@ export function ReportButton({
       </DialogTrigger>
       <DialogContent className="sm:max-w-md">
         <ReportDialog
+          key={openKey}
           listingId={target.type === "listing" ? target.listingId : null}
           sellerId={target.type === "seller" ? target.sellerId : null}
           onClose={() => setOpen(false)}

--- a/app/components/reports/report-dialog.tsx
+++ b/app/components/reports/report-dialog.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useActionState } from "react"
+import { CheckCircleIcon } from "lucide-react"
+
+import { submitReport } from "@/app/actions/reports"
+import type { SubmitReportState } from "@/app/actions/reports"
+import {
+  REPORT_REASONS,
+  REPORT_REASON_LABELS,
+  REPORT_NOTE_MAX,
+} from "@/lib/reports/constants"
+import { Button } from "@/components/ui/button"
+import {
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+
+function FieldError({ message }: { message: string | undefined }) {
+  return message ? <p className="text-sm text-destructive">{message}</p> : null
+}
+
+export function ReportDialog({
+  listingId,
+  sellerId,
+  onClose,
+}: {
+  listingId: string | null
+  sellerId: string | null
+  onClose: () => void
+}) {
+  const [state, formAction, pending] = useActionState<
+    SubmitReportState,
+    FormData
+  >(submitReport, {})
+
+  // T11 AC4: show a "report received" acknowledgement instead of silently
+  // closing — the reporter must see that their report was accepted.
+  if (state.ok) {
+    return (
+      <>
+        <DialogHeader>
+          <DialogTitle>Report received</DialogTitle>
+          <DialogDescription>
+            A moderator will review your report and take action if needed.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4 flex items-start gap-3">
+          <CheckCircleIcon className="mt-0.5 size-5 text-green-500" />
+          <p className="text-sm text-muted-foreground">
+            Thank you for helping keep the marketplace safe.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button type="button" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Report item</DialogTitle>
+        <DialogDescription>
+          Let us know why this item or seller should be reviewed. A moderator
+          will look at your report shortly.
+        </DialogDescription>
+      </DialogHeader>
+
+      <form action={formAction}>
+        <input type="hidden" name="listingId" value={listingId ?? ""} />
+        <input type="hidden" name="sellerId" value={sellerId ?? ""} />
+
+        <div className="mt-4 flex flex-col gap-3">
+          <fieldset className="flex flex-col gap-2">
+            <legend className="text-sm font-medium">Reason</legend>
+            {REPORT_REASONS.map((r) => (
+              <label
+                key={r}
+                className="flex items-center gap-2 text-sm"
+              >
+                <input type="radio" name="reason" value={r} required />
+                <span>{REPORT_REASON_LABELS[r]}</span>
+              </label>
+            ))}
+          </fieldset>
+          <FieldError message={state.errors?.reason?.[0]} />
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="report-note" className="text-sm font-medium">
+              Details (optional)
+            </label>
+            <textarea
+              id="report-note"
+              name="note"
+              rows={3}
+              maxLength={REPORT_NOTE_MAX}
+              placeholder="Add any details that will help the moderator."
+              className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+            />
+            <FieldError message={state.errors?.note?.[0]} />
+          </div>
+
+          {state.message ? (
+            <p role="alert" className="text-sm text-destructive">
+              {state.message}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button type="submit" disabled={pending}>
+            {pending ? "Sending…" : "Submit report"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </>
+  )
+}

--- a/app/components/reports/report-status-badge.tsx
+++ b/app/components/reports/report-status-badge.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import {
+  REPORT_STATUS_COLORS,
+  REPORT_STATUS_LABELS,
+  type ReportStatus,
+} from "@/lib/reports/constants"
+import { Badge } from "@/components/ui/badge"
+
+export function ReportStatusBadge({ status }: { status: ReportStatus }) {
+  return (
+    <Badge className={cn(REPORT_STATUS_COLORS[status])}>
+      {REPORT_STATUS_LABELS[status]}
+    </Badge>
+  )
+}

--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -53,3 +53,12 @@ export async function requireSeller(): Promise<SessionUser> {
   }
   return user
 }
+
+// T11: only admins may access the moderation queue.
+export async function requireAdmin(): Promise<SessionUser> {
+  const user = await requireUser()
+  if (user.role !== "admin") {
+    redirect("/dashboard")
+  }
+  return user
+}

--- a/app/lib/reports.ts
+++ b/app/lib/reports.ts
@@ -1,0 +1,331 @@
+import "server-only"
+
+import { createClient } from "@/lib/supabase/server"
+import type { ReportReason, ReportStatus } from "./reports/constants"
+
+// Re-export the pure value objects so imports from "@/lib/reports" keep
+// resolving. Definitions live in ./reports/constants (server-free).
+export * from "./reports/constants"
+
+// ---- Row shapes ----
+
+// Context for a listing-targeted report: the listing + its cover image + seller.
+export interface ReportListingContext {
+  id: string
+  title: string
+  price: number
+  image_url: string | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+  } | null
+}
+
+// Context for a seller-targeted report: the reported seller profile.
+export interface ReportSellerContext {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  trust_score: number | null
+}
+
+// A report enriched with the context needed by the admin queue and the
+// reporter's acknowledgement view. The listing/seller joins are nullable
+// (a report targets exactly one), mirroring the DB constraint.
+export interface ReportWithRelations {
+  id: string
+  reporter_id: string
+  reported_listing_id: string | null
+  reported_seller_id: string | null
+  reason: ReportReason
+  note: string | null
+  status: ReportStatus
+  created_at: string
+  updated_at: string
+  listing: ReportListingContext | null
+  seller: ReportSellerContext | null
+  reporter: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+  } | null
+}
+
+// The subset of a report's columns that the reporter sees (no other users'
+// identities leak — only their own reports are selectable under RLS).
+export interface MyReportRow {
+  id: string
+  reason: ReportReason
+  note: string | null
+  status: ReportStatus
+  target_type: "listing" | "seller"
+  target_id: string
+  target_title: string | null
+  created_at: string
+}
+
+// ---- Reads ----
+
+/** Columns selected for every report query (keeps the two read paths in sync). */
+const REPORT_COLUMNS =
+  "id, reporter_id, reported_listing_id, reported_seller_id, reason, note, status, created_at, updated_at"
+
+// Join spec for the reported item context. Reports has two FKs to profiles
+// (reporter_id and reported_seller_id), so the seller join needs an explicit
+// FK hint to disambiguate from the reporter join.
+const REPORT_JOINS = `${REPORT_COLUMNS},
+ listing:listings(id, title, price,
+   seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url),
+   images:listing_images(image_url, display_order)),
+ seller:profiles!reports_reported_seller_id_fkey(id, full_name, avatar_url, role, trust_score),
+ reporter:profiles!reports_reporter_id_fkey(id, full_name, avatar_url)`
+
+/**
+ * The reporter's own reports, newest first. Each row carries a denormalised
+ * target label so the client can render a compact "you reported X" line
+ * without a second round-trip.
+ */
+export async function fetchMyReports(
+  userId: string
+): Promise<MyReportRow[]> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from("reports")
+    .select(REPORT_JOINS)
+    .eq("reporter_id", userId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    console.error("fetchMyReports:", error.message)
+    return []
+  }
+
+  return (
+    (data ?? []) as unknown as RawReportRow[]
+  ).map(normalizeMyReport)
+}
+
+/**
+ * The admin moderation queue: all open reports with the reported item's
+ * context (listing + seller profile, or just the seller profile).
+ */
+export async function fetchAdminReports(): Promise<ReportWithRelations[]> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from("reports")
+    .select(REPORT_JOINS)
+    .in("status", ["open"])
+    .order("created_at", { ascending: true })
+
+  if (error) {
+    console.error("fetchAdminReports:", error.message)
+    return []
+  }
+
+  return (
+    (data ?? []) as unknown as RawReportRow[]
+  ).map(normalizeAdminReport)
+}
+
+// ---- Writes ----
+
+export interface ReportResult {
+  ok: boolean
+  error: string | null
+}
+
+/**
+ * Submit a report. Delegates to the submit_report RPC so the rate limit and
+ * duplicate-open checks run in a single SECURITY DEFINER round-trip.
+ */
+export async function createReport(params: {
+  reporterId: string
+  listingId?: string | null
+  sellerId?: string | null
+  reason: ReportReason
+  note?: string | null
+}): Promise<ReportResult> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase.rpc("submit_report", {
+    p_listing_id: params.listingId ?? null,
+    p_seller_id: params.sellerId ?? null,
+    p_reason: params.reason,
+    p_note: params.note?.trim() || null,
+  })
+
+  if (error) {
+    console.error("createReport:", error.message)
+    return { ok: false, error: error.message }
+  }
+
+  const result = (data ?? {}) as { ok?: boolean; error?: string | null }
+  return { ok: result.ok === true, error: result.error ?? null }
+}
+
+/**
+ * Admin-only: resolve a report with a moderation action. Returns the same
+ * jsonb shape the RPC emits ({ ok, error }) so the action layer can translate
+ * it uniformly.
+ */
+export async function resolveReport(
+  reportId: string,
+  action: "remove_listing" | "block_seller" | "reject",
+  adminNote?: string | null
+): Promise<ReportResult> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase.rpc("resolve_report", {
+    p_report_id: reportId,
+    p_action: action,
+    p_admin_note: adminNote?.trim() || null,
+  })
+
+  if (error) {
+    console.error("resolveReport:", error.message)
+    return { ok: false, error: error.message }
+  }
+
+  const result = (data ?? {}) as { ok?: boolean; error?: string | null }
+  return { ok: result.ok === true, error: result.error ?? null }
+}
+
+/**
+ * Count of open reports on a target. Used by the listing detail page to show
+ * a badge, and by the report dialog to warn the reporter.
+ */
+export async function countReports(
+  target: { listingId?: string | null; sellerId?: string | null } = {}
+): Promise<number> {
+  const supabase = await createClient()
+
+  let query = supabase
+    .from("reports")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "open")
+
+  if (target.listingId) {
+    query = query.eq("reported_listing_id", target.listingId)
+  } else if (target.sellerId) {
+    query = query.eq("reported_seller_id", target.sellerId)
+  } else {
+    return 0
+  }
+
+  const { count, error } = await query
+  if (error) {
+    console.error("countReports:", error.message)
+    return 0
+  }
+  return count ?? 0
+}
+
+// ---- Normalisation helpers (convert raw join rows to typed shapes) ----
+
+interface RawReportRow {
+  id: string
+  reporter_id: string
+  reported_listing_id: string | null
+  reported_seller_id: string | null
+  reason: string
+  note: string | null
+  status: string
+  created_at: string
+  updated_at: string
+  listing: {
+    id: string
+    title: string
+    price: number | string
+    seller?: { id: string; full_name: string | null; avatar_url: string | null } | null
+    images?: { image_url: string; display_order: number }[] | null
+  } | null
+  seller: {
+    id: string
+    full_name: string | null
+    avatar_url: string | null
+    role: string | null
+    trust_score: number | null
+  } | null
+  reporter: { id: string; full_name: string | null; avatar_url: string | null } | null
+}
+
+function pickCoverImage(
+  images: { image_url: string; display_order: number }[] | null | undefined
+): string | null {
+  return (
+    [...(images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]
+      ?.image_url ?? null
+  )
+}
+
+function normalizeAdminReport(row: RawReportRow): ReportWithRelations {
+  const listing = row.listing
+  const seller = row.seller
+  const reporter = row.reporter
+
+  return {
+    id: row.id,
+    reporter_id: row.reporter_id,
+    reported_listing_id: row.reported_listing_id,
+    reported_seller_id: row.reported_seller_id,
+    reason: (row.reason ?? "other") as ReportReason,
+    note: row.note,
+    status: (row.status ?? "open") as ReportStatus,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    listing: listing
+      ? {
+          id: listing.id,
+          title: listing.title,
+          price: Number(listing.price),
+          image_url: pickCoverImage(listing.images),
+          seller: listing.seller
+            ? {
+                id: listing.seller.id,
+                full_name: listing.seller.full_name,
+                avatar_url: listing.seller.avatar_url,
+              }
+            : null,
+        }
+      : null,
+    seller: seller
+      ? {
+          id: seller.id,
+          full_name: seller.full_name,
+          avatar_url: seller.avatar_url,
+          role: seller.role,
+          trust_score: seller.trust_score,
+        }
+      : null,
+    reporter: reporter
+      ? {
+          id: reporter.id,
+          full_name: reporter.full_name,
+          avatar_url: reporter.avatar_url,
+        }
+      : null,
+  }
+}
+
+function normalizeMyReport(row: RawReportRow): MyReportRow {
+  const listing = row.listing
+  const seller = row.seller
+
+  const isListing = row.reported_listing_id !== null
+  return {
+    id: row.id,
+    reason: (row.reason ?? "other") as ReportReason,
+    note: row.note,
+    status: (row.status ?? "open") as ReportStatus,
+    target_type: isListing ? "listing" : "seller",
+    target_id: isListing
+      ? row.reported_listing_id!
+      : row.reported_seller_id!,
+    target_title: isListing ? listing?.title ?? null : seller?.full_name ?? null,
+    created_at: row.created_at,
+  }
+}

--- a/app/lib/reports.ts
+++ b/app/lib/reports.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import { OPEN_REPORT_STATUSES } from "./reports/constants"
 import type { ReportReason, ReportStatus } from "./reports/constants"
 
 // Re-export the pure value objects so imports from "@/lib/reports" keep
@@ -118,7 +119,7 @@ export async function fetchAdminReports(): Promise<ReportWithRelations[]> {
   const { data, error } = await supabase
     .from("reports")
     .select(REPORT_JOINS)
-    .in("status", ["open"])
+    .in("status", OPEN_REPORT_STATUSES)
     .order("created_at", { ascending: true })
 
   if (error) {
@@ -141,9 +142,10 @@ export interface ReportResult {
 /**
  * Submit a report. Delegates to the submit_report RPC so the rate limit and
  * duplicate-open checks run in a single SECURITY DEFINER round-trip.
+ * The reporter is resolved from the session (auth.uid) inside the RPC, so
+ * the caller's own user id is not trusted.
  */
 export async function createReport(params: {
-  reporterId: string
   listingId?: string | null
   sellerId?: string | null
   reason: ReportReason
@@ -192,36 +194,6 @@ export async function resolveReport(
 
   const result = (data ?? {}) as { ok?: boolean; error?: string | null }
   return { ok: result.ok === true, error: result.error ?? null }
-}
-
-/**
- * Count of open reports on a target. Used by the listing detail page to show
- * a badge, and by the report dialog to warn the reporter.
- */
-export async function countReports(
-  target: { listingId?: string | null; sellerId?: string | null } = {}
-): Promise<number> {
-  const supabase = await createClient()
-
-  let query = supabase
-    .from("reports")
-    .select("id", { count: "exact", head: true })
-    .eq("status", "open")
-
-  if (target.listingId) {
-    query = query.eq("reported_listing_id", target.listingId)
-  } else if (target.sellerId) {
-    query = query.eq("reported_seller_id", target.sellerId)
-  } else {
-    return 0
-  }
-
-  const { count, error } = await query
-  if (error) {
-    console.error("countReports:", error.message)
-    return 0
-  }
-  return count ?? 0
 }
 
 // ---- Normalisation helpers (convert raw join rows to typed shapes) ----

--- a/app/lib/reports/constants.ts
+++ b/app/lib/reports/constants.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure reports domain value objects.
+ *
+ * Framework-agnostic constants, types and helpers shared by Server and Client
+ * modules. This module intentionally has NO `server-only` import and imports no
+ * Supabase client, so Client Components can consume it directly without pulling
+ * the server seam into the client graph. `@/lib/reports` re-exports everything
+ * here (`export *`).
+ */
+
+export const REPORT_REASONS = [
+  "spam",
+  "fraud",
+  "duplicate",
+  "wrong_category",
+  "offensive_content",
+  "other",
+] as const
+
+export type ReportReason = (typeof REPORT_REASONS)[number]
+
+export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
+  spam: "Spam",
+  fraud: "Fraud",
+  duplicate: "Duplicate",
+  wrong_category: "Wrong Category",
+  offensive_content: "Offensive Content",
+  other: "Other",
+}
+
+// A small icon hint per reason so the admin queue can badge each row without a
+// lookup table. Reuses lucide icon names (kept as strings to avoid a client
+// import in this server-safe module).
+export const REPORT_REASON_ICONS: Record<ReportReason, string> = {
+  spam: "Flag",
+  fraud: "ShieldAlert",
+  duplicate: "Copy",
+  wrong_category: "Tag",
+  offensive_content: "AlertCircle",
+  other: "HelpCircle",
+}
+
+export const REPORT_STATUSES = ["open", "resolved", "rejected"] as const
+
+export type ReportStatus = (typeof REPORT_STATUSES)[number]
+
+export const REPORT_STATUS_LABELS: Record<ReportStatus, string> = {
+  open: "Open",
+  resolved: "Resolved",
+  rejected: "Rejected",
+}
+
+// Open is the only actionable state in the admin queue.
+export const OPEN_REPORT_STATUSES: ReportStatus[] = ["open"]
+
+// Palette mirrors the offer-badge convention: neutral for open, green for
+// resolved, red for rejected.
+export const REPORT_STATUS_COLORS: Record<ReportStatus, string> = {
+  open: "bg-amber-100 text-amber-800",
+  resolved: "bg-green-100 text-green-800",
+  rejected: "bg-red-100 text-red-800",
+}
+
+// Note length mirrors the DB constraint (1-1000).
+export const REPORT_NOTE_MAX = 1000
+
+// Rate limit: max 5 reports per reporter per target within a 1-hour window.
+// Enforced in the submit_report RPC (DB) and surfaced here for the client to
+// show a friendly message before the request lands.
+export const REPORT_RATE_LIMIT_COUNT = 5
+export const REPORT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
+
+/**
+ * The login redirect target for the Report button. Login honors a `?next=`
+ * query param (see app/login/page.tsx), so a signed-out visitor who taps
+ * Report lands back on the exact listing after signing in. Kept here so the
+ * Client Component needs no URL-building logic.
+ */
+export function buildLoginUrl(pathname: string): string {
+  return `/login?next=${encodeURIComponent(pathname)}`
+}

--- a/app/lib/reports/constants.ts
+++ b/app/lib/reports/constants.ts
@@ -28,18 +28,6 @@ export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
   other: "Other",
 }
 
-// A small icon hint per reason so the admin queue can badge each row without a
-// lookup table. Reuses lucide icon names (kept as strings to avoid a client
-// import in this server-safe module).
-export const REPORT_REASON_ICONS: Record<ReportReason, string> = {
-  spam: "Flag",
-  fraud: "ShieldAlert",
-  duplicate: "Copy",
-  wrong_category: "Tag",
-  offensive_content: "AlertCircle",
-  other: "HelpCircle",
-}
-
 export const REPORT_STATUSES = ["open", "resolved", "rejected"] as const
 
 export type ReportStatus = (typeof REPORT_STATUSES)[number]

--- a/app/proxy.ts
+++ b/app/proxy.ts
@@ -2,7 +2,14 @@ import { type NextRequest, NextResponse } from "next/server"
 
 import { updateSession } from "@/lib/supabase/middleware"
 
-const PROTECTED_PREFIXES = ["/profile", "/dashboard", "/favorites", "/sell", "/onboarding"]
+const PROTECTED_PREFIXES = [
+  "/profile",
+  "/dashboard",
+  "/favorites",
+  "/sell",
+  "/onboarding",
+  "/admin",
+]
 const AUTH_PREFIXES = ["/login", "/register", "/forgot-password", "/reset-password"]
 
 function matches(pathname: string, prefixes: string[]) {

--- a/app/supabase/migrations/20260813120000_create_reports.sql
+++ b/app/supabase/migrations/20260813120000_create_reports.sql
@@ -164,9 +164,9 @@ $$;
 -- resolve_report RPC (SECURITY DEFINER).
 -- Admin moderation action. p_action decides the verdict:
 --   'remove_listing'  -> soft-delete the reported listing, close the report.
---   'block_seller'    -> set the seller's role back to 'buyer' (revokes seller
---                        tools; RLS keeps their existing listings readable),
---                        close the report.
+--   'block_seller'    -> demote the seller's role to 'buyer' and soft-delete
+--                        their active listings (so blocked content disappears
+--                        from all reads under RLS), close the report.
 --   'reject'          -> just close the report with status 'rejected' (no
 --                        content change).
 ------------------------------------------------------------------------------
@@ -210,10 +210,16 @@ begin
       return jsonb_build_object('ok', false, 'error', 'report has no seller target');
     end if;
     -- Revoke seller privileges: demote to buyer. This strips the seller
-    -- role so the profile gate (requireSeller) blocks them.
+    -- role so the profile gate (requireSeller) blocks them. Any active
+    -- listings they have are soft-deleted so they disappear from all reads.
     update public.profiles
       set role = 'buyer'
       where id = v_report.reported_seller_id;
+    update public.listings
+      set deleted_at = now(), status = 'archived'
+      where seller_id = v_report.reported_seller_id
+        and deleted_at is null
+        and status in ('published', 'draft');
   elsif p_action = 'reject' then
     -- No content change; just close the report.
   else
@@ -227,7 +233,8 @@ begin
     end,
     note = case
       when p_admin_note is not null then
-        coalesce(note, '') || ' [admin: ' || p_admin_note || ']'
+        -- Truncate to honour the reports_note_length check (1000 chars).
+        left(coalesce(note, '') || ' [admin: ' || p_admin_note || ']', 1000)
       else note
     end
     where id = p_report_id;

--- a/app/supabase/migrations/20260813120000_create_reports.sql
+++ b/app/supabase/migrations/20260813120000_create_reports.sql
@@ -1,0 +1,243 @@
+-- T11 - Reports & admin moderation
+-- reports: users report listings or sellers; an admin review queue processes them
+-- and can remove content or block a seller. Per docs/02-architecture/03-database-design-specification.md
+-- §20 (RLS: reporter reads own, admin full access), §22 (migration naming), §18
+-- (constraints), and the T11 acceptance criteria.
+--
+-- Submission is rate-limited by the submit_report RPC (SECURITY DEFINER) so a
+-- caller cannot bypass it with a raw INSERT. Admin resolution is likewise an RPC
+-- so a single action atomically closes the report and applies the moderation
+-- verdict to the targeted listing/seller.
+
+create type if not exists public.report_reason as enum (
+  'spam', 'fraud', 'duplicate', 'wrong_category', 'offensive_content', 'other'
+);
+
+create type if not exists public.report_status as enum (
+  'open', 'resolved', 'rejected'
+);
+
+create table if not exists public.reports (
+  id uuid primary key default gen_random_uuid(),
+  reporter_id uuid not null references public.profiles (id) on delete cascade,
+  reported_listing_id uuid references public.listings (id) on delete cascade,
+  reported_seller_id uuid references public.profiles (id) on delete cascade,
+  reason public.report_reason not null,
+  note text,
+  status public.report_status not null default 'open',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- A report must target exactly one of listing or seller.
+  constraint reports_target_one check (
+    (reported_listing_id is not null)::integer + (reported_seller_id is not null)::integer = 1
+  ),
+  constraint reports_note_length check (
+    note is null or char_length(note) between 1 and 1000
+  )
+);
+
+create index if not exists reports_reporter_id_idx on public.reports (reporter_id);
+create index if not exists reports_listing_id_idx on public.reports (reported_listing_id);
+create index if not exists reports_seller_id_idx on public.reports (reported_seller_id);
+create index if not exists reports_status_idx on public.reports (status);
+create index if not exists reports_created_at_idx on public.reports (created_at);
+
+create trigger if not exists reports_set_updated_at
+  before update on public.reports
+  for each row execute function public.handle_updated_at();
+
+------------------------------------------------------------------------------
+-- RLS (T11 AC): a user sees only their own reports; an admin sees all.
+-- No one else can read a report (reasons/notes never leak to other users).
+------------------------------------------------------------------------------
+alter table public.reports enable row level security;
+
+create policy if not exists "Reports are readable by the reporter"
+  on public.reports for select
+  to authenticated
+  using ((select auth.uid()) = reporter_id);
+
+create policy if not exists "Reports are readable by admins"
+  on public.reports for select
+  to authenticated
+  using (public.is_admin());
+
+create policy if not exists "Reports are manageable by admins"
+  on public.reports for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- Inserts are never direct: the submit_report RPC enforces the rate limit and
+-- the "exactly one target" rule is already covered by the table constraint.
+revoke all on public.reports from public;
+grant usage on schema public to authenticated;
+grant select on public.reports to authenticated;
+
+------------------------------------------------------------------------------
+-- submit_report RPC (SECURITY DEFINER).
+-- Enforces rate limiting (max REPORT_RATE_LIMIT_COUNT submissions per reporter
+-- per target within REPORT_RATE_LIMIT_WINDOW seconds) and inserts the row.
+-- Returns jsonb { ok, error } so the caller gets a single result.
+------------------------------------------------------------------------------
+create or replace function public.submit_report(
+  p_listing_id uuid default null,
+  p_seller_id uuid default null,
+  p_reason public.report_reason,
+  p_note text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_reporter uuid;
+  v_recent integer;
+begin
+  -- Resolve the reporter from the session, never trust the caller-supplied id.
+  v_reporter := auth.uid();
+
+  if v_reporter is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  -- A report targets exactly one of listing or seller.
+  if (p_listing_id is not null)::integer + (p_seller_id is not null)::integer <> 1 then
+    return jsonb_build_object('ok', false, 'error', 'report must target a listing or a seller');
+  end if;
+
+  -- If targeting a listing, it must exist and be readable (RLS). If targeting a
+  -- seller, that profile must exist.
+  if p_listing_id is not null then
+    if not exists (select 1 from public.listings where id = p_listing_id) then
+      return jsonb_build_object('ok', false, 'error', 'listing not found');
+    end if;
+  else
+    if not exists (select 1 from public.profiles where id = p_seller_id) then
+      return jsonb_build_object('ok', false, 'error', 'seller not found');
+    end if;
+  end if;
+
+  -- Rate limit: max 5 reports per reporter per target within the last hour.
+  select count(*) into v_recent
+  from public.reports
+  where (
+        (p_listing_id is not null and reported_listing_id = p_listing_id)
+       or (p_seller_id is not null and reported_seller_id = p_seller_id)
+    )
+    and reporter_id = v_reporter
+    and created_at > now() - interval '1 hour';
+
+  if v_recent >= 5 then
+    return jsonb_build_object('ok', false, 'error', 'rate limit exceeded, please wait before submitting another report');
+  end if;
+
+  -- Prevent duplicate open reports for the same target by the same reporter.
+  if p_listing_id is not null and exists (
+    select 1 from public.reports
+    where reporter_id = v_reporter
+      and reported_listing_id = p_listing_id
+      and status = 'open'
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'you already have an open report for this listing');
+  end if;
+
+  if p_seller_id is not null and exists (
+    select 1 from public.reports
+    where reporter_id = v_reporter
+      and reported_seller_id = p_seller_id
+      and status = 'open'
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'you already have an open report for this seller');
+  end if;
+
+  insert into public.reports (reporter_id, reported_listing_id, reported_seller_id, reason, note)
+  values (v_reporter, p_listing_id, p_seller_id, p_reason, p_note);
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+------------------------------------------------------------------------------
+-- resolve_report RPC (SECURITY DEFINER).
+-- Admin moderation action. p_action decides the verdict:
+--   'remove_listing'  -> soft-delete the reported listing, close the report.
+--   'block_seller'    -> set the seller's role back to 'buyer' (revokes seller
+--                        tools; RLS keeps their existing listings readable),
+--                        close the report.
+--   'reject'          -> just close the report with status 'rejected' (no
+--                        content change).
+------------------------------------------------------------------------------
+create or replace function public.resolve_report(
+  p_report_id uuid,
+  p_action text,
+  p_admin_note text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_report public.reports;
+begin
+  if not public.is_admin() then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  select * into v_report from public.reports where id = p_report_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'report not found');
+  end if;
+
+  if v_report.status <> 'open' then
+    return jsonb_build_object('ok', false, 'error', 'report already resolved');
+  end if;
+
+  if p_action = 'remove_listing' then
+    if v_report.reported_listing_id is null then
+      return jsonb_build_object('ok', false, 'error', 'report has no listing target');
+    end if;
+    -- Soft-delete the listing (mirrors softDeleteListing; RLS already gives
+    -- admins full access via the "manageable by admins" policy).
+    update public.listings
+      set deleted_at = now(), status = 'archived'
+      where id = v_report.reported_listing_id;
+  elsif p_action = 'block_seller' then
+    if v_report.reported_seller_id is null then
+      return jsonb_build_object('ok', false, 'error', 'report has no seller target');
+    end if;
+    -- Revoke seller privileges: demote to buyer. This strips the seller
+    -- role so the profile gate (requireSeller) blocks them.
+    update public.profiles
+      set role = 'buyer'
+      where id = v_report.reported_seller_id;
+  elsif p_action = 'reject' then
+    -- No content change; just close the report.
+  else
+    return jsonb_build_object('ok', false, 'error', 'invalid action');
+  end if;
+
+  update public.reports
+    set status = case
+      when p_action = 'reject' then 'rejected'
+      else 'resolved'
+    end,
+    note = case
+      when p_admin_note is not null then
+        coalesce(note, '') || ' [admin: ' || p_admin_note || ']'
+      else note
+    end
+    where id = p_report_id;
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+-- RPC grants: only authenticated (admin checks happen inside each function).
+revoke all on function public.submit_report from public;
+revoke all on function public.resolve_report from public;
+grant execute on function public.submit_report to authenticated;
+grant execute on function public.resolve_report to authenticated;

--- a/app/tests/unit/reports.test.ts
+++ b/app/tests/unit/reports.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  REPORT_REASONS,
+  REPORT_REASON_LABELS,
+  REPORT_REASON_ICONS,
+  REPORT_STATUSES,
+  REPORT_STATUS_LABELS,
+  REPORT_STATUS_COLORS,
+  REPORT_NOTE_MAX,
+  REPORT_RATE_LIMIT_COUNT,
+  REPORT_RATE_LIMIT_WINDOW_MS,
+  type ReportReason,
+  type ReportStatus,
+} from "@/lib/reports/constants"
+
+describe("reports reasons", () => {
+  it("declares the six AC reasons", () => {
+    expect(REPORT_REASONS).toEqual([
+      "spam",
+      "fraud",
+      "duplicate",
+      "wrong_category",
+      "offensive_content",
+      "other",
+    ])
+  })
+
+  it("maps a label to every declared reason", () => {
+    for (const reason of REPORT_REASONS) {
+      expect(REPORT_REASON_LABELS[reason]).toBeTruthy()
+    }
+  })
+
+  it("maps an icon hint to every declared reason", () => {
+    for (const reason of REPORT_REASONS) {
+      expect(REPORT_REASON_ICONS[reason]).toBeTruthy()
+    }
+  })
+
+  it("does not add labels for undeclared reasons", () => {
+    const declared = new Set<string>(REPORT_REASONS)
+    const labeled = Object.keys(REPORT_REASON_LABELS) as ReportReason[]
+    expect(labeled.every((s) => declared.has(s))).toBe(true)
+  })
+})
+
+describe("reports statuses", () => {
+  it("declares open, resolved, rejected", () => {
+    expect(REPORT_STATUSES).toEqual(["open", "resolved", "rejected"])
+  })
+
+  it("labels and colors cover every declared status", () => {
+    for (const status of REPORT_STATUSES) {
+      expect(REPORT_STATUS_LABELS[status]).toBeTruthy()
+      expect(REPORT_STATUS_COLORS[status]).toMatch(/^bg-.*text-/)
+    }
+  })
+
+  it("labels every declared status", () => {
+    const declared = new Set<string>(REPORT_STATUSES)
+    const labeled = Object.keys(REPORT_STATUS_LABELS) as ReportStatus[]
+    expect(labeled.every((s) => declared.has(s))).toBe(true)
+  })
+})
+
+describe("reports bounds", () => {
+  it("exposes a 1000-char note ceiling", () => {
+    expect(REPORT_NOTE_MAX).toBe(1000)
+  })
+
+  it("exposes a positive rate-limit count within a 1-hour window", () => {
+    expect(REPORT_RATE_LIMIT_COUNT).toBeGreaterThan(0)
+    expect(REPORT_RATE_LIMIT_WINDOW_MS).toBe(60 * 60 * 1000)
+  })
+})

--- a/app/tests/unit/reports.test.ts
+++ b/app/tests/unit/reports.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest"
 import {
   REPORT_REASONS,
   REPORT_REASON_LABELS,
-  REPORT_REASON_ICONS,
   REPORT_STATUSES,
   REPORT_STATUS_LABELS,
   REPORT_STATUS_COLORS,
@@ -29,12 +28,6 @@ describe("reports reasons", () => {
   it("maps a label to every declared reason", () => {
     for (const reason of REPORT_REASONS) {
       expect(REPORT_REASON_LABELS[reason]).toBeTruthy()
-    }
-  })
-
-  it("maps an icon hint to every declared reason", () => {
-    for (const reason of REPORT_REASONS) {
-      expect(REPORT_REASON_ICONS[reason]).toBeTruthy()
     }
   })
 


### PR DESCRIPTION
Implements T11 (issue #15):

- Reports table with RLS (reporter sees own reports, admins see all)
- submit_report RPC: rate-limited (5/hr per target), dedup open reports
- resolve_report RPC: remove_listing, block_seller, reject actions
- Report dialog on listing detail page (report listing + report seller)
- Admin moderation queue at /admin/reports
- Dashboard moderation card for admin role
- requireAdmin() auth helper

All checks pass: typecheck, lint, 70 tests, production build.