### PR TITLE
T15: polish, accessibility & Lighthouse

### DIFF
--- a/web/app/actions/offers.ts
+++ b/web/app/actions/offers.ts
@@ -51,9 +51,8 @@ export async function submitOffer(
     return { errors: parsed.error.flatten().fieldErrors }
   }
 
-  const user = await requireUser()
+  await requireUser()
   const result = await submitOfferRow({
-    userId: user.id,
     listingId: parsed.data.listingId,
     amount: parsed.data.amount,
     message: parsed.data.message ?? null,

--- a/web/app/admin/reports/loading.tsx
+++ b/web/app/admin/reports/loading.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function AdminReportsLoading() {
+  return (
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="mt-2 h-4 w-40" />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="h-40 rounded-lg border bg-card p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-16 w-20" />
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-44" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              </div>
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </div>
+            <Skeleton className="mt-4 h-4 w-2/3" />
+            <Skeleton className="mt-3 h-8 w-40" />
+          </div>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/web/app/dashboard/loading.tsx
+++ b/web/app/dashboard/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function DashboardLoading() {
+  return (
+    <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <Skeleton className="h-5 w-20" />
+        <Skeleton className="mt-3 h-9 w-72" />
+        <Skeleton className="mt-2 h-4 w-96 max-w-full" />
+      </div>
+
+      <div className="mb-10 rounded-lg border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-8 w-36" />
+        </div>
+        <Skeleton className="mt-4 h-4 w-72 max-w-full" />
+        <div className="mt-6 space-y-3">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="flex gap-3">
+              <Skeleton className="h-20 w-24" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} className="h-36 rounded-lg border bg-card" />
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.error("App route error:", error)
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-4 px-4 py-20 text-center">
+      <h1 className="font-heading text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-sm text-muted-foreground">
+        We could not load this page right now.
+      </p>
+      <div className="flex gap-3">
+        <Button onClick={reset}>Try again</Button>
+        <Button asChild variant="outline">
+          <Link href="/">Back to home</Link>
+        </Button>
+      </div>
+    </main>
+  )
+}

--- a/web/app/favorites/loading.tsx
+++ b/web/app/favorites/loading.tsx
@@ -1,13 +1,15 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
 export default function FavoritesLoading() {
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
-      <div className="mb-8 h-7 w-48 animate-pulse rounded bg-muted" />
-      <div className="grid grid-cols-1 gap-x-6 gap-y-8 animate-pulse sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <Skeleton className="mb-8 h-7 w-48" />
+      <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {Array.from({ length: 8 }).map((_, i) => (
           <div key={i}>
-            <div className="aspect-[4/3] w-full rounded-lg bg-muted" />
-            <div className="mt-2 h-4 w-3/4 rounded bg-muted" />
-            <div className="mt-2 h-4 w-1/4 rounded bg-muted" />
+            <Skeleton className="aspect-[4/3] w-full" />
+            <Skeleton className="mt-2 h-4 w-3/4" />
+            <Skeleton className="mt-2 h-4 w-1/4" />
           </div>
         ))}
       </div>

--- a/web/app/global-error.tsx
+++ b/web/app/global-error.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.error("Unhandled app error:", error)
+  return (
+    <html lang="en">
+      <body className="flex min-h-full flex-col items-center justify-center gap-4 bg-background px-4 py-20 text-center font-sans text-foreground">
+        <h1 className="font-heading text-2xl font-semibold">
+          Something went wrong
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          A critical error occurred. Please reload the page.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  )
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -7,6 +7,7 @@ import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
 import { AuthProvider } from "@/components/auth/auth-provider";
 import { siteName } from "@/lib/nav";
+import { SITE_URL, SITE_TITLE, SITE_DESCRIPTION } from "@/lib/site";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -19,12 +20,30 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: `${siteName} — Buy and sell used goods`,
+    default: SITE_TITLE,
     template: `%s | ${siteName}`,
   },
-  description:
-    "VinTech Marketplace is a trusted platform for buying and selling used goods.",
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    siteName,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: "/",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#2563EB",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/web/app/listings/[id]/edit/loading.tsx
+++ b/web/app/listings/[id]/edit/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function EditListingLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-8 sm:px-6 lg:px-8">
+      <Skeleton className="h-8 w-40" />
+      <Skeleton className="mt-2 h-4 w-72 max-w-full" />
+
+      <div className="mt-6 rounded-lg border bg-card p-6">
+        <div className="space-y-4">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      </div>
+
+      <Skeleton className="mt-4 h-11 w-full" />
+    </main>
+  )
+}

--- a/web/app/listings/[id]/page.tsx
+++ b/web/app/listings/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import { MapPinIcon, TagIcon } from "lucide-react"
@@ -73,20 +74,27 @@ export default async function ListingPage({
         <div>
           {cover ? (
             <div className="relative aspect-[4/3] w-full overflow-hidden rounded-lg border">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={cover} alt={l.title} className="h-full w-full object-cover" />
+              <Image
+                src={cover}
+                alt={l.title}
+                fill
+                priority
+                sizes="(max-width: 768px) 100vw, 50vw"
+                className="object-cover"
+              />
               {images.length > 1 ? (
                 <div className="mt-3 grid grid-cols-5 gap-2">
                   {images.map((img) => (
                     <div
                       key={img.id}
-                      className="aspect-video w-full overflow-hidden rounded-md border"
+                      className="relative aspect-video w-full overflow-hidden rounded-md border"
                     >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
+                      <Image
                         src={img.image_url}
                         alt={img.alt_text ?? l.title}
-                        className="h-full w-full object-cover"
+                        fill
+                        sizes="(max-width: 768px) 18vw, 10vw"
+                        className="object-cover"
                       />
                     </div>
                   ))}

--- a/web/app/loading.tsx
+++ b/web/app/loading.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function HomeLoading() {
+  return (
+    <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
+      <section className="mb-12 text-center">
+        <Skeleton className="mx-auto h-10 w-3/4 max-w-xl" />
+        <Skeleton className="mx-auto mt-3 h-4 w-1/2 max-w-sm" />
+        <div className="mx-auto mt-6 flex w-64 justify-center gap-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-10 w-32" />
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <Skeleton className="h-6 w-48" />
+        <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+          {Array.from({ length: 6 }, (_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }, (_, i) => (
+            <div key={i}>
+              <Skeleton className="aspect-[4/3] w-full" />
+              <Skeleton className="mt-2 h-4 w-3/4" />
+              <Skeleton className="mt-2 h-4 w-1/4" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/web/app/login/loading.tsx
+++ b/web/app/login/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function LoginLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-sm flex-1 flex-col justify-center px-4 py-16 sm:px-6 lg:px-8">
+      <div className="rounded-lg border bg-card">
+        <div className="space-y-2 p-6 text-center">
+          <Skeleton className="mx-auto h-6 w-32" />
+          <Skeleton className="mx-auto h-4 w-48" />
+        </div>
+        <div className="space-y-4 px-6 pb-6">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center px-4 py-20 text-center">
+      <h1 className="font-heading text-2xl font-semibold">Page not found</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <Link href="/" className={cn(buttonVariants({ variant: "link", size: "lg" }), "mt-4")}>
+        Back to home
+      </Link>
+    </main>
+  )
+}

--- a/web/app/offers/page.tsx
+++ b/web/app/offers/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Image from "next/image"
 import Link from "next/link"
 import { SendIcon } from "lucide-react"
 
@@ -56,13 +57,14 @@ export default async function OffersPage() {
               <Card>
                 <CardContent className="p-4">
                   <div className="flex items-start gap-4">
-                    <div className="size-20 shrink-0 overflow-hidden rounded-md border bg-muted">
+                    <div className="relative size-20 shrink-0 overflow-hidden rounded-md border bg-muted">
                       {offer.listing?.image_url ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
+                        <Image
                           src={offer.listing.image_url}
                           alt=""
-                          className="h-full w-full object-cover"
+                          fill
+                          sizes="80px"
+                          className="object-cover"
                         />
                       ) : (
                         <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">

--- a/web/app/onboarding/loading.tsx
+++ b/web/app/onboarding/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function OnboardingLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col justify-center px-4 py-16 sm:px-6 lg:px-8">
+      <div className="space-y-2 text-center">
+        <Skeleton className="mx-auto h-6 w-56" />
+        <Skeleton className="mx-auto h-4 w-72 max-w-full" />
+      </div>
+      <div className="mt-8 space-y-4 rounded-lg border bg-card p-6">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-11 w-full" />
+      </div>
+    </main>
+  )
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
@@ -8,6 +9,12 @@ import { buildBrowseUrl, nextOffset, parseBrowseParams } from "@/lib/browse"
 import { CategoryCard } from "@/components/categories/category-card"
 import { ListingCard } from "@/components/listings/listing-card"
 import { FavoriteButton } from "@/components/favorites/favorite-button"
+
+export const metadata: Metadata = {
+  title: "Marketplace for trusted second-hand goods",
+  description:
+    "Buy and sell used goods confidently across Addis Ababa with VinTech Marketplace.",
+}
 
 function NoResultsIcon({ className }: { className?: string }) {
   return (

--- a/web/app/profile/loading.tsx
+++ b/web/app/profile/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function ProfileLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <div className="rounded-lg border bg-card p-6">
+        <div className="flex items-center gap-4">
+          <Skeleton className="size-16 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+        </div>
+        <div className="mt-6 space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <div className="grid grid-cols-2 gap-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-11 w-full" />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/register/loading.tsx
+++ b/web/app/register/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function RegisterLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-sm flex-1 flex-col justify-center px-4 py-16 sm:px-6 lg:px-8">
+      <div className="rounded-lg border bg-card">
+        <div className="space-y-2 p-6 text-center">
+          <Skeleton className="mx-auto h-6 w-44" />
+          <Skeleton className="mx-auto h-4 w-56" />
+        </div>
+        <div className="space-y-4 px-6 pb-6">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_URL } from "@/lib/site"
+
+export default function robots(): MetadataRoute.Robots {
+  const base = SITE_URL
+  return {
+    rules: { userAgent: "*", allow: "/", disallow: ["/dashboard", "/profile", "/sell", "/offers", "/favorites", "/admin", "/onboarding"] },
+    sitemap: base ? `${base}/sitemap.xml` : undefined,
+  }
+}

--- a/web/app/search/loading.tsx
+++ b/web/app/search/loading.tsx
@@ -1,22 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
 export default function SearchLoading() {
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
       <div className="mb-8 space-y-3">
-        <div className="h-9 w-72 animate-pulse rounded-lg bg-muted" />
-        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+        <Skeleton className="h-9 w-72" />
+        <Skeleton className="h-4 w-40" />
       </div>
 
-      <div className="animate-pulse rounded-lg border bg-card p-4">
-        <div className="h-9 w-full rounded-md bg-muted" />
-        <div className="mt-4 h-9 w-full rounded-md bg-muted" />
+      <div className="rounded-lg border bg-card p-4">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="mt-4 h-9 w-full" />
       </div>
 
       <div className="mt-8 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {Array.from({ length: 8 }, (_, i) => (
-          <div key={i} className="animate-pulse">
-            <div className="aspect-[4/3] rounded-lg bg-muted" />
-            <div className="mt-3 h-4 w-3/4 rounded bg-muted" />
-            <div className="mt-2 h-4 w-1/3 rounded bg-muted" />
+          <div key={i}>
+            <Skeleton className="aspect-[4/3] rounded-lg" />
+            <Skeleton className="mt-3 h-4 w-3/4" />
+            <Skeleton className="mt-2 h-4 w-1/3" />
           </div>
         ))}
       </div>

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
@@ -5,6 +6,12 @@ import { fetchCategories, searchListings } from "@/lib/listings"
 import { buildSearchUrl, nextOffset, parseSearchParams } from "@/lib/search"
 import { ListingCard } from "@/components/listings/listing-card"
 import { SearchFilters } from "@/components/search/search-filters"
+
+export const metadata: Metadata = {
+  title: "Search listings",
+  description:
+    "Search and filter used goods listings on VinTech Marketplace by keyword, category, price, condition, and city.",
+}
 
 function SearchIcon({ className }: { className?: string }) {
   return (

--- a/web/app/sell/loading.tsx
+++ b/web/app/sell/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function SellLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-8 sm:px-6 lg:px-8">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="mt-2 h-4 w-80 max-w-full" />
+      <div className="mt-6 space-y-4 rounded-lg border bg-card p-6">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <div className="grid grid-cols-2 gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+        <Skeleton className="h-28 w-full" />
+        <Skeleton className="h-11 w-full" />
+      </div>
+    </main>
+  )
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next"
+
+import { SITE_URL } from "@/lib/site"
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = SITE_URL
+  const now = new Date()
+  return [
+    { url: base, lastModified: now, changeFrequency: "daily", priority: 1 },
+    { url: `${base}/search`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${base}/register`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
+    { url: `${base}/login`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
+  ]
+}

--- a/web/app/users/[id]/loading.tsx
+++ b/web/app/users/[id]/loading.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function UserProfileLoading() {
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 py-10 sm:px-6 lg:px-8">
+      <div className="rounded-lg border bg-card p-6">
+        <div className="flex items-center gap-4">
+          <Skeleton className="size-16 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </div>
+        <div className="mt-6 space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+        <div className="mt-6 grid grid-cols-2 gap-4">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-lg border bg-card p-6">
+        <Skeleton className="h-5 w-40" />
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 2 }, (_, i) => (
+            <Skeleton key={i} className="h-20" />
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/users/[id]/page.tsx
+++ b/web/app/users/[id]/page.tsx
@@ -252,7 +252,18 @@ export default async function UserProfilePage({
             </ul>
           </CardContent>
         </Card>
-      ) : null}
+      ) : (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Reviews</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              No reviews yet. Reviews appear after a completed transaction.
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
 
       <div className="mt-6 text-center">

--- a/web/components/contact/contact-button.tsx
+++ b/web/components/contact/contact-button.tsx
@@ -6,9 +6,14 @@ import { MessageCircleIcon } from "lucide-react"
 
 import { buildLoginUrl } from "@/lib/contact/constants"
 import type { SellerContactInfo } from "@/lib/contact"
+import { lazyDialog } from "@/lib/lazy-dialog"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { ContactDialog } from "@/components/contact/contact-dialog"
+
+// T15: load the contact form only when the dialog opens (code splitting).
+const ContactDialog = lazyDialog(() =>
+  import("@/components/contact/contact-dialog").then((m) => m.ContactDialog)
+)
 
 interface ContactButtonProps {
   listingId?: string | null

--- a/web/components/dashboard/listing-manager.tsx
+++ b/web/components/dashboard/listing-manager.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import Link from "next/link"
 import { useActionState, useState } from "react"
 import { EyeIcon, HeartIcon, PackageOpenIcon, PencilIcon, PlusIcon, XIcon } from "lucide-react"
@@ -19,14 +20,14 @@ function ListingRow({ listing }: { listing: SellerListingRow }) {
     <li>
       <Card>
         <CardContent className="flex flex-wrap items-center gap-4 p-4">
-          <div className="size-16 shrink-0 overflow-hidden rounded-md border bg-muted">
+          <div className="relative size-16 shrink-0 overflow-hidden rounded-md border bg-muted">
             {listing.cover_image_url && !imgError ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
+              <Image
                 src={listing.cover_image_url}
                 alt=""
-                className="h-full w-full object-cover"
-                loading="lazy"
+                fill
+                sizes="64px"
+                className="object-cover"
                 onError={() => setImgError(true)}
               />
             ) : (

--- a/web/components/listings/create-listing-form.tsx
+++ b/web/components/listings/create-listing-form.tsx
@@ -7,6 +7,7 @@ import { XIcon, UploadIcon } from "lucide-react"
 import { createListing } from "@/app/actions/listings"
 import { CONDITIONS } from "@/lib/listings/constants"
 import type { Category } from "@/lib/listings"
+import { FIELD_CLASS, TEXTAREA_CLASS } from "@/lib/form-fields"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -91,6 +92,7 @@ export function CreateListingForm({
                       URL.revokeObjectURL(url)
                       setPreviews((p) => p.filter((u) => u !== url))
                     }}
+                    aria-label={`Remove photo ${i + 1}`}
                     className="absolute right-1 top-1 rounded bg-background/80 p-0.5"
                   >
                     <XIcon className="size-4" />
@@ -124,7 +126,7 @@ export function CreateListingForm({
               id="description"
               name="description"
               rows={5}
-              className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+              className={TEXTAREA_CLASS}
               placeholder="Include condition, brand, age, what's included..."
             />
             <FieldError message={state.errors?.description?.[0]} />
@@ -171,7 +173,7 @@ export function CreateListingForm({
             <select
               id="categoryId"
               name="categoryId"
-              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+              className={FIELD_CLASS}
               aria-invalid={!!state.errors?.categoryId}
             >
               <option value="">Pick a category</option>

--- a/web/components/listings/edit-listing-form.tsx
+++ b/web/components/listings/edit-listing-form.tsx
@@ -6,6 +6,7 @@ import { XIcon } from "lucide-react"
 import { updateListing, deleteListing } from "@/app/actions/listings"
 import { CONDITIONS, STATUSES_FOR_DISPLAY } from "@/lib/listings/constants"
 import type { Category, Listing } from "@/lib/listings"
+import { FIELD_CLASS, TEXTAREA_CLASS } from "@/lib/form-fields"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -53,7 +54,7 @@ export function EditListingForm({
                 name="description"
                 rows={5}
                 defaultValue={listing.description ?? ""}
-                className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+                className={TEXTAREA_CLASS}
               />
               <FieldError message={state.errors?.description?.[0]} />
             </div>
@@ -100,7 +101,7 @@ export function EditListingForm({
               <select
                 id="categoryId"
                 name="categoryId"
-                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                className={FIELD_CLASS}
                 defaultValue={listing.category_id ?? ""}
                 aria-invalid={!!state.errors?.categoryId}
               >
@@ -160,7 +161,7 @@ export function EditListingForm({
           <CardContent>
             <select
               name="status"
-              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+              className={FIELD_CLASS}
               defaultValue={listing.status}
             >
               {STATUSES_FOR_DISPLAY.map((s) => (

--- a/web/components/listings/listing-card.tsx
+++ b/web/components/listings/listing-card.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image"
 import Link from "next/link"
 import type { ReactNode } from "react"
 
@@ -21,12 +22,12 @@ export function ListingCard({
         <Link href={href} aria-label={listing.title}>
           <div className="aspect-[4/3] w-full overflow-hidden rounded-lg border bg-muted">
             {listing.image_url ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
+              <Image
                 src={listing.image_url}
                 alt=""
-                className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                loading="lazy"
+                fill
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="object-cover transition-transform duration-200 group-hover:scale-105"
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">

--- a/web/components/offers/make-offer-button.tsx
+++ b/web/components/offers/make-offer-button.tsx
@@ -5,9 +5,14 @@ import { useState } from "react"
 import { usePathname } from "next/navigation"
 
 import { buildLoginUrl } from "@/lib/offers/constants"
+import { lazyDialog } from "@/lib/lazy-dialog"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { OfferModal } from "@/components/offers/offer-modal"
+
+// T15: load the offer form only when the dialog opens (code splitting).
+const OfferModal = lazyDialog(() =>
+  import("@/components/offers/offer-modal").then((m) => m.OfferModal)
+)
 
 export function MakeOfferButton({
   listingId,

--- a/web/components/offers/offer-modal.tsx
+++ b/web/components/offers/offer-modal.tsx
@@ -6,6 +6,7 @@ import { useActionState } from "react"
 import { submitOffer } from "@/app/actions/offers"
 import { formatPrice } from "@/lib/listings/constants"
 import { OFFER_MESSAGE_MAX } from "@/lib/offers/constants"
+import { TEXTAREA_CLASS } from "@/lib/form-fields"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -76,7 +77,7 @@ export function OfferModal({
             rows={4}
             maxLength={OFFER_MESSAGE_MAX}
             placeholder="e.g. I can collect this weekend, would you take…"
-            className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+            className={TEXTAREA_CLASS}
           />
           <FieldError message={state.errors?.message?.[0]} />
         </div>

--- a/web/components/reports/admin-report-card.tsx
+++ b/web/components/reports/admin-report-card.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import { useActionState } from "react"
 import { ExternalLinkIcon, TrashIcon, XIcon } from "lucide-react"
 
@@ -23,13 +24,14 @@ function ReportTarget({ report }: { report: ReportWithRelations }) {
   if (listing) {
     return (
       <div className="flex items-start gap-3">
-        <div className="size-14 shrink-0 overflow-hidden rounded-md border bg-muted">
+        <div className="relative size-14 shrink-0 overflow-hidden rounded-md border bg-muted">
           {listing.image_url ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={listing.image_url}
               alt={listing.title}
-              className="h-full w-full object-cover"
+              fill
+              sizes="56px"
+              className="object-cover"
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">

--- a/web/components/reports/report-button.tsx
+++ b/web/components/reports/report-button.tsx
@@ -5,9 +5,14 @@ import { useState } from "react"
 import { FlagIcon } from "lucide-react"
 
 import { buildLoginUrl } from "@/lib/reports/constants"
+import { lazyDialog } from "@/lib/lazy-dialog"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { ReportDialog } from "@/components/reports/report-dialog"
+
+// T15: load the report form only when the dialog opens (code splitting).
+const ReportDialog = lazyDialog(() =>
+  import("@/components/reports/report-dialog").then((m) => m.ReportDialog)
+)
 
 type Target =
   | { type: "listing"; listingId: string }

--- a/web/components/reports/report-dialog.tsx
+++ b/web/components/reports/report-dialog.tsx
@@ -10,6 +10,7 @@ import {
   REPORT_REASON_LABELS,
   REPORT_NOTE_MAX,
 } from "@/lib/reports/constants"
+import { TEXTAREA_CLASS } from "@/lib/form-fields"
 import { Button } from "@/components/ui/button"
 import {
   DialogHeader,
@@ -101,7 +102,7 @@ export function ReportDialog({
               rows={3}
               maxLength={REPORT_NOTE_MAX}
               placeholder="Add any details that will help the moderator."
-              className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+              className={TEXTAREA_CLASS}
             />
             <FieldError message={state.errors?.note?.[0]} />
           </div>

--- a/web/components/reviews/review-form.tsx
+++ b/web/components/reviews/review-form.tsx
@@ -5,6 +5,7 @@ import { StarIcon } from "lucide-react"
 
 import { submitReview, type ReviewState } from "@/app/actions/reviews"
 import { RATING_MAX, REVIEW_COMMENT_MAX } from "@/lib/reviews/constants"
+import { TEXTAREA_CLASS } from "@/lib/form-fields"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
@@ -79,7 +80,7 @@ export function ReviewForm({
           rows={4}
           maxLength={REVIEW_COMMENT_MAX}
           placeholder="What was the transaction like?"
-          className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
+          className={TEXTAREA_CLASS}
         />
         <FieldError message={state.errors?.comment?.[0]} />
       </div>

--- a/web/components/search/search-filters.tsx
+++ b/web/components/search/search-filters.tsx
@@ -7,11 +7,9 @@ import { SearchIcon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { FIELD_CLASS } from "@/lib/form-fields"
 import { CONDITIONS, type Category, type Condition } from "@/lib/listings/constants"
 import { buildSearchUrl, SEARCH_SORTS, type SearchQuery } from "@/lib/search"
-
-const FIELD_CLASS =
-  "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
 
 const SELECT_SORT_LABELS: Record<(typeof SEARCH_SORTS)[number], string> = {
   newest: "Newest first",
@@ -59,7 +57,11 @@ export function SearchFilters({
       <div className="flex flex-col gap-4 rounded-lg border bg-card p-4">
         <div className="relative">
           <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Label htmlFor="search-keyword" className="sr-only">
+            Search by keyword
+          </Label>
           <Input
+            id="search-keyword"
             type="search"
             name="q"
             value={q}

--- a/web/components/ui/skeleton.tsx
+++ b/web/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/web/lib/contact.ts
+++ b/web/lib/contact.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import type { SellerContactInfo, ContactMethod } from "./contact/constants"
 
 export * from "./contact/constants"
@@ -48,15 +49,15 @@ export async function recordContactAttempt(params: {
 }): Promise<ContactAttemptResult> {
   const supabase = await createClient()
 
-  const { error } = await supabase.from("contact_attempts").insert({
-    contact_method: params.contactMethod,
-    listing_id: params.listingId ?? null,
-    seller_id: params.sellerId,
-  })
-
-  if (error) {
-    console.error("recordContactAttempt:", error.message)
-    return { ok: false, error: error.message }
-  }
-  return { ok: true, error: null }
+  const result = await callOutcomeRpc(
+    supabase,
+    "record_contact_attempt",
+    {
+      p_contact_method: params.contactMethod,
+      p_seller_id: params.sellerId,
+      p_listing_id: params.listingId ?? null,
+    },
+    "recordContactAttempt"
+  )
+  return { ok: result.ok === true, error: result.error ?? null }
 }

--- a/web/lib/form-fields.ts
+++ b/web/lib/form-fields.ts
@@ -1,0 +1,7 @@
+// Shared field styling so every form control keeps the same focus ring and
+// border treatment (T15: consistent keyboard-visible focus at WCAG AA).
+export const FIELD_CLASS =
+  "w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+
+export const TEXTAREA_CLASS =
+  "resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring"

--- a/web/lib/lazy-dialog.ts
+++ b/web/lib/lazy-dialog.ts
@@ -1,0 +1,15 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import type { ComponentType } from "react"
+
+/**
+ * Lazy-load a dialog/form component when its dialog opens, so the heavy form
+ * code never ships in the initial bundle (T15 code splitting). Usage:
+ * `const OfferModal = lazyDialog(() => import("./offer-modal").then(m => m.OfferModal))`
+ */
+export function lazyDialog<TProps extends object>(
+  loader: () => Promise<ComponentType<TProps>>
+): ComponentType<TProps> {
+  return dynamic(() => loader(), { ssr: false })
+}

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import {
   isValidUuid,
   mapBrowseListing,
@@ -178,10 +179,11 @@ export interface OfferResult {
   error: string | null
 }
 
-// A new offer. RLS enforces the published + not-own-listing rules (INV-005,
-// ListingMarkedSold); the explicit uuid gate keeps junk ids from reaching the DB.
+// A new offer. The submit_offer RPC enforces the published + not-own-listing
+// rules (INV-005, ListingMarkedSold), validates amount/message, and applies a
+// per-buyer-per-listing rate limit; the explicit uuid gate keeps junk ids from
+// reaching the DB. The buyer is resolved from the session inside the RPC.
 export async function submitOfferRow(input: {
-  userId: string
   listingId: string
   amount: number
   message: string | null
@@ -190,17 +192,12 @@ export async function submitOfferRow(input: {
     return { ok: false, error: "invalid listing id" }
   }
   const supabase = await createClient()
-  const { error } = await supabase.from("offers").insert({
-    listing_id: input.listingId,
-    buyer_id: input.userId,
-    amount: input.amount,
-    message: input.message?.trim() || null,
-  })
-  if (error) {
-    console.error("submitOfferRow:", error.message)
-    return { ok: false, error: error.message }
-  }
-  return { ok: true, error: null }
+  const result = await callOutcomeRpc(supabase, "submit_offer", {
+    p_listing_id: input.listingId,
+    p_amount: input.amount,
+    p_message: input.message?.trim() || null,
+  }, "submitOfferRow")
+  return { ok: result.ok === true, error: result.error ?? null }
 }
 
 async function runOfferRpc(
@@ -208,12 +205,7 @@ async function runOfferRpc(
   args: Record<string, string | number>
 ): Promise<OfferResult> {
   const supabase = await createClient()
-  const { data, error } = await supabase.rpc(fn, args)
-  if (error) {
-    console.error(`${fn}:`, error.message)
-    return { ok: false, error: error.message }
-  }
-  const result = (data ?? {}) as { ok?: boolean; error?: string | null }
+  const result = await callOutcomeRpc(supabase, fn, args, fn)
   return { ok: result.ok === true, error: result.error ?? null }
 }
 

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -1,0 +1,9 @@
+// Canonical site identity shared by the root layout's metadata (metadataBase,
+// OG/Twitter defaults) and the sitemap so the deployment URL and copy are
+// defined once.
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://vintech-marketplace.vercel.app"
+
+export const SITE_TITLE = "VinTech Marketplace — Buy and sell used goods"
+export const SITE_DESCRIPTION =
+  "VinTech Marketplace is a trusted platform for buying and selling used goods."

--- a/web/lib/supabase/rpc.ts
+++ b/web/lib/supabase/rpc.ts
@@ -9,12 +9,23 @@ export type RpcName =
   | "submit_report"
   | "resolve_report"
   | "record_verification"
+  | "submit_offer"
+  | "accept_offer"
+  | "decline_offer"
+  | "counter_offer"
+  | "record_contact_attempt"
 
 export type RpcArgs = Record<string, string | number | null>
 
 export interface RpcResult<T> {
   data: T | null
   error: string | null
+}
+
+/** The jsonb envelope every SECURITY DEFINER write-RPC returns. */
+export interface RpcOutcome {
+  ok?: boolean
+  error?: string | null
 }
 
 /** One typed seam for every RPC call. Mirrors offers.ts::runOfferRpc: the name
@@ -28,4 +39,20 @@ export async function callRpc<T>(
 ): Promise<RpcResult<T>> {
   const { data, error } = await supabase.rpc(name, args)
   return { data: (data ?? null) as T | null, error: error?.message ?? null }
+}
+
+/** Normalise a write-RPC's `{ ok, error }` envelope, collapsing the jsonb
+ * payload and the transport error into one `{ ok, error }` result. */
+export async function callOutcomeRpc(
+  supabase: Supabase,
+  name: RpcName,
+  args: RpcArgs,
+  logLabel: string
+): Promise<RpcOutcome> {
+  const { data, error } = await callRpc<RpcOutcome>(supabase, name, args)
+  if (error) {
+    console.error(`${logLabel}:`, error)
+    return { ok: false, error }
+  }
+  return data ?? {}
 }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,9 +1,33 @@
 import type { NextConfig } from "next";
 
+// T04: allow multi-photo create requests (10 x 5 MB) in a single server action.
+// T15: images are served from Supabase Storage; next/image needs the host
+// allowlisted so it can optimize (resize/AVIF/WebP) and lazy-load them.
+function supabaseImageHost(): { protocol: "http" | "https"; hostname: string } | undefined {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+    return {
+      protocol: parsed.protocol === "http:" ? "http" : "https",
+      hostname: parsed.hostname,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+const imageHost = supabaseImageHost();
+
 const nextConfig: NextConfig = {
-  /* config options here */
-  // T04: allow multi-photo create requests (10 x 5 MB) in a single server action.
   experimental: { serverActions: { bodySizeLimit: "50mb" } },
+  images: {
+    remotePatterns: imageHost
+      ? [{ protocol: imageHost.protocol, hostname: imageHost.hostname, pathname: "/**" }]
+      : [],
+    formats: ["image/avif", "image/webp"],
+  },
 };
 
 export default nextConfig;

--- a/web/supabase/migrations/20260815000000_security_hardening.sql
+++ b/web/supabase/migrations/20260815000000_security_hardening.sql
@@ -1,0 +1,166 @@
+-- T15 - Polish, accessibility & Lighthouse: security pass
+-- Two gaps closed (per the T15 audit):
+--   1. offers/contact_attempts had no rate limit and accepted direct inserts.
+--      Mirrors the reports pattern (submit_report): move the write behind a
+--      SECURITY DEFINER RPC that enforces a per-target window, and revoke the
+--      raw INSERT so the limit cannot be bypassed.
+--   2. listing_images UPDATE policy had `using` but no `with check`, letting a
+--      seller rewrite image_url/alt_text/display_order to arbitrary values.
+
+-- The per-buyer-per-seller rate limit below needs the attempt's initiator
+-- recorded. The T13 table only captured the target (seller_id), so add the
+-- buyer side (populated by the RPC from auth.uid(), never client-supplied).
+alter table public.contact_attempts
+  add column if not exists buyer_id uuid references public.profiles (id) on delete cascade;
+
+create index if not exists contact_attempts_buyer_id_idx
+  on public.contact_attempts (buyer_id);
+
+-----------------------------------------------------------------------------
+-- 1. submit_offer RPC (rate-limited offer submission)
+-----------------------------------------------------------------------------
+create or replace function public.submit_offer(
+  p_listing_id uuid,
+  p_amount numeric,
+  p_message text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_buyer uuid;
+  v_recent integer;
+begin
+  v_buyer := auth.uid();
+  if v_buyer is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  if p_amount is null or p_amount <= 0 then
+    return jsonb_build_object('ok', false, 'error', 'invalid amount');
+  end if;
+  if p_amount > 100000000 then
+    return jsonb_build_object('ok', false, 'error', 'amount too large');
+  end if;
+  if p_message is not null and char_length(p_message) > 500 then
+    return jsonb_build_object('ok', false, 'error', 'message too long');
+  end if;
+
+  -- The listing must be live, published, and not the buyer's own (INV-005).
+  if not exists (
+    select 1 from public.listings
+    where id = p_listing_id
+      and status = 'published'
+      and deleted_at is null
+      and seller_id <> v_buyer
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'listing is not available for offers');
+  end if;
+
+  -- Rate limit: max 10 offers per buyer per listing within the last hour.
+  select count(*) into v_recent
+  from public.offers
+  where buyer_id = v_buyer
+    and listing_id = p_listing_id
+    and created_at > now() - interval '1 hour';
+
+  if v_recent >= 10 then
+    return jsonb_build_object('ok', false, 'error', 'rate limit exceeded, please wait before submitting another offer');
+  end if;
+
+  insert into public.offers (listing_id, buyer_id, amount, message)
+  values (p_listing_id, v_buyer, p_amount, nullif(trim(p_message), ''));
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+revoke all on function public.submit_offer(uuid, numeric, text) from public;
+grant execute on function public.submit_offer(uuid, numeric, text) to authenticated;
+
+-- Offers are written only via the RPC now (rate limit). SELECT stays open to
+-- participants; the transition RPCs already own the UPDATE/DELETE surface.
+revoke insert on public.offers from authenticated;
+
+-----------------------------------------------------------------------------
+-- 2. record_contact_attempt RPC (rate-limited contact audit log)
+-----------------------------------------------------------------------------
+create or replace function public.record_contact_attempt(
+  p_contact_method public.contact_method,
+  p_seller_id uuid,
+  p_listing_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_buyer uuid;
+  v_recent integer;
+begin
+  v_buyer := auth.uid();
+  if v_buyer is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  -- The target seller must exist (no forging audit rows for arbitrary ids).
+  if not exists (select 1 from public.profiles where id = p_seller_id) then
+    return jsonb_build_object('ok', false, 'error', 'seller not found');
+  end if;
+
+  -- If a listing context is given, it must exist.
+  if p_listing_id is not null and not exists (
+    select 1 from public.listings where id = p_listing_id
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'listing not found');
+  end if;
+
+  -- Rate limit: max 20 contact attempts per buyer per seller within an hour.
+  select count(*) into v_recent
+  from public.contact_attempts
+  where seller_id = p_seller_id
+    and buyer_id = v_buyer
+    and created_at > now() - interval '1 hour';
+  if v_recent >= 20 then
+    return jsonb_build_object('ok', false, 'error', 'rate limit exceeded, please wait before contacting this seller again');
+  end if;
+
+  insert into public.contact_attempts (contact_method, seller_id, listing_id, buyer_id)
+  values (p_contact_method, p_seller_id, p_listing_id, v_buyer);
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+revoke all on function public.record_contact_attempt(public.contact_method, uuid, uuid) from public;
+grant execute on function public.record_contact_attempt(public.contact_method, uuid, uuid) to authenticated;
+
+-- Contact attempts are written only via the RPC now (rate limit + target check).
+revoke insert on public.contact_attempts from authenticated;
+
+-----------------------------------------------------------------------------
+-- 3. listing_images UPDATE policy: add the missing `with check`
+-----------------------------------------------------------------------------
+drop policy if exists "Listing images are updatable by the listing owner"
+  on public.listing_images;
+
+create policy "Listing images are updatable by the listing owner"
+  on public.listing_images for update
+  to authenticated
+  using (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.seller_id = (select auth.uid())
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.listings l
+      where l.id = listing_images.listing_id
+        and l.seller_id = (select auth.uid())
+    )
+  );

--- a/web/tests/unit/contact.test.ts
+++ b/web/tests/unit/contact.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+import { createClient } from "@/lib/supabase/server"
+import { recordContactAttempt } from "@/lib/contact"
 import {
   CONTACT_METHODS,
   CONTACT_METHOD_LABELS,
@@ -9,6 +15,8 @@ import {
   type ContactMethod,
   type SellerContactInfo,
 } from "@/lib/contact/constants"
+
+const mockCreateClient = vi.mocked(createClient)
 
 const makeInfo = (over: Partial<SellerContactInfo>): SellerContactInfo => ({
   telegram_username: null,
@@ -98,5 +106,74 @@ describe("buildContactUrl", () => {
   it("strips non-digits from phone for the tel: scheme", () => {
     const info = makeInfo({ phone: "07911 123 456", phone_public: true })
     expect(buildContactUrl("phone", info)).toBe("tel:07911123456")
+  })
+})
+
+describe("recordContactAttempt (rate-limited RPC)", () => {
+  it("delegates to the record_contact_attempt RPC with seller and listing", async () => {
+    const rpc = vi.fn(async () => ({
+      data: { ok: true, error: null },
+      error: null,
+    }))
+    mockCreateClient.mockResolvedValue({ rpc } as never)
+
+    const result = await recordContactAttempt({
+      contactMethod: "telegram",
+      sellerId: "s-1",
+      listingId: "l-1",
+    })
+
+    expect(rpc).toHaveBeenCalledWith("record_contact_attempt", {
+      p_contact_method: "telegram",
+      p_seller_id: "s-1",
+      p_listing_id: "l-1",
+    })
+    expect(result).toEqual({ ok: true, error: null })
+  })
+
+  it("passes null listing when no listing context is given", async () => {
+    const rpc = vi.fn(async () => ({
+      data: { ok: true, error: null },
+      error: null,
+    }))
+    mockCreateClient.mockResolvedValue({ rpc } as never)
+
+    await recordContactAttempt({ contactMethod: "phone", sellerId: "s-1" })
+
+    expect(rpc).toHaveBeenCalledWith("record_contact_attempt", {
+      p_contact_method: "phone",
+      p_seller_id: "s-1",
+      p_listing_id: null,
+    })
+  })
+
+  it("surfaces a rate-limit error from the RPC", async () => {
+    mockCreateClient.mockResolvedValue({
+      rpc: async () => ({
+        data: { ok: false, error: "rate limit exceeded, please wait before contacting this seller again" },
+        error: null,
+      }),
+    } as never)
+
+    const result = await recordContactAttempt({
+      contactMethod: "telegram",
+      sellerId: "s-1",
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("rate limit exceeded")
+  })
+
+  it("reduces a PostgREST error to its message", async () => {
+    mockCreateClient.mockResolvedValue({
+      rpc: async () => ({ data: null, error: { message: "boom" } }),
+    } as never)
+
+    const result = await recordContactAttempt({
+      contactMethod: "phone",
+      sellerId: "s-1",
+    })
+
+    expect(result).toEqual({ ok: false, error: "boom" })
   })
 })

--- a/web/tests/unit/offers.test.ts
+++ b/web/tests/unit/offers.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+import { createClient } from "@/lib/supabase/server"
+import { submitOfferRow } from "@/lib/offers"
 import {
   buildLoginUrl,
   OFFER_AMOUNT_MAX,
@@ -10,6 +16,8 @@ import {
   OPEN_OFFER_STATUSES,
   type OfferStatus,
 } from "@/lib/offers/constants"
+
+const mockCreateClient = vi.mocked(createClient)
 
 describe("offers status machine", () => {
   it("declares the four AC statuses", () => {
@@ -59,5 +67,74 @@ describe("offers.buildLoginUrl", () => {
     expect(buildLoginUrl("/?category=books")).toContain(
       "next=%2F%3Fcategory%3Dbooks"
     )
+  })
+})
+
+describe("offers.submitOfferRow (rate-limited RPC)", () => {
+  it("delegates to the submit_offer RPC with the listing id and amount", async () => {
+    const rpc = vi.fn(async () => ({
+      data: { ok: true, error: null },
+      error: null,
+    }))
+    mockCreateClient.mockResolvedValue({ rpc } as never)
+
+    const result = await submitOfferRow({
+      listingId: "11111111-1111-4111-8111-111111111111",
+      amount: 500,
+      message: "  hi  ",
+    })
+
+    expect(rpc).toHaveBeenCalledWith("submit_offer", {
+      p_listing_id: "11111111-1111-4111-8111-111111111111",
+      p_amount: 500,
+      p_message: "hi",
+    })
+    expect(result).toEqual({ ok: true, error: null })
+  })
+
+  it("surfaces a rate-limit error from the RPC", async () => {
+    mockCreateClient.mockResolvedValue({
+      rpc: async () => ({
+        data: { ok: false, error: "rate limit exceeded, please wait before submitting another offer" },
+        error: null,
+      }),
+    } as never)
+
+    const result = await submitOfferRow({
+      listingId: "22222222-2222-4222-8222-222222222222",
+      amount: 50,
+      message: null,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("rate limit exceeded")
+  })
+
+  it("rejects a malformed listing id before touching the RPC", async () => {
+    const rpc = vi.fn()
+    mockCreateClient.mockResolvedValue({ rpc } as never)
+
+    const result = await submitOfferRow({
+      listingId: "not-a-uuid",
+      amount: 50,
+      message: null,
+    })
+
+    expect(rpc).not.toHaveBeenCalled()
+    expect(result).toEqual({ ok: false, error: "invalid listing id" })
+  })
+
+  it("reduces a PostgREST error to its message", async () => {
+    mockCreateClient.mockResolvedValue({
+      rpc: async () => ({ data: null, error: { message: "boom" } }),
+    } as never)
+
+    const result = await submitOfferRow({
+      listingId: "33333333-3333-4333-8333-333333333333",
+      amount: 50,
+      message: null,
+    })
+
+    expect(result).toEqual({ ok: false, error: "boom" })
   })
 })

--- a/web/tests/unit/rpc.test.ts
+++ b/web/tests/unit/rpc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 
-import { callRpc } from "@/lib/supabase/rpc"
+import { callOutcomeRpc, callRpc } from "@/lib/supabase/rpc"
 
 describe("supabase.callRpc", () => {
   it("returns the typed data with no error on success", async () => {
@@ -27,5 +27,31 @@ describe("supabase.callRpc", () => {
     } as never
     const result = await callRpc(supabase, "submit_review", {})
     expect(result).toEqual({ data: null, error: null })
+  })
+})
+
+describe("supabase.callOutcomeRpc", () => {
+  it("returns the { ok, error } envelope on success", async () => {
+    const supabase = {
+      rpc: async () => ({ data: { ok: true, error: null }, error: null }),
+    } as never
+    const result = await callOutcomeRpc(supabase, "submit_offer", {}, "test")
+    expect(result).toEqual({ ok: true, error: null })
+  })
+
+  it("collapses a transport error into the envelope", async () => {
+    const supabase = {
+      rpc: async () => ({ data: null, error: { message: "boom" } }),
+    } as never
+    const result = await callOutcomeRpc(supabase, "record_contact_attempt", {}, "test")
+    expect(result).toEqual({ ok: false, error: "boom" })
+  })
+
+  it("returns an empty envelope when the payload is missing", async () => {
+    const supabase = {
+      rpc: async () => ({ data: undefined, error: null }),
+    } as never
+    const result = await callOutcomeRpc(supabase, "submit_offer", {}, "test")
+    expect(result).toEqual({})
   })
 })


### PR DESCRIPTION
Closes #19

## What changed

- **AC1 — States:** root `error.tsx`, `global-error.tsx`, `not-found.tsx`; route `loading.tsx` skeletons for home, dashboard, admin/reports, seller profiles, and edit-listing; "No reviews yet" empty state on seller profiles.
- **AC2 — Performance:** all product/avatar images converted to `next/image` (AVIF/WebP via `images.formats`, explicit `sizes`, lazy by default, `priority` on the listing cover/LCP). `OfferModal`, `ReportDialog`, and `ContactDialog` lazy-loaded with `next/dynamic`.
- **AC3 — SEO & a11y:** `metadataBase` + OG/Twitter defaults + `viewport` theme color; per-route metadata on home and search; `robots.ts` + `sitemap.ts`; sr-only label on the search input; `aria-label` on remove-photo; focus rings bumped to full contrast (`ring-ring`).
- **AC4 — Responsive:** layout grids/containers audited for 320–1920px (NFR-COMP-003); responsive classes already in place, small contrast fixes applied.
- **AC5 — Security:** migration `20260815000000_security_hardening.sql` closes two gaps:
  - `submit_offer` and `record_contact_attempt` are now rate-limited SECURITY DEFINER RPCs (10 offers/buyer/listing per hour; 20 contact attempts/buyer/seller per hour), mirroring the `submit_report` pattern; raw INSERT on `offers` and `contact_attempts` revoked.
  - `listing_images` UPDATE policy gains the missing `with check`.
  - App data layer routes through the typed `callRpc` seam (new `RpcName` entries so a dropped RPC fails at compile time).

## Verification

- `npx tsc --noEmit` clean
- `npx eslint app components lib tests --max-warnings=0` clean
- `npx vitest run` — 133 passed (new RPC-path tests for `submitOfferRow` and `recordContactAttempt`)
- `npx next build` — succeeds; `/robots.txt` + `/sitemap.xml` generated

## Checklist

- [x] AC1 skeleton/empty/error states on core screens
- [x] AC2 image compression + lazy loading + code splitting
- [x] AC3 Lighthouse SEO/a11y: metadataBase, OG, robots, sitemap, labels, contrast
- [x] AC4 responsive 320–1920px (NFR-COMP-003)
- [x] AC5 final security pass (RLS, rate limits, input validation)

## Notes

- Lighthouse numerical scores (≥95 on all four axes) still need a live run once the app is hosted (same limitation as T19 — no public URL yet). The code-level checklist above is complete and builds green.
- Migration naming continues `20260815…` per DB spec §22.

## Code-review fixes (applied after the Standards/Spec review)

- `next/image` `fill` parents: added `relative` to the thumbnails in `offers/page.tsx`, `listing-manager.tsx`, `admin-report-card.tsx` (`listing-card.tsx` and `listings/[id]` already had it).
- **Rate-limit bug**: `record_contact_attempt` now filters `buyer_id = auth.uid()` (migration comment already said "per buyer per seller"); added the `buyer_id` column + index to `contact_attempts` since the T13 table never recorded the initiator.
- Dropped the dead `userId` param from `submitOfferRow` (the RPC resolves the buyer from the session).
- Extracted duplicated patterns: `lazyDialog()` helper (3 `next/dynamic` buttons), shared `Skeleton` ui component (all loading files), `FIELD_CLASS`/`TEXTAREA_CLASS` consts, `SITE_URL`/`SITE_TITLE`/`SITE_DESCRIPTION` consts.
- Collapsed the repeated `{ ok, error }` jsonb unwrap into a single `callOutcomeRpc` seam in `lib/supabase/rpc.ts` (`submitOfferRow`, `recordContactAttempt`, `runOfferRpc` now all use it); `accept_offer`/`decline_offer`/`counter_offer` added to the typed `RpcName` union.
- AC1 gap closed: added loading skeletons for `sell`, `profile`, `login`, `register`, `onboarding` (previously only 5 routes had them).
- Re-verified: tsc clean, eslint clean, **138 tests pass**, `next build` succeeds.