### PR TITLE
T14: AI listing assistant (FS-005)

### DIFF
--- a/web/app/actions/ai.ts
+++ b/web/app/actions/ai.ts
@@ -1,12 +1,13 @@
 "use server"
 
 import { generateListingSuggestions } from "@/lib/ai/listings"
+import { recordAiUsage } from "@/lib/ai/telemetry"
 import type { AIListingResult, AIListingSuggestion } from "@/lib/ai/constants"
 import type { Category } from "@/lib/listings/constants"
 
 export interface AiSuggestionsState {
   ok?: boolean
-  reason?: "unavailable" | "rate_limited" | "degraded"
+  reason?: Extract<AIListingResult, { ok: false }>["reason"]
   message?: string
   suggestion?: AIListingSuggestion
 }
@@ -17,13 +18,17 @@ export interface AiSuggestionsState {
  * to the Gemini seam (lib/ai/listings), and returns a typed state object. The
  * AI key never reaches the client — the action runs server-side, mirroring the
  * GenerateListingService → Gemini Provider flow (docs/05-backend §9).
+ *
+ * FS-005 analytics: the seller's already-typed title/description (optional
+ * inputs) are forwarded to the prompt, and the interaction is recorded as
+ * ai_used (first assist) or ai_regenerated (Regenerate).
  */
 export async function generateListingSuggestionsAction(
   _prevState: AiSuggestionsState,
   formData: FormData
 ): Promise<AiSuggestionsState> {
   const files = (formData.getAll("photos") as File[]).filter(
-    (f): f is File => f instanceof File && f.size > 0
+    (f): f is File => f instanceof File
   )
   if (!files.length) {
     return { ok: false, reason: "degraded", message: "Add a photo first" }
@@ -39,7 +44,18 @@ export async function generateListingSuggestionsAction(
     }
   }
 
-  const result: AIListingResult = await generateListingSuggestions(files, categories)
+  const readText = (key: string): string | undefined => {
+    const v = formData.get(key)
+    return typeof v === "string" && v.trim() ? v : undefined
+  }
+
+  recordAiUsage(formData.get("ai_event") === "regenerate" ? "ai_regenerated" : "ai_used")
+
+  const result: AIListingResult = await generateListingSuggestions(
+    files,
+    categories,
+    { title: readText("title"), description: readText("description") }
+  )
   if (result.ok) {
     return { ok: true, suggestion: result.suggestion }
   }

--- a/web/app/actions/ai.ts
+++ b/web/app/actions/ai.ts
@@ -1,0 +1,47 @@
+"use server"
+
+import { generateListingSuggestions } from "@/lib/ai/listings"
+import type { AIListingResult, AIListingSuggestion } from "@/lib/ai/constants"
+import type { Category } from "@/lib/listings/constants"
+
+export interface AiSuggestionsState {
+  ok?: boolean
+  reason?: "unavailable" | "rate_limited" | "degraded"
+  message?: string
+  suggestion?: AIListingSuggestion
+}
+
+/**
+ * Server Action entry point for the "AI Assist" button in the create-listing
+ * form. Reads uploaded photos + the live category list from FormData, delegates
+ * to the Gemini seam (lib/ai/listings), and returns a typed state object. The
+ * AI key never reaches the client — the action runs server-side, mirroring the
+ * GenerateListingService → Gemini Provider flow (docs/05-backend §9).
+ */
+export async function generateListingSuggestionsAction(
+  _prevState: AiSuggestionsState,
+  formData: FormData
+): Promise<AiSuggestionsState> {
+  const files = (formData.getAll("photos") as File[]).filter(
+    (f): f is File => f instanceof File && f.size > 0
+  )
+  if (!files.length) {
+    return { ok: false, reason: "degraded", message: "Add a photo first" }
+  }
+
+  let categories: Category[] = []
+  const raw = formData.get("categories")
+  if (typeof raw === "string" && raw) {
+    try {
+      categories = JSON.parse(raw) as Category[]
+    } catch {
+      categories = []
+    }
+  }
+
+  const result: AIListingResult = await generateListingSuggestions(files, categories)
+  if (result.ok) {
+    return { ok: true, suggestion: result.suggestion }
+  }
+  return { ok: false, reason: result.reason, message: result.message }
+}

--- a/web/app/actions/listings.ts
+++ b/web/app/actions/listings.ts
@@ -31,6 +31,7 @@ const createSchema = z.object({
   subCity: z.string().max(100).optional(),
   address: z.string().max(200).optional(),
   negotiable: z.boolean().optional(),
+  ai_assisted: z.boolean().optional(),
   photos: z.array(z.instanceof(File)).min(1, "Add at least one photo").max(MAX_IMAGES, `Up to ${MAX_IMAGES} photos allowed`),
 })
 
@@ -85,8 +86,9 @@ export async function createListing(
     city: formData.get("city"),
     subCity: formValue(formData, "subCity"),
     address: formValue(formData, "address"),
-    negotiable: formData.get("negotiable") === "on",
-    photos: files.length ? files : undefined,
+     negotiable: formData.get("negotiable") === "on",
+     ai_assisted: formData.get("ai_assisted") === "on",
+     photos: files.length ? files : undefined,
   })
 
   if (!parsed.success) {

--- a/web/app/actions/listings.ts
+++ b/web/app/actions/listings.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation"
 import { revalidatePath } from "next/cache"
 
 import { getCurrentUser } from "@/lib/auth"
+import { recordAiUsage } from "@/lib/ai/telemetry"
 import {
   createListing as createListingRow,
   updateListing as updateListingRow,
@@ -109,6 +110,10 @@ export async function createListing(
     if ("error" in result) {
       return { message: result.error }
     }
+
+    // FS-005 analytics: a listing created with AI assistance counts as an
+    // accepted suggestion (the seller pressed Apply, not just generated).
+    if (parsed.data.ai_assisted) recordAiUsage("ai_accepted")
 
     revalidatePath("/dashboard")
     revalidatePath(`/listings/${result.id}`)

--- a/web/app/listings/[id]/page.tsx
+++ b/web/app/listings/[id]/page.tsx
@@ -97,6 +97,9 @@ export default async function ListingPage({
               {l.title}
             </h1>
             <Badge variant="secondary">{formatCondition(l.condition)}</Badge>
+            {l.ai_assisted ? (
+              <Badge variant="outline">AI-assisted</Badge>
+            ) : null}
             <FavoriteButton listingId={l.id} initial={favorited} />
             <ReportButton
               target={{ type: "listing", listingId: l.id }}

--- a/web/components/listings/ai-assist.tsx
+++ b/web/components/listings/ai-assist.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { SparklesIcon } from "lucide-react"
+import { SparklesIcon, XIcon } from "lucide-react"
 
 import type { Category } from "@/lib/listings/constants"
 import type { AIListingSuggestion } from "@/lib/ai/constants"
@@ -13,6 +13,10 @@ export interface AiAssistProps {
   categories: Category[]
   /** The photos selected so far in the create-listing form. */
   photos: File[]
+  /** The seller's already-typed title, forwarded as optional prompt context (FS-005 Inputs). */
+  title?: string
+  /** The seller's already-typed description, forwarded as optional prompt context (FS-005 Inputs). */
+  description?: string
   /** Apply the accepted suggestion to the form's controlled fields. */
   onApply: (suggestion: AIListingSuggestion) => void
 }
@@ -21,29 +25,86 @@ type AiState =
   | { phase: "idle" }
   | { phase: "loading" }
   | { phase: "unavailable"; message: string }
-  | { phase: "error"; message: string }
   | { phase: "ready"; suggestion: AIListingSuggestion }
 
-export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
+// FS-005 "Every field remains editable" / NFR-AI-001: keywords are editable
+// chips (remove on click, add with Enter) before the seller accepts. Keywords
+// stay an AI-output field — the listing schema has no keywords column (DB spec
+// §8; Module 6 search sources are title/description/category/location) — so
+// editing here refines the suggestion without persisting dead data.
+function KeywordEditor({ initial }: { initial: string[] }) {
+  const [keywords, setKeywords] = useState<string[]>(initial)
+  const [draft, setDraft] = useState("")
+
+  function add() {
+    const k = draft.trim()
+    if (k && !keywords.includes(k)) setKeywords((ks) => [...ks, k])
+    setDraft("")
+  }
+
+  return (
+    <div>
+      <p className="text-sm font-medium">Keywords</p>
+      <div className="flex flex-wrap items-center gap-1.5 pt-1">
+        {keywords.map((k) => (
+          <span
+            key={k}
+            className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs"
+          >
+            {k}
+            <button
+              type="button"
+              aria-label={`Remove keyword ${k}`}
+              onClick={() => setKeywords((ks) => ks.filter((x) => x !== k))}
+            >
+              <XIcon className="size-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault()
+              add()
+            }
+          }}
+          aria-label="Add keyword"
+          placeholder="Add tag…"
+          className="w-24 rounded-full border border-input bg-transparent px-2.5 py-0.5 text-xs outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+    </div>
+  )
+}
+
+export function AiAssist({
+  categories,
+  photos,
+  title,
+  description,
+  onApply,
+}: AiAssistProps) {
   const [state, setState] = useState<AiState>({ phase: "idle" })
   const canRun = photos.length > 0 && state.phase !== "loading"
 
-  async function run() {
+  async function run(mode: "generate" | "regenerate" = "generate") {
     setState({ phase: "loading" })
     const fd = new FormData()
     for (const f of photos) fd.append("photos", f)
     fd.append("categories", JSON.stringify(categories))
+    fd.append("ai_event", mode)
+    if (title) fd.append("title", title)
+    if (description) fd.append("description", description)
     const res = await generateListingSuggestionsAction({}, fd)
 
     if (res.ok && res.suggestion) {
       setState({ phase: "ready", suggestion: res.suggestion })
-    } else if (res.reason === "rate_limited" || res.reason === "unavailable") {
-      setState({ phase: "unavailable", message: res.message ?? "AI unavailable" })
     } else {
-      setState({
-        phase: "unavailable",
-        message: res.message ?? "AI unavailable",
-      })
+      // unavailable / rate_limited / degraded all mean "manual listing remains
+      // available" (AC-3) — one message path, no config details leaked.
+      setState({ phase: "unavailable", message: res.message ?? "AI unavailable" })
     }
   }
 
@@ -53,7 +114,7 @@ export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
         type="button"
         variant="outline"
         size="sm"
-        onClick={run}
+        onClick={() => run()}
         disabled={!canRun}
       >
         <SparklesIcon className="mr-2 size-4" />
@@ -78,7 +139,7 @@ export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
               <p className="text-sm font-medium">Description</p>
               <p className="text-sm">{state.suggestion.description}</p>
             </div>
-            <div className="grid grid-cols-2 gap-4 text-sm">
+            <div className="grid grid-cols-3 gap-4 text-sm">
               <div>
                 <p className="text-sm font-medium">Category</p>
                 <p className="text-sm">{state.suggestion.categoryName ?? "—"}</p>
@@ -91,11 +152,11 @@ export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
                 <p className="text-sm font-medium">Quality</p>
                 <p className="text-sm">{state.suggestion.qualityScore}/100</p>
               </div>
-              <div>
-                <p className="text-sm font-medium">Keywords</p>
-                <p className="text-sm">{state.suggestion.keywords.join(", ")}</p>
-              </div>
             </div>
+            <KeywordEditor
+              key={state.suggestion.keywords.join(",")}
+              initial={state.suggestion.keywords}
+            />
             <div className="flex gap-2 pt-2">
               <Button
                 type="button"
@@ -107,7 +168,12 @@ export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
               >
                 Apply to form
               </Button>
-              <Button type="button" size="sm" variant="ghost" onClick={run}>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => run("regenerate")}
+              >
                 Regenerate
               </Button>
               <Button

--- a/web/components/listings/ai-assist.tsx
+++ b/web/components/listings/ai-assist.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useState } from "react"
+import { SparklesIcon } from "lucide-react"
+
+import type { Category } from "@/lib/listings/constants"
+import type { AIListingSuggestion } from "@/lib/ai/constants"
+import { generateListingSuggestionsAction } from "@/app/actions/ai"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export interface AiAssistProps {
+  categories: Category[]
+  /** The photos selected so far in the create-listing form. */
+  photos: File[]
+  /** Apply the accepted suggestion to the form's controlled fields. */
+  onApply: (suggestion: AIListingSuggestion) => void
+}
+
+type AiState =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "unavailable"; message: string }
+  | { phase: "error"; message: string }
+  | { phase: "ready"; suggestion: AIListingSuggestion }
+
+export function AiAssist({ categories, photos, onApply }: AiAssistProps) {
+  const [state, setState] = useState<AiState>({ phase: "idle" })
+  const canRun = photos.length > 0 && state.phase !== "loading"
+
+  async function run() {
+    setState({ phase: "loading" })
+    const fd = new FormData()
+    for (const f of photos) fd.append("photos", f)
+    fd.append("categories", JSON.stringify(categories))
+    const res = await generateListingSuggestionsAction({}, fd)
+
+    if (res.ok && res.suggestion) {
+      setState({ phase: "ready", suggestion: res.suggestion })
+    } else if (res.reason === "rate_limited" || res.reason === "unavailable") {
+      setState({ phase: "unavailable", message: res.message ?? "AI unavailable" })
+    } else {
+      setState({
+        phase: "unavailable",
+        message: res.message ?? "AI unavailable",
+      })
+    }
+  }
+
+  return (
+    <div className="mt-4">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={run}
+        disabled={!canRun}
+      >
+        <SparklesIcon className="mr-2 size-4" />
+        {state.phase === "loading" ? "Generating…" : "AI Assist"}
+      </Button>
+
+      {state.phase === "unavailable" ? (
+        <p className="mt-2 text-sm text-muted-foreground">{state.message}</p>
+      ) : null}
+
+      {state.phase === "ready" ? (
+        <Card className="mt-4">
+          <CardHeader>
+            <CardTitle className="text-base">AI suggestions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">Title</p>
+              <p className="text-sm">{state.suggestion.title}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium">Description</p>
+              <p className="text-sm">{state.suggestion.description}</p>
+            </div>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-sm font-medium">Category</p>
+                <p className="text-sm">{state.suggestion.categoryName ?? "—"}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium">Condition</p>
+                <p className="text-sm">{state.suggestion.condition ?? "—"}</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium">Quality</p>
+                <p className="text-sm">{state.suggestion.qualityScore}/100</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium">Keywords</p>
+                <p className="text-sm">{state.suggestion.keywords.join(", ")}</p>
+              </div>
+            </div>
+            <div className="flex gap-2 pt-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => {
+                  onApply(state.suggestion)
+                  setState({ phase: "idle" })
+                }}
+              >
+                Apply to form
+              </Button>
+              <Button type="button" size="sm" variant="ghost" onClick={run}>
+                Regenerate
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => setState({ phase: "idle" })}
+              >
+                Dismiss
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Suggestions are editable — accepting them only pre-fills the fields;
+              the listing is never published automatically.
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  )
+}

--- a/web/components/listings/create-listing-form.tsx
+++ b/web/components/listings/create-listing-form.tsx
@@ -5,8 +5,9 @@ import { useRouter } from "next/navigation"
 import { XIcon, UploadIcon } from "lucide-react"
 
 import { createListing } from "@/app/actions/listings"
-import { CONDITIONS } from "@/lib/listings/constants"
+import { CONDITIONS, type Condition } from "@/lib/listings/constants"
 import type { Category } from "@/lib/listings"
+import { AiAssist } from "@/components/listings/ai-assist"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -24,8 +25,18 @@ export function CreateListingForm({
   const router = useRouter()
   const [state, formAction, pending] = useActionState(createListing, {})
   const [previews, setPreviews] = useState<string[]>([])
+  const [photoFiles, setPhotoFiles] = useState<File[]>([])
   const fileRef = useRef<HTMLInputElement>(null)
   const urlRefs = useRef<string[]>([])
+
+  // T14: the AI-fillable fields are controlled so the assistant can pre-fill
+  // them (editable, never auto-submitted). The native form still posts their
+  // DOM values on submit.
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [categoryId, setCategoryId] = useState<string | null>(null)
+  const [condition, setCondition] = useState<Condition>("" as Condition)
+  const [aiAssisted, setAiAssisted] = useState(false)
 
   useEffect(() => {
     return () => {
@@ -41,16 +52,18 @@ export function CreateListingForm({
 
   function handlePhotos(e: ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files ?? [])
-    // revoke prior previews
     urlRefs.current.forEach((url) => URL.revokeObjectURL(url))
     urlRefs.current = []
     const urls = files.map((f) => URL.createObjectURL(f))
     urlRefs.current = urls
     setPreviews(urls)
+    setPhotoFiles(files.filter((f) => f.size > 0))
   }
 
   return (
     <form action={formAction}>
+      <input type="hidden" name="ai_assisted" value={aiAssisted ? "on" : ""} />
+
       <Card className="mb-6">
         <CardHeader>
           <CardTitle>Photos *</CardTitle>
@@ -89,7 +102,8 @@ export function CreateListingForm({
                     type="button"
                     onClick={() => {
                       URL.revokeObjectURL(url)
-                      setPreviews((p) => p.filter((u) => u !== url))
+                      setPreviews((p) => p.filter((_, idx) => idx !== i))
+                      setPhotoFiles((p) => p.filter((_, idx) => idx !== i))
                     }}
                     className="absolute right-1 top-1 rounded bg-background/80 p-0.5"
                   >
@@ -98,6 +112,20 @@ export function CreateListingForm({
                 </div>
               ))}
             </div>
+          ) : null}
+
+          {photoFiles.length > 0 ? (
+            <AiAssist
+              categories={categories}
+              photos={photoFiles}
+              onApply={(s) => {
+                setTitle(s.title)
+                setDescription(s.description)
+                if (s.categoryId) setCategoryId(s.categoryId)
+                if (s.condition) setCondition(s.condition)
+                setAiAssisted(true)
+              }}
+            />
           ) : null}
         </CardContent>
       </Card>
@@ -109,12 +137,14 @@ export function CreateListingForm({
         <CardContent className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="title">Title *</Label>
-              <Input
-                id="title"
-                name="title"
-                placeholder="What are you selling?"
-                aria-invalid={!!state.errors?.title}
-              />
+            <Input
+              id="title"
+              name="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="What are you selling?"
+              aria-invalid={!!state.errors?.title}
+            />
             <FieldError message={state.errors?.title?.[0]} />
           </div>
 
@@ -123,6 +153,8 @@ export function CreateListingForm({
             <textarea
               id="description"
               name="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
               rows={5}
               className="resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-within:ring-2 focus-within:ring-ring/50"
               placeholder="Include condition, brand, age, what's included..."
@@ -155,6 +187,8 @@ export function CreateListingForm({
                       type="radio"
                       name="condition"
                       value={c}
+                      checked={condition === c}
+                      onChange={() => setCondition(c)}
                       required
                       className="accent-primary"
                     />
@@ -171,6 +205,8 @@ export function CreateListingForm({
             <select
               id="categoryId"
               name="categoryId"
+              value={categoryId ?? ""}
+              onChange={(e) => setCategoryId(e.target.value || null)}
               className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
               aria-invalid={!!state.errors?.categoryId}
             >
@@ -211,14 +247,14 @@ export function CreateListingForm({
               />
             </div>
           </div>
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="address">Address (optional)</Label>
-              <Input
-                id="address"
-                name="address"
-                placeholder="Street address or landmark"
-              />
-            </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="address">Address (optional)</Label>
+            <Input
+              id="address"
+              name="address"
+              placeholder="Street address or landmark"
+            />
+          </div>
           <label className="flex items-center gap-2 text-sm">
             <input type="checkbox" name="negotiable" className="accent-primary" />
             Price is negotiable

--- a/web/components/listings/create-listing-form.tsx
+++ b/web/components/listings/create-listing-form.tsx
@@ -35,7 +35,8 @@ export function CreateListingForm({
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [categoryId, setCategoryId] = useState<string | null>(null)
-  const [condition, setCondition] = useState<Condition>("" as Condition)
+  // "" is the unselected radio state — a real Condition value, never a cast lie.
+  const [condition, setCondition] = useState<Condition | "">("")
   const [aiAssisted, setAiAssisted] = useState(false)
 
   useEffect(() => {
@@ -118,6 +119,8 @@ export function CreateListingForm({
             <AiAssist
               categories={categories}
               photos={photoFiles}
+              title={title}
+              description={description}
               onApply={(s) => {
                 setTitle(s.title)
                 setDescription(s.description)

--- a/web/lib/ai/constants.ts
+++ b/web/lib/ai/constants.ts
@@ -7,14 +7,20 @@
  * contract is testable without hitting the network or holding a credential.
  */
 
+import { CONDITIONS } from "@/lib/listings/constants"
+
 export const AI_LISTING_MODEL = "gemini-2.5-flash"
 export const AI_LISTING_BASE_URL = `https://generativelanguage.googleapis.com/v1/models/${AI_LISTING_MODEL}:generateContent`
 
-// Mirrors the listing_condition enum (DB spec §18), NOT the broader vocabulary
-// in the vision-proof runbook: Gemini must emit one of our three stored values
-// so it can be saved verbatim. (The UI reuses `CONDITIONS` from listings; this
-// constant keeps the AI seam self-contained if the sets ever diverge.)
-export const AI_LISTING_CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+// NFR-AI-002: AI responses should complete within 10 seconds. The seam passes
+// this to AbortSignal.timeout so a hung Gemini call degrades instead of leaving
+// the seller stuck on "Generating…".
+export const AI_LISTING_TIMEOUT_MS = 10_000
+
+// Reuses the shared listing_condition vocabulary (lib/listings/constants) so the
+// AI seam and the DB enum (DB spec §8) can never drift apart. Gemini must emit
+// one of our three stored values so it can be saved verbatim.
+export const AI_LISTING_CONDITIONS = CONDITIONS
 export type AICondition = (typeof AI_LISTING_CONDITIONS)[number]
 
 export interface AIListingSuggestion {
@@ -35,10 +41,32 @@ export type AIListingResult =
       message: string
     }
 
+// Optional context the seller already typed (FS-005 Inputs): the prompt treats it
+// as ground truth to refine rather than discard.
+export interface AIPromptContext {
+  title?: string
+  description?: string
+}
+
 // The prompt sent with every image set. `categoryNames` is interpolated so the
-// model can only emit a category the seller actually has.
-export const PROMPT_TEMPLATE = (categoryNames: string[]) =>
-  `You are a product listing assistant. Return a STRICT JSON object matching the response schema for this used-item photo. title: a concise, searchable title (≤70 chars). description: 1–2 sentences. category: one of: ${categoryNames.join(", ")}. keywords: 1–5 tags. condition: one of: Brand New, Lightly Used, Fair. quality_score: integer 0-100. Do NOT add prose, markdown, or fields outside the schema.`
+// model can only emit a category the seller actually has; `context` lets it
+// refine the seller's already-typed title/description.
+export const buildPrompt = (
+  categoryNames: string[],
+  context: AIPromptContext = {}
+): string => {
+  const typed = [
+    context.title ? `Title: ${context.title}` : "",
+    context.description ? `Description: ${context.description}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+  return `You are a product listing assistant. Return a STRICT JSON object matching the response schema for this used-item photo. title: a concise, searchable title (≤70 chars). description: 1–2 sentences. category: one of: ${categoryNames.join(", ")}. keywords: 1–5 tags. condition: one of: ${AI_LISTING_CONDITIONS.join(", ")}. quality_score: integer 0-100.${
+    typed
+      ? ` The seller already typed this optional context — keep its meaning, refine the wording, and do not contradict it:\n${typed}`
+      : ""
+  } Do NOT add prose, markdown, or fields outside the schema.`
+}
 
 // JSON Schema (Gemini `responseSchema`). `category` enum is populated from the
 // seller's live categories so the model can only return a stored value.

--- a/web/lib/ai/constants.ts
+++ b/web/lib/ai/constants.ts
@@ -1,0 +1,78 @@
+/**
+ * T14 - AI Listing Assistant. Pure value objects (no `server-only`, no Supabase,
+ * no I/O) shared by the server seam (lib/ai/listings) and the client UI.
+ *
+ * Framework-agnostic, like lib/reviews/constants: the prompt and the Gemini
+ * response-schema are deterministic functions of their inputs, so the AI output
+ * contract is testable without hitting the network or holding a credential.
+ */
+
+export const AI_LISTING_MODEL = "gemini-2.5-flash"
+export const AI_LISTING_BASE_URL = `https://generativelanguage.googleapis.com/v1/models/${AI_LISTING_MODEL}:generateContent`
+
+// Mirrors the listing_condition enum (DB spec §18), NOT the broader vocabulary
+// in the vision-proof runbook: Gemini must emit one of our three stored values
+// so it can be saved verbatim. (The UI reuses `CONDITIONS` from listings; this
+// constant keeps the AI seam self-contained if the sets ever diverge.)
+export const AI_LISTING_CONDITIONS = ["Brand New", "Lightly Used", "Fair"] as const
+export type AICondition = (typeof AI_LISTING_CONDITIONS)[number]
+
+export interface AIListingSuggestion {
+  title: string
+  description: string
+  categoryId: string | null
+  categoryName: string | null
+  condition: AICondition | null
+  keywords: string[]
+  qualityScore: number
+}
+
+export type AIListingResult =
+  | { ok: true; suggestion: AIListingSuggestion }
+  | {
+      ok: false
+      reason: "unavailable" | "rate_limited" | "degraded"
+      message: string
+    }
+
+// The prompt sent with every image set. `categoryNames` is interpolated so the
+// model can only emit a category the seller actually has.
+export const PROMPT_TEMPLATE = (categoryNames: string[]) =>
+  `You are a product listing assistant. Return a STRICT JSON object matching the response schema for this used-item photo. title: a concise, searchable title (≤70 chars). description: 1–2 sentences. category: one of: ${categoryNames.join(", ")}. keywords: 1–5 tags. condition: one of: Brand New, Lightly Used, Fair. quality_score: integer 0-100. Do NOT add prose, markdown, or fields outside the schema.`
+
+// JSON Schema (Gemini `responseSchema`). `category` enum is populated from the
+// seller's live categories so the model can only return a stored value.
+export function buildResponseSchema(categoryNames: string[]) {
+  return {
+    type: "object" as const,
+    properties: {
+      title: { type: "string" as const },
+      description: { type: "string" as const },
+      category: { type: "string" as const, enum: categoryNames },
+      keywords: {
+        type: "array" as const,
+        items: { type: "string" as const },
+        minItems: 1,
+        maxItems: 5,
+      },
+      condition: { type: "string" as const, enum: AI_LISTING_CONDITIONS },
+      quality_score: { type: "integer" as const, minimum: 0, maximum: 100 },
+    },
+    required: [
+      "title",
+      "description",
+      "category",
+      "keywords",
+      "condition",
+      "quality_score",
+    ],
+    propertyOrdering: [
+      "title",
+      "description",
+      "category",
+      "keywords",
+      "condition",
+      "quality_score",
+    ],
+  }
+}

--- a/web/lib/ai/listings.ts
+++ b/web/lib/ai/listings.ts
@@ -1,0 +1,187 @@
+import "server-only"
+
+import { z } from "zod"
+import type { Category } from "@/lib/listings/constants"
+import {
+  AI_LISTING_BASE_URL,
+  AI_LISTING_CONDITIONS,
+  type AICondition,
+  type AIListingResult,
+  buildResponseSchema,
+  PROMPT_TEMPLATE,
+} from "./constants"
+
+// ---- Rate limiting (AC-4) ----
+// Simple per-process sliding window. Good enough for the demo MVP; a
+// multi-instance deployment would back this with a shared store (Redis/Upstash),
+// but the feature is explicitly non-gating — a miss here just degrades to manual.
+// Env is read per-call so tests (and runtime overrides) can vary the limit.
+const AI_RATE_WINDOW_MS = 60_000
+const aiCallTimestamps: number[] = []
+
+export function resetAiRateLimiter(): void {
+  aiCallTimestamps.length = 0
+}
+
+function aiRateLimited(now: number): boolean {
+  const limit = Number(process.env.AI_RATE_LIMIT ?? 10)
+  const cutoff = now - AI_RATE_WINDOW_MS
+  for (let i = aiCallTimestamps.length - 1; i >= 0; i--) {
+    if (aiCallTimestamps[i] < cutoff) aiCallTimestamps.splice(i, 1)
+  }
+  if (aiCallTimestamps.length >= limit) return true
+  aiCallTimestamps.push(now)
+  return false
+}
+
+// Convert a browser File to a Gemini inlineData part without pulling in an
+// image-resize dependency (ADR-019's ≤1024px downscale is a future token-budget
+// tune; sending the bytes is sufficient for the non-gating demo).
+async function toInlinePart(
+  file: File
+): Promise<{ mimeType: string; data: string } | null> {
+  if (!file || file.size === 0) return null
+  const buf = Buffer.from(await file.arrayBuffer())
+  return { mimeType: file.type || "image/jpeg", data: buf.toString("base64") }
+}
+
+const suggestionSchema = (categoryNames: string[]) =>
+  z.object({
+    title: z.string().min(1).max(70),
+    description: z.string().min(1),
+    category: z
+      .string()
+      .refine((v) => categoryNames.includes(v), "invalid category"),
+    keywords: z.array(z.string().min(1)).min(1).max(5),
+    condition: z
+      .string()
+      .refine(
+        (v): v is AICondition =>
+          (AI_LISTING_CONDITIONS as readonly string[]).includes(v),
+        "invalid condition"
+      ),
+      quality_score: z.number().int().min(0).max(100),
+  })
+
+interface GeminiResponse {
+  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
+}
+
+/**
+ * Call Gemini (flash-class multimodal) with the given photos and return a typed,
+ * schema-validated suggestion. Every failure — missing key, rate limit, network
+ * error, non-2xx, malformed JSON, schema mismatch — resolves to a degraded
+ * result (AC-3/AC-4) so the caller can always fall back to manual creation.
+ */
+export async function generateListingSuggestions(
+  photos: File[],
+  categories: Category[]
+): Promise<AIListingResult> {
+  const apiKey = process.env.GEMINI_API_KEY
+  if (!apiKey) {
+    return { ok: false, reason: "unavailable", message: "AI key not configured" }
+  }
+  if (aiRateLimited(Date.now())) {
+    return {
+      ok: false,
+      reason: "rate_limited",
+      message: "AI assist is rate limited",
+    }
+  }
+
+  const parts: { mimeType: string; data: string }[] = []
+  for (const file of photos) {
+    const part = await toInlinePart(file)
+    if (part) parts.push(part)
+  }
+  if (!parts.length) {
+    return { ok: false, reason: "degraded", message: "No readable photos" }
+  }
+
+  const categoryNames = [...new Set(categories.map((c) => c.name))]
+  if (!categoryNames.length) {
+    return { ok: false, reason: "degraded", message: "No categories available" }
+  }
+
+  const url = `${AI_LISTING_BASE_URL}?key=${apiKey}`
+  const body = {
+    contents: [
+      {
+        parts: [
+          { text: PROMPT_TEMPLATE(categoryNames) },
+          ...parts.map((p) => ({
+            inlineData: { mimeType: p.mimeType, data: p.data },
+          })),
+        ],
+      },
+    ],
+    generationConfig: {
+      temperature: 0.5,
+      maxOutputTokens: 512,
+      responseMimeType: "application/json",
+      responseSchema: buildResponseSchema(categoryNames),
+    },
+  }
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    return { ok: false, reason: "degraded", message: "AI request failed" }
+  }
+
+  if (res.status === 429) {
+    return {
+      ok: false,
+      reason: "rate_limited",
+      message: `Gemini responded ${res.status}`,
+    }
+  }
+  if (res.status === 403) {
+    return {
+      ok: false,
+      reason: "unavailable",
+      message: `Gemini responded ${res.status}`,
+    }
+  }
+  if (!res.ok) {
+    return { ok: false, reason: "degraded", message: `Gemini responded ${res.status}` }
+  }
+
+  const json = (await res.json().catch(() => null)) as GeminiResponse | null
+  const text = json?.candidates?.[0]?.content?.parts?.[0]?.text
+  if (!text) {
+    return { ok: false, reason: "degraded", message: "Empty AI response" }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return { ok: false, reason: "degraded", message: "Malformed AI response" }
+  }
+
+  const result = suggestionSchema(categoryNames).safeParse(parsed)
+  if (!result.success) {
+    return { ok: false, reason: "degraded", message: "Unparseable AI response" }
+  }
+
+  const out = result.data
+  const category = categories.find((c) => c.name === out.category)
+  return {
+    ok: true,
+    suggestion: {
+      title: out.title,
+      description: out.description,
+      categoryId: category?.id ?? null,
+      categoryName: out.category,
+      condition: out.condition,
+      keywords: out.keywords,
+      qualityScore: out.quality_score,
+    },
+  }
+}

--- a/web/lib/ai/listings.ts
+++ b/web/lib/ai/listings.ts
@@ -5,17 +5,22 @@ import type { Category } from "@/lib/listings/constants"
 import {
   AI_LISTING_BASE_URL,
   AI_LISTING_CONDITIONS,
+  AI_LISTING_TIMEOUT_MS,
   type AICondition,
   type AIListingResult,
+  type AIPromptContext,
+  buildPrompt,
   buildResponseSchema,
-  PROMPT_TEMPLATE,
 } from "./constants"
 
 // ---- Rate limiting (AC-4) ----
-// Simple per-process sliding window. Good enough for the demo MVP; a
-// multi-instance deployment would back this with a shared store (Redis/Upstash),
-// but the feature is explicitly non-gating — a miss here just degrades to manual.
-// Env is read per-call so tests (and runtime overrides) can vary the limit.
+// Per-process sliding window: exactly `AI_RATE_LIMIT` (default 10) calls are
+// allowed per 60s window; the (limit+1)-th call within the window is rejected.
+// On the Vercel serverless target (ADR-017) each function instance keeps its
+// own window, so this is a per-instance cap rather than a global one — accepted
+// because the feature is non-gating: a miss simply degrades to manual listing
+// (NFR-AI-003). A shared store (Redis/Upstash) is the documented future
+// hardening. Env is read per-call so tests (and runtime overrides) can vary it.
 const AI_RATE_WINDOW_MS = 60_000
 const aiCallTimestamps: number[] = []
 
@@ -26,8 +31,8 @@ export function resetAiRateLimiter(): void {
 function aiRateLimited(now: number): boolean {
   const limit = Number(process.env.AI_RATE_LIMIT ?? 10)
   const cutoff = now - AI_RATE_WINDOW_MS
-  for (let i = aiCallTimestamps.length - 1; i >= 0; i--) {
-    if (aiCallTimestamps[i] < cutoff) aiCallTimestamps.splice(i, 1)
+  while (aiCallTimestamps.length && aiCallTimestamps[0] < cutoff) {
+    aiCallTimestamps.shift()
   }
   if (aiCallTimestamps.length >= limit) return true
   aiCallTimestamps.push(now)
@@ -60,7 +65,7 @@ const suggestionSchema = (categoryNames: string[]) =>
           (AI_LISTING_CONDITIONS as readonly string[]).includes(v),
         "invalid condition"
       ),
-      quality_score: z.number().int().min(0).max(100),
+    quality_score: z.number().int().min(0).max(100),
   })
 
 interface GeminiResponse {
@@ -69,23 +74,26 @@ interface GeminiResponse {
 
 /**
  * Call Gemini (flash-class multimodal) with the given photos and return a typed,
- * schema-validated suggestion. Every failure — missing key, rate limit, network
- * error, non-2xx, malformed JSON, schema mismatch — resolves to a degraded
- * result (AC-3/AC-4) so the caller can always fall back to manual creation.
+ * schema-validated suggestion. Every failure — missing key, rate limit, timeout,
+ * network error, non-2xx, malformed JSON, schema mismatch — resolves to a
+ * degraded result (AC-3/AC-4, NFR-AI-002/NFR-AI-003) so the caller can always
+ * fall back to manual creation. Messages are end-seller-safe: no server-config
+ * details leak to the UI (AC-3).
  */
 export async function generateListingSuggestions(
   photos: File[],
-  categories: Category[]
+  categories: Category[],
+  context: AIPromptContext = {}
 ): Promise<AIListingResult> {
   const apiKey = process.env.GEMINI_API_KEY
   if (!apiKey) {
-    return { ok: false, reason: "unavailable", message: "AI key not configured" }
+    return { ok: false, reason: "unavailable", message: "AI assist is unavailable right now" }
   }
   if (aiRateLimited(Date.now())) {
     return {
       ok: false,
       reason: "rate_limited",
-      message: "AI assist is rate limited",
+      message: "AI assist is busy right now — try again shortly",
     }
   }
 
@@ -108,7 +116,7 @@ export async function generateListingSuggestions(
     contents: [
       {
         parts: [
-          { text: PROMPT_TEMPLATE(categoryNames) },
+          { text: buildPrompt(categoryNames, context) },
           ...parts.map((p) => ({
             inlineData: { mimeType: p.mimeType, data: p.data },
           })),
@@ -129,6 +137,9 @@ export async function generateListingSuggestions(
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
+      // NFR-AI-002: hard 10s ceiling — a slow/hung model degrades instead of
+      // leaving the seller stuck.
+      signal: AbortSignal.timeout(AI_LISTING_TIMEOUT_MS),
     })
   } catch {
     return { ok: false, reason: "degraded", message: "AI request failed" }
@@ -138,36 +149,36 @@ export async function generateListingSuggestions(
     return {
       ok: false,
       reason: "rate_limited",
-      message: `Gemini responded ${res.status}`,
+      message: "AI assist is busy right now — try again shortly",
     }
   }
   if (res.status === 403) {
     return {
       ok: false,
       reason: "unavailable",
-      message: `Gemini responded ${res.status}`,
+      message: "AI assist is unavailable right now",
     }
   }
   if (!res.ok) {
-    return { ok: false, reason: "degraded", message: `Gemini responded ${res.status}` }
+    return { ok: false, reason: "degraded", message: "AI request failed" }
   }
 
   const json = (await res.json().catch(() => null)) as GeminiResponse | null
   const text = json?.candidates?.[0]?.content?.parts?.[0]?.text
   if (!text) {
-    return { ok: false, reason: "degraded", message: "Empty AI response" }
+    return { ok: false, reason: "degraded", message: "AI request failed" }
   }
 
   let parsed: unknown
   try {
     parsed = JSON.parse(text)
   } catch {
-    return { ok: false, reason: "degraded", message: "Malformed AI response" }
+    return { ok: false, reason: "degraded", message: "AI request failed" }
   }
 
   const result = suggestionSchema(categoryNames).safeParse(parsed)
   if (!result.success) {
-    return { ok: false, reason: "degraded", message: "Unparseable AI response" }
+    return { ok: false, reason: "degraded", message: "AI request failed" }
   }
 
   const out = result.data

--- a/web/lib/ai/telemetry.ts
+++ b/web/lib/ai/telemetry.ts
@@ -1,0 +1,29 @@
+import "server-only"
+
+// T14 analytics (FS-005: track ai_used, ai_regenerated, ai_accepted). In-process
+// counters are the integration point for the observability metrics (engineering
+// §8) — like the AC-4 rate limiter, this is per-instance on the Vercel target;
+// a shared metrics sink (PostHog/Vercel Analytics) is the future hardening.
+// Server-only so the counters can never be read or written from the client.
+
+export type AiUsageEvent = "ai_used" | "ai_regenerated" | "ai_accepted"
+
+const counters: Record<AiUsageEvent, number> = {
+  ai_used: 0,
+  ai_regenerated: 0,
+  ai_accepted: 0,
+}
+
+export function recordAiUsage(event: AiUsageEvent): void {
+  counters[event] += 1
+}
+
+export function getAiUsageCounters(): Readonly<Record<AiUsageEvent, number>> {
+  return { ...counters }
+}
+
+export function resetAiUsageCounters(): void {
+  counters.ai_used = 0
+  counters.ai_regenerated = 0
+  counters.ai_accepted = 0
+}

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -327,6 +327,7 @@ export async function createListing(
       sub_city: values.subCity ?? null,
       address: values.address ?? null,
       negotiable: values.negotiable ?? false,
+      ai_assisted: values.ai_assisted ?? false,
       status: "published" as ListingStatus,
     })
     .select("id")

--- a/web/lib/listings/constants.ts
+++ b/web/lib/listings/constants.ts
@@ -77,6 +77,8 @@ export interface Listing {
   published_at: string
   created_at: string
   updated_at: string
+  /** T14: true when the listing's fields were applied from AI suggestions. */
+  ai_assisted: boolean
 }
 
 export interface ListingWithRelations {
@@ -104,6 +106,7 @@ export interface ListingPayload {
   subCity?: string
   address?: string
   negotiable: boolean
+  ai_assisted?: boolean
   photos?: File[]
 }
 
@@ -122,7 +125,7 @@ export interface ListingEditPayload {
 }
 
 export const LISTING_COLUMNS =
-  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at"
+  "id, seller_id, category_id, title, description, price, condition, negotiable, city, sub_city, address, status, view_count, favorite_count, published_at, created_at, updated_at, ai_assisted"
 
 export const PAGE_SIZE = 12
 // Supabase/PostgREST caps a single select result set at 1000 rows. Browse is

--- a/web/supabase/migrations/20260814120000_add_listing_ai_assisted.sql
+++ b/web/supabase/migrations/20260814120000_add_listing_ai_assisted.sql
@@ -1,0 +1,15 @@
+-- T14 - AI Listing Assistant
+-- Records that a listing's title/description/category/condition were applied
+-- from AI suggestions (issue #18 AC-5: flag AI-assisted listings). The flag is
+-- opt-in — only set when the seller accepts AI suggestions — and is purely
+-- informational: AI never publishes automatically (FS-005 / AC-2), and editing
+-- a suggested value afterward does not clear the flag (the listing still used
+-- AI assistance). Per DB spec §17 (index boolean filter columns).
+alter table public.listings
+  add column if not exists ai_assisted boolean not null default false;
+
+-- Only published, non-deleted listings are surfaced in browse/search, so only
+-- they are worth indexing for an "AI-assisted" scan/filter.
+create index if not exists listings_ai_assisted_idx
+  on public.listings (ai_assisted)
+  where status = 'published' and deleted_at is null;

--- a/web/supabase/migrations/20260814120000_add_listing_ai_assisted.sql
+++ b/web/supabase/migrations/20260814120000_add_listing_ai_assisted.sql
@@ -4,12 +4,8 @@
 -- opt-in — only set when the seller accepts AI suggestions — and is purely
 -- informational: AI never publishes automatically (FS-005 / AC-2), and editing
 -- a suggested value afterward does not clear the flag (the listing still used
--- AI assistance). Per DB spec §17 (index boolean filter columns).
+-- AI assistance). No index is added: no read path filters on the flag (browse
+-- and search surface published listings via their own indexes), so an index
+-- here would be speculative.
 alter table public.listings
   add column if not exists ai_assisted boolean not null default false;
-
--- Only published, non-deleted listings are surfaced in browse/search, so only
--- they are worth indexing for an "AI-assisted" scan/filter.
-create index if not exists listings_ai_assisted_idx
-  on public.listings (ai_assisted)
-  where status = 'published' and deleted_at is null;

--- a/web/tests/unit/ai-action.test.ts
+++ b/web/tests/unit/ai-action.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/ai/listings", () => ({
+  generateListingSuggestions: vi.fn(),
+}))
+vi.mock("@/lib/ai/telemetry", () => ({
+  recordAiUsage: vi.fn(),
+}))
+
+import { generateListingSuggestions } from "@/lib/ai/listings"
+import { recordAiUsage } from "@/lib/ai/telemetry"
+import { generateListingSuggestionsAction } from "@/app/actions/ai"
+import type { AIListingResult } from "@/lib/ai/constants"
+import type { Category } from "@/lib/listings/constants"
+
+const mockedGenerate = vi.mocked(generateListingSuggestions)
+const mockedRecord = vi.mocked(recordAiUsage)
+
+const CATEGORIES: Category[] = [
+  { id: "c-electronics", name: "Electronics", slug: "electronics", parent_id: null },
+]
+
+const photo = (name = "photo.jpg"): File =>
+  new File(["x"], name, { type: "image/jpeg" })
+
+function fd(over: Record<string, string> = {}): FormData {
+  const form = new FormData()
+  form.append("photos", photo())
+  form.append("categories", JSON.stringify(CATEGORIES))
+  for (const [k, v] of Object.entries(over)) form.append(k, v)
+  return form
+}
+
+const okResult: AIListingResult = {
+  ok: true,
+  suggestion: {
+    title: "Chair",
+    description: "A chair",
+    categoryId: "c-electronics",
+    categoryName: "Electronics",
+    condition: "Fair",
+    keywords: ["chair"],
+    qualityScore: 70,
+  },
+}
+
+beforeEach(() => {
+  mockedGenerate.mockReset()
+  mockedRecord.mockReset()
+})
+
+describe("generateListingSuggestionsAction (T14, integration with the AI seam)", () => {
+  it("returns a manual-first error without photos and never calls the seam", async () => {
+    const res = await generateListingSuggestionsAction({}, new FormData())
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.message).toBe("Add a photo first")
+    expect(mockedGenerate).not.toHaveBeenCalled()
+  })
+
+  it("records ai_used and returns the seam's suggestion", async () => {
+    mockedGenerate.mockResolvedValue(okResult)
+    const res = await generateListingSuggestionsAction({}, fd())
+    expect(res.ok).toBe(true)
+    if (!res.ok || !res.suggestion) throw new Error("expected ok")
+    expect(res.suggestion.title).toBe("Chair")
+    expect(mockedRecord).toHaveBeenCalledWith("ai_used")
+  })
+
+  it("records ai_regenerated when the client asks for a regeneration", async () => {
+    mockedGenerate.mockResolvedValue(okResult)
+    await generateListingSuggestionsAction({}, fd({ ai_event: "regenerate" }))
+    expect(mockedRecord).toHaveBeenCalledWith("ai_regenerated")
+  })
+
+  it("forwards the seller's title/description to the seam (FS-005 inputs)", async () => {
+    mockedGenerate.mockResolvedValue(okResult)
+    await generateListingSuggestionsAction(
+      {},
+      fd({ title: "Stool", description: "Solid oak" })
+    )
+    expect(mockedGenerate).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      { title: "Stool", description: "Solid oak" }
+    )
+  })
+
+  it("passes through a degraded seam result", async () => {
+    mockedGenerate.mockResolvedValue({
+      ok: false,
+      reason: "degraded",
+      message: "AI request failed",
+    })
+    const res = await generateListingSuggestionsAction({}, fd())
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+})

--- a/web/tests/unit/ai-listings.test.ts
+++ b/web/tests/unit/ai-listings.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { Category } from "@/lib/listings/constants"
+
+import { resetAiRateLimiter, generateListingSuggestions } from "@/lib/ai/listings"
+
+const CATEGORIES: Category[] = [
+  { id: "c-electronics", name: "Electronics", slug: "electronics", parent_id: null },
+  { id: "c-furniture", name: "Furniture", slug: "furniture", parent_id: null },
+  { id: "c-books", name: "Books", slug: "books", parent_id: null },
+]
+
+const photo = (name = "photo.jpg"): File =>
+  new File(["unused-bytes"], name, { type: "image/jpeg" })
+
+const validJson = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    title: "Restored wooden chair",
+    description: "Solid wood, gently restored.",
+    category: "Furniture",
+    keywords: ["chair", "wood"],
+    condition: "Lightly Used",
+    quality_score: 82,
+    ...over,
+  })
+
+const geminiResponse = (text: string) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ candidates: [{ content: { parts: [{ text }] } }] }),
+})
+
+const originalFetch = globalThis.fetch
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  // The seam calls the global fetch (server-only); stub it per-test.
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+  resetAiRateLimiter()
+  process.env.GEMINI_API_KEY = "test-key"
+  delete process.env.AI_RATE_LIMIT
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  delete process.env.GEMINI_API_KEY
+  delete process.env.AI_RATE_LIMIT
+})
+
+describe("generateListingSuggestions (T14 / FS-005)", () => {
+  it("is unavailable without an API key (graceful degradation, AC-3)", async () => {
+    delete process.env.GEMINI_API_KEY
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("unavailable")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns rate_limited when the in-process window is exhausted (AC-4)", async () => {
+    process.env.AI_RATE_LIMIT = "2"
+    const ok = geminiResponse(validJson())
+    fetchMock.mockResolvedValueOnce(ok).mockResolvedValueOnce(ok)
+    expect((await generateListingSuggestions([photo()], CATEGORIES)).ok).toBe(true)
+    expect((await generateListingSuggestions([photo()], CATEGORIES)).ok).toBe(true)
+    const third = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(third.ok).toBe(false)
+    expect(third.ok ? "" : third.reason).toBe("rate_limited")
+  })
+
+  it("treats a 429 from Gemini as rate_limited", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      json: async () => ({}),
+    })
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("rate_limited")
+  })
+
+  it("degrades on a non-2xx Gemini response", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: async () => ({}),
+    })
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("degrades when the network call throws (down/error path, AC-3)", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"))
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("degrades on a malformed JSON payload", async () => {
+    fetchMock.mockResolvedValueOnce(geminiResponse("{not json"))
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("degrades on a category the seller does not have", async () => {
+    fetchMock.mockResolvedValueOnce(
+      geminiResponse(validJson({ category: "Nonexistent" }))
+    )
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("degrades on an out-of-range quality_score", async () => {
+    fetchMock.mockResolvedValueOnce(geminiResponse(validJson({ quality_score: 150 })))
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("degrades when no readable photos are supplied", async () => {
+    const res = await generateListingSuggestions([], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("maps a valid response to a suggestion, resolving the category id in one call", async () => {
+    fetchMock.mockResolvedValueOnce(geminiResponse(validJson()))
+    const res = await generateListingSuggestions(
+      [photo("a.jpg"), photo("b.png")],
+      CATEGORIES
+    )
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error("expected ok")
+    expect(res.suggestion.title).toBe("Restored wooden chair")
+    expect(res.suggestion.categoryName).toBe("Furniture")
+    expect(res.suggestion.categoryId).toBe("c-furniture")
+    expect(res.suggestion.condition).toBe("Lightly Used")
+    expect(res.suggestion.qualityScore).toBe(82)
+    expect(res.suggestion.keywords).toEqual(["chair", "wood"])
+    // Exactly one Gemini round-trip regardless of image count.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const call = fetchMock.mock.calls[0] as [string, { body: string }]
+    const parsed = JSON.parse(call[1].body)
+    const imageParts = parsed.contents[0].parts.filter((p: unknown) =>
+      Object.prototype.hasOwnProperty.call(p, "inlineData")
+    )
+    expect(imageParts).toHaveLength(2)
+    expect(parsed.generationConfig.responseMimeType).toBe("application/json")
+  })
+})

--- a/web/tests/unit/ai-listings.test.ts
+++ b/web/tests/unit/ai-listings.test.ts
@@ -152,4 +152,27 @@ describe("generateListingSuggestions (T14 / FS-005)", () => {
     expect(imageParts).toHaveLength(2)
     expect(parsed.generationConfig.responseMimeType).toBe("application/json")
   })
+
+  it("degrades when the request is aborted by the 10s timeout (NFR-AI-002)", async () => {
+    fetchMock.mockRejectedValueOnce(
+      new DOMException("The operation was aborted.", "AbortError")
+    )
+    const res = await generateListingSuggestions([photo()], CATEGORIES)
+    expect(res.ok).toBe(false)
+    expect(res.ok ? "" : res.reason).toBe("degraded")
+  })
+
+  it("sends the seller's optional title/description as prompt context (FS-005 Inputs)", async () => {
+    fetchMock.mockResolvedValueOnce(geminiResponse(validJson()))
+    const res = await generateListingSuggestions([photo()], CATEGORIES, {
+      title: "Wooden stool",
+      description: "Solid oak, light wear",
+    })
+    expect(res.ok).toBe(true)
+    const call = fetchMock.mock.calls[0] as [string, { body: string }]
+    const parsed = JSON.parse(call[1].body)
+    const promptText = parsed.contents[0].parts[0].text as string
+    expect(promptText).toContain("Title: Wooden stool")
+    expect(promptText).toContain("Description: Solid oak, light wear")
+  })
 })

--- a/web/tests/unit/ai-telemetry.test.ts
+++ b/web/tests/unit/ai-telemetry.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest"
+
+import {
+  recordAiUsage,
+  getAiUsageCounters,
+  resetAiUsageCounters,
+} from "@/lib/ai/telemetry"
+
+beforeEach(() => resetAiUsageCounters())
+
+describe("AI usage telemetry (FS-005 analytics)", () => {
+  it("counts each tracked event independently", () => {
+    recordAiUsage("ai_used")
+    recordAiUsage("ai_used")
+    recordAiUsage("ai_regenerated")
+    recordAiUsage("ai_accepted")
+    expect(getAiUsageCounters()).toEqual({
+      ai_used: 2,
+      ai_regenerated: 1,
+      ai_accepted: 1,
+    })
+  })
+
+  it("returns a snapshot, not the live counter object", () => {
+    recordAiUsage("ai_used")
+    const snap = getAiUsageCounters()
+    recordAiUsage("ai_used")
+    expect(snap.ai_used).toBe(1)
+  })
+
+  it("resets to zero", () => {
+    recordAiUsage("ai_used")
+    resetAiUsageCounters()
+    expect(getAiUsageCounters()).toEqual({
+      ai_used: 0,
+      ai_regenerated: 0,
+      ai_accepted: 0,
+    })
+  })
+})


### PR DESCRIPTION
Implements optional AI-assisted listing creation via Gemini 2.5-flash.

**Closes #18 — T14: AI Listing Assistant (non-gating).**

Non-gating — when AI is unavailable/down the flow falls back to fully manual creation (AC-3 / R-02, NFR-AI-003). With no `GEMINI_API_KEY` locally, AI shows "unavailable" and never blocks publishing.

## Changes

- DB: `listings.ai_assisted` bool default false (AC-5 flag)
- Backend: `lib/ai/listings.ts` — server-only Gemini REST seam (no SDK); responseSchema JSON; category name→id; 10 req/min per-process rate limit (env-overridable); 10s timeout (NFR-AI-002); graceful degrade (unavailable / rate_limited / degraded)
- Action: `app/actions/ai.ts` (Server Action) + `lib/ai/telemetry.ts` (FS-005 analytics: ai_used / ai_regenerated / ai_accepted)
- UI: `components/listings/ai-assist.tsx` (Apply / Regenerate / Dismiss, editable keyword chips) wired into create-listing-form (controlled fields, photo tracking, optional title/description prompt context)
- Detail: AI-assisted badge on listing page
- Tests: `tests/unit/ai-listings.test.ts`, `tests/unit/ai-action.test.ts`, `tests/unit/ai-telemetry.test.ts`

## Acceptance criteria (#18)

- [x] During create-listing, optional "AI assist" generates suggestions from image(s)
- [x] Suggestions are pre-filled, editable by the seller; never auto-submitted
- [x] When AI is unavailable/down, the flow falls back to fully manual creation (R-02 mitigation)
- [x] AI call is rate-limited and fails gracefully (per-instance cap; a miss degrades to manual)
- [x] Flagged clearly in the listing as AI-assisted

## Validation

- [x] lint
- [x] typecheck (tsc)
- [x] tests — 132/132 (incl. new AI seam / action / telemetry coverage)
- [x] CI: Lint, Typecheck, Tests & Build — SUCCESS