### PR TITLE
T16 - README, docs & demo prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,62 @@
 This repository is the single source of truth for the product (see `docs/`)
 and now hosts the web application under `web/`.
 
+## What is this?
+
+A used-goods marketplace for Addis Ababa, built for the VinTech Challenge 2026.
+Buyers search and filter listings, contact sellers (Telegram / call), and make
+offers; sellers publish listings (with an optional AI-assisted listing
+assistant); a seller trust framework (verified sellers, reviews, ratings)
+supports safe transactions. The winning strategy and product vision live in
+[`docs/00-strategy/00-winning-strategy.md`](docs/00-strategy/00-winning-strategy.md).
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router, Server Components) |
+| Language | TypeScript |
+| UI | React 19, Tailwind CSS 4, shadcn/ui (Radix) |
+| Backend | Supabase (PostgreSQL, Auth, Storage) |
+| Security model | Postgres Row Level Security + typed Server Actions |
+| AI (optional) | Google Gemini API — listing assistant |
+| Testing | Vitest (unit), ESLint, `tsc --noEmit` |
+| CI/CD | GitHub Actions + Vercel |
+
+## System architecture
+
+```text
+             Browser (desktop / mobile)
+                        │
+              Next.js App (web/) — RSC + Server Actions
+                        │
+      ┌─────────────────┴──────────────────┐
+   Supabase (BaaS)                     Gemini API
+   │  ├─ PostgreSQL (RLS)               (AI listing assist)
+   │  ├─ Auth (email + password, JWT)
+   │  └─ Storage (avatars, listing-images)
+```
+
+The app is a serverless Next.js frontend over Supabase-as-backend. Reads and
+writes go through Row Level Security policies on Postgres; privileged or
+stateful writes (offers, reviews, reports, contact attempts) run as
+`SECURITY DEFINER` RPCs that re-check the caller and apply rate limits.
+See [`docs/02-architecture/00-system-architecture.md`](docs/02-architecture/00-system-architecture.md)
+for the full picture and the ADRs.
+
+## Repository layout
+
+```
+web/                Web application (Next.js App Router, Tailwind, shadcn/ui)
+docs/00-strategy/   Winning strategy + product vision
+docs/01-prd/        PRD: overview, goals, personas, stories, FR/NFR, flows
+docs/02-architecture/  System architecture, ADRs, domain model, DB/API/backend specs
+docs/03-engineering/   Performance, testing, CI/CD, coding standard, roadmap
+docs/04-design/     Design system: foundations, components, library, UX
+docs/agents/        Agent working notes (tracker conventions)
+load-test/          k6 load-test scenario + runbook
+```
+
 ## Application
 
 The web app lives in `web/` (Next.js App Router, Tailwind CSS, shadcn/ui).
@@ -14,4 +70,12 @@ npm run dev
 ```
 
 See [web/README.md](web/README.md) for full setup, the Supabase local stack
-commands, and the design-token overview.
+commands, and the design-token overview. For a hosted deployment, see
+[`docs/03-engineering/12-deployment-guide.md`](docs/03-engineering/12-deployment-guide.md).
+
+## Documentation map
+
+- **PRD:** [`docs/01-prd/00-overview.md`](docs/01-prd/00-overview.md)
+- **Build plan:** [`docs/03-engineering/06-implementation-roadmap.md`](docs/03-engineering/06-implementation-roadmap.md)
+- **Design authority:** [`docs/04-design/00-design-foundations.md`](docs/04-design/00-design-foundations.md)
+- **Architecture decisions:** [`docs/02-architecture/01-architecture-decision-records.md`](docs/02-architecture/01-architecture-decision-records.md)

--- a/docs/03-engineering/12-deployment-guide.md
+++ b/docs/03-engineering/12-deployment-guide.md
@@ -1,0 +1,149 @@
+# Deployment Guide — Hosted Supabase + Vercel
+
+> **Project:** VinTech Challenge 2026
+>
+> **Version:** 1.0
+>
+> **Owner:** Engineering Team
+>
+> **Status:** Draft
+
+This guide deploys the Used Goods Marketplace to a hosted Supabase project
+plus Vercel. It is the concrete how-to behind the hosting plan in
+[`10-submission-readiness.md`](10-submission-readiness.md) (ADR-017: GitHub,
+GitHub Actions, Vercel, Supabase). Local development uses the Supabase CLI
+stack instead (see [`web/README.md`](../../web/README.md)).
+
+# 1. Overview
+
+The app needs three pieces to run:
+
+1. **Supabase** — the database (Postgres + RLS), auth, and storage. Migrations
+   in `web/supabase/migrations/` are the schema of record.
+2. **Vercel** — the Next.js frontend (stateless, auto-scaling).
+3. **Environment variables** — live in Vercel and Supabase, never in git.
+
+```text
+Developer → GitHub → GitHub Actions (CI) → Vercel → production URL
+                                              │
+                                              └→ Supabase (Postgres, Auth, Storage)
+```
+
+# 2. Hosted Supabase project
+
+## 2.1 Create the project
+
+1. Sign in at [supabase.com](https://supabase.com) and create a new project.
+2. **Region:** pick the closest region to Ethiopia for demo latency (e.g.
+   `eu-west-1` / `eu-central-1` if offered).
+3. Note the project URL (`https://<project-ref>.supabase.co`) and the anon key
+   (Settings → API).
+4. The free tier (500 MB DB, 1 GB storage) is ample for the ~50–75 seeded
+   listings used by the demo.
+
+## 2.2 Apply migrations
+
+The local CLI applies the same migrations that run in CI. From `web/`:
+
+```bash
+supabase link --project-ref <project-ref>
+supabase db push
+```
+
+- `supabase db push` applies any migrations not yet on the hosted DB, in order.
+- `supabase db reset` is **local only** (wipes the local stack); never run it
+  against hosted.
+
+## 2.3 Load the demo seed
+
+The seed (`web/supabase/seed.sql`) creates the demo accounts and Addis Ababa
+listings. On hosted, run it once as the service role:
+
+```bash
+supabase db execute --file supabase/seed.sql
+```
+
+The seed is idempotent (safe to re-run). It creates demo accounts with known
+credentials — **change these passwords** before sharing the demo broadly (see
+section 5).
+
+## 2.4 Storage buckets
+
+The migration `20260812200000_create_listings.sql` creates the
+`listing-images` bucket and its storage policies. Verify it exists on hosted:
+
+```bash
+supabase storage ls
+```
+
+# 3. Vercel deployment
+
+## 3.1 Connect the repository
+
+1. Create a Vercel account and import the GitHub repository
+   `hamdi-ab/used-goods-marketplace`.
+2. Vercel detects the Next.js app in `web/` — set **Root Directory** to `web/`.
+3. Framework preset: **Next.js**. Build command `npm run build`, output
+   `.next`.
+
+## 3.2 Environment variables
+
+Set these in Vercel (Project → Settings → Environment Variables) for the
+Production, Preview, and Development environments:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | `https://<project-ref>.supabase.co` | Public, safe to expose |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key from Supabase | Public, safe to expose |
+| `SUPABASE_SERVICE_ROLE_KEY` | service role key | Secret — used only by Server Actions on the server |
+| `GEMINI_API_KEY` | Gemini API key | Secret — AI listing assistant |
+| `NEXT_PUBLIC_SITE_URL` | the Vercel production URL | Optional — used for metadata/sitemap |
+
+Never commit these to git. The repo ships `.env.example` for the public-shape
+only.
+
+## 3.3 First deploy
+
+Push to `main` (or run a manual deploy) — CI (`ci.yml`) runs lint, typecheck,
+test, and build on every PR; the deploy workflow (`deploy.yml`) auto-deploys
+`main` once the Vercel secrets are configured in GitHub. Preview deployments
+are created per-PR automatically.
+
+# 4. Post-deploy verification
+
+1. Open the production URL — the home page shows seeded Addis Ababa listings.
+2. Log in with a demo account (section 5) and confirm protected routes
+   (`/dashboard`, `/profile`, `/sell`) redirect correctly.
+3. Make an offer on a listing and confirm it appears on the seller's
+   `/offers/seller`.
+4. Confirm images load (Supabase Storage public bucket + `next/image`).
+
+# 5. Demo accounts
+
+The seed creates the accounts below (all password `demo1234` except admin):
+
+| Account | Email | Role | Purpose |
+|---|---|---|---|
+| Admin | `admin@vintch.local` | admin | Moderation queue (Reports) — password `admin1234` |
+| Seller (phone-verified) | `amira.sellers@vintch.local` | seller | "Verified Seller" trust badge |
+| Seller (Fayda-verified) | `fayad.verified@vintch.local` | seller | "Verified Seller" trust badge |
+| Seller (plain) | `kebede.trader@vintch.local` | seller | Unverified seller badge state |
+| Buyer | `biniam.buyer@vintch.local` | buyer | Browsing, offers, favorites |
+
+**Change the passwords before shared hosting.** See the tracker note in
+`docs/agents/issue-tracker.md` for the canonical list.
+
+# 6. Rollback / recovery
+
+- **App:** Vercel deployment history — redeploy any previous build.
+- **DB:** migrations are forward-only. To undo, write a corrective migration
+  (follow the timestamped naming) rather than editing history.
+- **Secrets:** rotate keys in Vercel/Supabase dashboards; the app reads them
+  at runtime, so a rotation only needs a redeploy.
+
+# 7. Related docs
+
+- Hosting plan & decisions: `10-submission-readiness.md`
+- CI/CD strategy: `02-ci-cd-strategy.md`
+- Load verification (live run once hosted): `11-load-verification.md`
+- Architecture: `../../02-architecture/00-system-architecture.md`

--- a/docs/03-engineering/12-deployment-guide.md
+++ b/docs/03-engineering/12-deployment-guide.md
@@ -93,11 +93,12 @@ Production, Preview, and Development environments:
 
 | Variable | Value | Notes |
 |---|---|---|
-| `NEXT_PUBLIC_SUPABASE_URL` | `https://<project-ref>.supabase.co` | Public, safe to expose |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key from Supabase | Public, safe to expose |
-| `SUPABASE_SERVICE_ROLE_KEY` | service role key | Secret — used only by Server Actions on the server |
-| `GEMINI_API_KEY` | Gemini API key | Secret — AI listing assistant |
-| `NEXT_PUBLIC_SITE_URL` | the Vercel production URL | Optional — used for metadata/sitemap |
+| `NEXT_PUBLIC_SUPABASE_URL` | `https://<project-ref>.supabase.co` | Public — the Supabase project URL (read by `lib/supabase/server.ts`) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | anon key from Supabase | Public — RLS-scoped client key (read by `lib/supabase/server.ts`) |
+| `GEMINI_API_KEY` | Gemini API key | Secret — AI listing assistant (`lib/ai/listings.ts`) |
+| `AI_RATE_LIMIT` | `10` | Optional — per-process AI-call rate window (`lib/ai/listings.ts`); defaults to 10 |
+| `NEXT_PUBLIC_SITE_URL` | the Vercel production URL | Public — metadata/sitemap base (`lib/site.ts`); has a sensible fallback, set to the real URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | service role key | Secret — **not read by the app today**; provisioned for parity with CI/CD §9 and reserved for admin/seed tooling. Do not expose client-side |
 
 Never commit these to git. The repo ships `.env.example` for the public-shape
 only.
@@ -120,18 +121,14 @@ are created per-PR automatically.
 
 # 5. Demo accounts
 
-The seed creates the accounts below (all password `demo1234` except admin):
+The seed creates the demo accounts (admin + phone-verified seller, Fayda-
+verified seller, plain seller, and buyer — all with the documented
+credentials). The canonical account table lives in
+[`web/README.md`](../../web/README.md) (under "Database migrations") and is
+the single source of truth — update it there if accounts ever change.
 
-| Account | Email | Role | Purpose |
-|---|---|---|---|
-| Admin | `admin@vintch.local` | admin | Moderation queue (Reports) — password `admin1234` |
-| Seller (phone-verified) | `amira.sellers@vintch.local` | seller | "Verified Seller" trust badge |
-| Seller (Fayda-verified) | `fayad.verified@vintch.local` | seller | "Verified Seller" trust badge |
-| Seller (plain) | `kebede.trader@vintch.local` | seller | Unverified seller badge state |
-| Buyer | `biniam.buyer@vintch.local` | buyer | Browsing, offers, favorites |
-
-**Change the passwords before shared hosting.** See the tracker note in
-`docs/agents/issue-tracker.md` for the canonical list.
+**Change the demo passwords before shared hosting** (all demo accounts share
+`demo1234`, admin uses `admin1234`).
 
 # 6. Rollback / recovery
 

--- a/docs/03-engineering/13-demo-script.md
+++ b/docs/03-engineering/13-demo-script.md
@@ -22,14 +22,12 @@ marketplace. Target length: **3–5 minutes, ≤ 5:00**.
 - [ ] Recording tool ready (OS-native or OBS); trim to ≤ 5:00.
 - [ ] Browser window clean, e.g. 1440×900, no bookmarks bar clutter.
 
-## 1. Demo accounts (use these in the video)
+## 1. Demo accounts
 
-| Account | Email | Password | Role |
-|---|---|---|---|
-| Seller (phone-verified) | `amira.sellers@vintch.local` | `demo1234` | Posts listings |
-| Seller (Fayda-verified) | `fayad.verified@vintch.local` | `demo1234` | Trust-badge variety |
-| Buyer | `biniam.buyer@vintch.local` | `demo1234` | Searches, offers |
-| Admin | `admin@vintch.local` | `admin1234` | Moderation queue (optional) |
+Use the demo accounts (canonical table in
+[`web/README.md`](../../web/README.md) under "Database migrations"): sign in as
+the buyer (`biniam.buyer@vintch.local`) for the search/offer flow, and as a
+seller (e.g. `amira.sellers@vintch.local`) for the create-listing flow.
 
 ## 2. Shot list
 

--- a/docs/03-engineering/13-demo-script.md
+++ b/docs/03-engineering/13-demo-script.md
@@ -1,0 +1,100 @@
+# Demo Script — 5-Minute Walkthrough
+
+> **Project:** VinTech Challenge 2026
+>
+> **Version:** 1.0
+>
+> **Owner:** Engineering Team
+>
+> **Status:** Draft
+
+This is the recorded demo screenplay for the submission (tracker T16 AC-5,
+issue #20). It turns the plan in
+[`10-submission-readiness.md`](10-submission-readiness.md) §4 into a concrete,
+timed run against the **hosted production URL** with the seeded Addis Ababa
+marketplace. Target length: **3–5 minutes, ≤ 5:00**.
+
+## 0. Pre-flight checklist
+
+- [ ] Hosted app deployed (see [`12-deployment-guide.md`](12-deployment-guide.md)).
+- [ ] Seed data applied to hosted; demo accounts sign in.
+- [ ] No local stack in the video — record against the production URL.
+- [ ] Recording tool ready (OS-native or OBS); trim to ≤ 5:00.
+- [ ] Browser window clean, e.g. 1440×900, no bookmarks bar clutter.
+
+## 1. Demo accounts (use these in the video)
+
+| Account | Email | Password | Role |
+|---|---|---|---|
+| Seller (phone-verified) | `amira.sellers@vintch.local` | `demo1234` | Posts listings |
+| Seller (Fayda-verified) | `fayad.verified@vintch.local` | `demo1234` | Trust-badge variety |
+| Buyer | `biniam.buyer@vintch.local` | `demo1234` | Searches, offers |
+| Admin | `admin@vintch.local` | `admin1234` | Moderation queue (optional) |
+
+## 2. Shot list
+
+Pacing: each shot advances exactly one story step; total ≤ 5:00.
+
+### Shot 1 — Brand hero (~10 s)
+- **Screen:** Home page, signature neighborhood hero illustration, marketplace name.
+- **Voice:** "The fastest and most trustworthy way to buy and sell used goods in Addis Ababa."
+
+### Shot 2 — Seller creates a listing (~60 s)
+- **Screen:** Sign in as **Amira** → `/sell`. Fill title, description, price in ETB, condition, Addis location; pick the AI Listing Assistant to suggest a title/description/category (AI differentiator, optional path).
+- **Voice:** "Listing is effortless — and the AI assistant writes a convincing post in seconds."
+
+### Shot 3 — Listing goes live (~20 s)
+- **Screen:** Publish → the listing card appears on the home page with condition badge, ETB price, Addis location.
+- **Voice:** "Live instantly, with the trust bar buyers look for."
+
+### Shot 4 — Buyer searches and filters (~30 s)
+- **Screen:** Sign in as **Biniam**. Keyword search + filters (category / price / condition / city) → results snap in.
+- **Voice:** "Discovery is fast — search, filter, and it is there in seconds."
+
+### Shot 5 — Result → detail with trust bar (~20 s)
+- **Screen:** Open a card → listing detail shows the seller's Trust score and verified badges.
+- **Voice:** "Every listing carries the seller's trust history, so buyers know who they are dealing with."
+
+### Shot 6 — Buyer contacts the seller (~20 s)
+- **Screen:** Telegram / call buttons; a contact attempt is recorded (t.me deep-link / `tel:`).
+- **Voice:** "Talk first, in the way that suits Addis — Telegram or a call."
+
+### Shot 7 — Offer lifecycle (~40 s)
+- **Screen:** Buyer submits an offer → seller's `/offers/seller` shows it → seller accepts.
+- **Voice:** "Then make an offer, and the seller sees it on their dashboard the moment it lands."
+
+### Shot 8 — (optional) Admin moderation (~30 s)
+- **Screen:** Admin queue sees the new listing / a reported listing; toggle on/off.
+- **Voice:** "And there is a real governance layer behind the marketplace."
+
+### Shot 9 — Closing (~15 s)
+- **Screen:** Value-proposition card.
+- **Voice:** "Speed, trust, and simplicity — a marketplace that works the way Addis does. This is VinTech."
+
+## 3. Time budget
+
+| Block | Time |
+|---|---|
+| Brand hero | 0:10 |
+| Seller flow (create + AI + publish) | 1:20 |
+| Buyer flow (search, detail, contact, offer) | 1:50 |
+| Admin (optional) | 0:30 |
+| Closing | 0:15 |
+| **Total** | **~4:05** |
+
+Cut the admin shot and trim AI assist to land comfortably under 5:00.
+
+## 4. Recording & hosting
+
+- Record with OS-native capture or OBS at 1080p; trim in the editor to ≤ 5:00.
+- Host the recording (Vercel static file or external link) and record the URL
+  in the submission-readiness Decisions-so-far when chosen (T16/T17 tooling
+  note, `10-submission-readiness.md` §4).
+- Verify audio level and subtitles if adding voiceover.
+
+## 5. Related docs
+
+- Demo plan & decisions: `10-submission-readiness.md` §4
+- Winning strategy voice: `../../00-strategy/00-winning-strategy.md`
+- Deployment: `12-deployment-guide.md`
+- Video deliverables: `06-implementation-roadmap.md` §12

--- a/web/README.md
+++ b/web/README.md
@@ -149,9 +149,11 @@ accounts below (change passwords before any shared hosting):
 | Seller (plain) | `kebede.trader@vintch.local` | `demo1234` | Unverified state |
 | Buyer | `biniam.buyer@vintch.local` | `demo1234` | Browsing / offers |
 
-The seed also publishes ~60 Addis Ababa listings across every category
-(Bole, Piassa, Merkato, Kazanchis, …) so search/filter/detail have a full
-catalog to work with.
+The seed also publishes ~69 Addis Ababa listings across every category
+(Bole, Piassa, Merkato, Kazanchis, …), weighted toward Electronics, Furniture,
+and Home Appliances, so search/filter/detail have a full catalog to work
+with. Six of those are marked sold behind the demo sellers' earned reviews
+and ratings, leaving ~63 live listings to browse.
 
 ## Authentication & roles
 

--- a/web/README.md
+++ b/web/README.md
@@ -8,6 +8,48 @@ Design and architecture source of truth: the repository `docs/` tree
 (design authority: `docs/04-design/00-design-foundations.md`; CI/CD shape:
 `docs/03-engineering/02-ci-cd-strategy.md`).
 
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router, React Server Components) |
+| Language | TypeScript |
+| UI | React 19, Tailwind CSS 4, shadcn/ui (Radix) |
+| Backend | Supabase (PostgreSQL, Auth, Storage, RLS) |
+| AI (optional) | Google Gemini API — AI listing assistant |
+| Validation | Zod (server actions) |
+| Testing | Vitest, ESLint, TypeScript |
+| CI/CD | GitHub Actions (lint, typecheck, test, build) + Vercel |
+
+## System architecture
+
+```text
+             Browser (desktop / mobile)
+                        │
+              Next.js App (this dir) — RSC + Server Actions
+                        │
+      ┌─────────────────┴──────────────────┐
+   Supabase (BaaS)                     Gemini API
+   │  ├─ PostgreSQL (RLS)               (AI listing assist)
+   │  ├─ Auth (email + password, JWT)
+   │  └─ Storage (avatars, listing-images)
+```
+
+The app is a stateless Next.js frontend over Supabase-as-backend:
+
+- **Reads** run as server components / Server Actions that call Supabase
+  PostgREST; every table has Row Level Security policies scoping rows to the
+  caller (see `supabase/migrations/`).
+- **Privileged or stateful writes** (offers, reviews, reports, contact
+  attempts) go through `SECURITY DEFINER` RPCs that re-check the caller,
+  enforce invariants, and apply rate limits — never a raw client insert.
+- **AI listing assist** is optional; manual listing creation always works
+  (ADR-009, Gemini free tier).
+
+The full architecture, ADRs, DB schema, and API surface are documented in
+`docs/02-architecture/`. The deployment guide for hosted Supabase + Vercel is
+`docs/03-engineering/12-deployment-guide.md`.
+
 ## Requirements
 
 - Node.js 20+ and npm
@@ -96,9 +138,20 @@ and load the seed on the local stack:
 supabase db reset
 ```
 
-`supabase db reset` also runs `supabase/seed.sql`, which creates one admin
-account for moderation: **admin@vintch.local / admin1234** (change the
-password before any shared hosting).
+`supabase db reset` also runs `supabase/seed.sql`, which creates the demo
+accounts below (change passwords before any shared hosting):
+
+| Account | Email | Password | Role |
+|---|---|---|---|
+| Admin | `admin@vintch.local` | `admin1234` | Moderation queue |
+| Seller (phone-verified) | `amira.sellers@vintch.local` | `demo1234` | Trust badge + listings |
+| Seller (Fayda-verified) | `fayad.verified@vintch.local` | `demo1234` | Trust badge + listings |
+| Seller (plain) | `kebede.trader@vintch.local` | `demo1234` | Unverified state |
+| Buyer | `biniam.buyer@vintch.local` | `demo1234` | Browsing / offers |
+
+The seed also publishes ~60 Addis Ababa listings across every category
+(Bole, Piassa, Merkato, Kazanchis, …) so search/filter/detail have a full
+catalog to work with.
 
 ## Authentication & roles
 

--- a/web/supabase/seed.sql
+++ b/web/supabase/seed.sql
@@ -167,32 +167,36 @@ begin
      'Steel bedside table', 'Minimal steel frame bedside table, minor scuffs.', 950,
      'Fair', false, 'Dire Dawa', null, 'published', now())
   on conflict (id) do nothing;
-
-  insert into public.listing_images (listing_id, image_url, display_order, alt_text)
-  select l.id, '/images/illustrations/trust-safe-transactions.svg', 0, 'Demo listing image'
-  from public.listings l
-  where l.seller_id in (seller_phone, seller_fayda, seller_plain)
-    and not exists (select 1 from public.listing_images where listing_id = l.id);
 end $$;
 
 -----------------------------------------------------------------------------
 -- T16 demo seed: a populated Addis Ababa marketplace (issue #20 AC-4) so the
 -- browse/search/detail/offer walkthrough has a full catalog to work with.
--- ~58 listings across every category (DB spec §7), spread across the demo
--- sellers above (most on Amira so the phone-verified seller badge shows up
--- across cards) and Addis Ababa sub-cities (Bole, Piassa, Merkato,
--- Kazanchis, Arada, Yeka). A few Dire Dawa rows from Kebede exercise the
--- city filter. IDs are deterministic
+-- ~67 listings across every category (DB spec §7), weighted toward the persona
+-- pain-point categories Electronics / Furniture / Home Appliances (each 10,
+-- per the plan in docs/03-engineering/10-submission-readiness.md §3.2), spread
+-- across the demo sellers above (most on Amira so the phone-verified seller
+-- badge shows up across cards) and Addis Ababa sub-cities (Bole, Piassa,
+-- Merkato, Kazanchis, Arada, Yeka). IDs are deterministic
 -- (20000000-...-00000000000N) so re-running `supabase db reset` stays
 -- idempotent (on conflict (id) do nothing). Image URLs are local illustration
 -- / photo SVG stand-ins for demo only; swap for real product photos before
 -- production hosting.
+--
+-- The same block seeds the trust framework the demo relies on (plan §3.3):
+-- six accepted offers from the demo buyer on real listings (marking them
+-- sold), six matching reviews, and a trust_score recomputed from those reviews
+-- with the same formula submit_review uses (round(avg(rating) * 20)) — so the
+-- seller trust bars in the demo are earned, not hard-coded with no backing
+-- rows. Unlike production, seed inserts bypass the SECURITY DEFINER RPCs
+-- because the seed runs as the postgres role on `db reset`.
 -----------------------------------------------------------------------------
 do $$
 declare
   seller_phone uuid := '00000000-0000-0000-0000-000000000002';
   seller_fayda uuid := '00000000-0000-0000-0000-000000000003';
   seller_plain uuid := '00000000-0000-0000-0000-000000000004';
+  a_buyer uuid := '00000000-0000-0000-0000-000000000005';
   rec record;
 begin
   for rec in select * from (values
@@ -320,7 +324,28 @@ begin
     (57, seller_phone, 'other', 'DSLR camera bag + tripod',
      'Large padded camera bag plus aluminum tripod. Both in good condition, padding intact.', 5000, 'Lightly Used', false, 'Yeka', 12),
     (58, seller_fayda, 'other', 'Ergonomic office chair',
-     'Ergonomic mesh office chair with lumbar support, adjustable height and armrests. One caster replaced.', 6500, 'Fair', false, 'Bole', 21)
+     'Ergonomic mesh office chair with lumbar support, adjustable height and armrests. One caster replaced.', 6500, 'Fair', false, 'Bole', 21),
+    ------------------------------------------------------------------ Electronics (weighted: +3)
+    (59, seller_phone, 'electronics', 'iPhone 13 128GB',
+     'iPhone 13, 128GB, battery health 92%, Face ID works, includes original box and cable. Minor wear on the frame.', 52000, 'Lightly Used', false, 'Bole', 4),
+    (60, seller_fayda, 'electronics', 'Samsung Galaxy Tab S6 Lite',
+     'Galaxy Tab S6 Lite, 64GB, with S-pen. Used mostly for notes, screen protector fitted since day one.', 21000, 'Lightly Used', true, 'Piassa', 8),
+    (61, seller_phone, 'electronics', 'Apple Watch SE 40mm',
+     'Apple Watch SE (2nd gen), 40mm GPS. Unopened, still sealed in box. Wrong size gift.', 18500, 'Brand New', false, 'Kazanchis', 2),
+    ------------------------------------------------------------------ Furniture (weighted: +3)
+    (62, seller_fayda, 'furniture', '2-door wardrobe',
+     '2-door wooden wardrobe, 180cm tall, with a mirror on one door. Minor scratches, hinges work smoothly.', 9500, 'Fair', true, 'Bole', 27),
+    (63, seller_phone, 'furniture', 'Patio table + 4 chairs',
+     'Round patio table with four folding chairs, aluminum frame and glass top. Light use, no rust.', 12500, 'Lightly Used', true, 'Merkato', 16),
+    (64, seller_fayda, 'furniture', 'Children study desk',
+     'Adjustable-height children study desk with a shelf. Good condition, some pencil marks that clean off easily.', 4800, 'Lightly Used', false, 'Yeka', 19),
+    ------------------------------------------------------------------ Home Appliances (weighted: +3)
+    (65, seller_phone, 'home-appliances', 'Blender 1.5L',
+     '1.5L blender with 2 speeds and pulse, 600W. Box included, never used.', 3200, 'Brand New', false, 'Piassa', 1),
+    (66, seller_fayda, 'home-appliances', 'Ironing board + steam iron',
+     'Folding ironing board with adjustable height plus a steam iron. Board padding is worn but fully functional.', 2500, 'Fair', false, 'Bole', 14),
+    (67, seller_phone, 'home-appliances', '16-inch stand fan',
+     '16-inch oscillating stand fan, 3 speeds, remote control. Sealed in box, never opened.', 2800, 'Brand New', false, 'Merkato', 3)
   ) as t(k int, seller_id uuid, category_slug text, title text, description text,
         price numeric, condition public.listing_condition, negotiable boolean, sub_city text, age_days int)
   loop
@@ -338,7 +363,7 @@ begin
   end loop;
 
   -- One stand-in image per demo listing that does not already have one
-  -- (covers the T12 three listings and the ~58 above). Rows are numbered to
+  -- (covers the T12 three listings and the ~67 above). Rows are numbered to
   -- rotate between a few local assets so cards look varied during the demo.
   with ranked as (
     select l.id, l.title,
@@ -358,4 +383,65 @@ begin
          0,
          coalesce(title, 'Demo listing image')
   from ranked;
+
+  -- Earned trust framework (plan §3.3): six completed transactions from the
+  -- demo buyer on six published listings (two per seller). Each accepted offer
+  -- marks its listing sold with the winning buyer stamped (ListingMarkedSold,
+  -- mirroring accept_offer), and each transaction gets one review — so the
+  -- seller trust bars in the demo are backed by real reviews, not just the
+  -- hard-coded trust_score from T12. trust_score is then recomputed with the
+  -- same formula submit_review uses, so the badge score equals the earned
+  -- average (Amira 90, Fayad 80, Kebede 60). Deterministic IDs keep the seed
+  -- idempotent.
+  insert into public.offers (id, listing_id, buyer_id, amount, message, status)
+  values
+    ('30000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001',
+     a_buyer, 26000, 'Hi, would you accept 26000 for the iPhone?', 'accepted'),
+    ('30000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000008',
+     a_buyer, 35000, 'Is 35000 okay for the sofa set, delivered?', 'accepted'),
+    ('30000000-0000-0000-0000-000000000003', '20000000-0000-0000-0000-000000000004',
+     a_buyer, 23000, '23000 for the Galaxy A54 if you can deliver to Piassa.', 'accepted'),
+    ('30000000-0000-0000-0000-000000000004', '20000000-0000-0000-0000-000000000016',
+     a_buyer, 55000, 'Would you take 55000 for the fridge?', 'accepted'),
+    ('30000000-0000-0000-0000-000000000005', '20000000-0000-0000-0000-000000000011',
+     a_buyer, 5000, '5000 for the bookshelf, I can pick it up.', 'accepted'),
+    ('30000000-0000-0000-0000-000000000006', '20000000-0000-0000-0000-000000000023',
+     a_buyer, 150000, '150000 for the Boxer if the documents are ready.', 'accepted')
+  on conflict (id) do nothing;
+
+  update public.listings
+    set status = 'sold', sold_to_buyer_id = a_buyer
+    where id in (
+      '20000000-0000-0000-0000-000000000001',
+      '20000000-0000-0000-0000-000000000008',
+      '20000000-0000-0000-0000-000000000004',
+      '20000000-0000-0000-0000-000000000016',
+      '20000000-0000-0000-0000-000000000011',
+      '20000000-0000-0000-0000-000000000023'
+    );
+
+  insert into public.reviews (offer_id, seller_id, buyer_id, rating, comment)
+  values
+    ('30000000-0000-0000-0000-000000000001', seller_phone, a_buyer, 5,
+     'Exactly as described, met in Bole and it was an easy transaction.'),
+    ('30000000-0000-0000-0000-000000000002', seller_phone, a_buyer, 4,
+     'Good sofa, delivery arranged without fuss. Slight delay but fair price.'),
+    ('30000000-0000-0000-0000-000000000003', seller_fayda, a_buyer, 4,
+     'Phone was clean and boxed as promised, smooth meetup.'),
+    ('30000000-0000-0000-0000-000000000004', seller_fayda, a_buyer, 4,
+     'Fridge works perfectly, still under warranty as said.'),
+    ('30000000-0000-0000-0000-000000000005', seller_plain, a_buyer, 3,
+     'Bookshelf is sturdy but a bit more scuffed than the photos showed.'),
+    ('30000000-0000-0000-0000-000000000006', seller_plain, a_buyer, 3,
+     'Bike runs well and papers were ready, though price took some negotiation.')
+  on conflict (offer_id) do nothing;
+
+  -- ReviewSubmitted -> Recalculate Trust Score (domain model §9; same formula
+  -- as submit_review). Overrides the T12 hard-coded values with earned ones.
+  update public.profiles
+    set trust_score = (
+      select round(avg(rating) * 20)::smallint
+      from public.reviews where seller_id = public.profiles.id
+    )
+    where id in (seller_phone, seller_fayda, seller_plain);
 end $$;

--- a/web/supabase/seed.sql
+++ b/web/supabase/seed.sql
@@ -174,3 +174,188 @@ begin
   where l.seller_id in (seller_phone, seller_fayda, seller_plain)
     and not exists (select 1 from public.listing_images where listing_id = l.id);
 end $$;
+
+-----------------------------------------------------------------------------
+-- T16 demo seed: a populated Addis Ababa marketplace (issue #20 AC-4) so the
+-- browse/search/detail/offer walkthrough has a full catalog to work with.
+-- ~58 listings across every category (DB spec §7), spread across the demo
+-- sellers above (most on Amira so the phone-verified seller badge shows up
+-- across cards) and Addis Ababa sub-cities (Bole, Piassa, Merkato,
+-- Kazanchis, Arada, Yeka). A few Dire Dawa rows from Kebede exercise the
+-- city filter. IDs are deterministic
+-- (20000000-...-00000000000N) so re-running `supabase db reset` stays
+-- idempotent (on conflict (id) do nothing). Image URLs are local illustration
+-- / photo SVG stand-ins for demo only; swap for real product photos before
+-- production hosting.
+-----------------------------------------------------------------------------
+do $$
+declare
+  seller_phone uuid := '00000000-0000-0000-0000-000000000002';
+  seller_fayda uuid := '00000000-0000-0000-0000-000000000003';
+  seller_plain uuid := '00000000-0000-0000-0000-000000000004';
+  rec record;
+begin
+  for rec in select * from (values
+    ------------------------------------------------------------------ Electronics
+    (1, seller_phone, 'electronics', 'iPhone 12 64GB',
+     'Unlocked iPhone 12, 64GB, battery health 87%. Comes with the original cable. Minor scuffs on the back, screen flawless.', 28000, 'Lightly Used', false, 'Bole', 5),
+    (2, seller_phone, 'electronics', 'MacBook Air M1 13"',
+     'M1 chip, 8GB RAM, 256GB SSD, 42 battery cycles. Charger included. Ready for university or office work.', 62000, 'Lightly Used', true, 'Bole', 9),
+    (3, seller_phone, 'electronics', 'Sony WH-1000XM4 headphones',
+     'Noise-cancelling over-ear headphones in box with all accessories. Used twice, like new. Great for calls and music.', 15500, 'Brand New', false, 'Kazanchis', 3),
+    (4, seller_fayda, 'electronics', 'Samsung Galaxy A54 5G',
+     '128GB, dual SIM, box and charger included. Kept in a case since purchase, minor signs of use on the frame.', 25000, 'Lightly Used', false, 'Piassa', 12),
+    (5, seller_plain, 'electronics', 'Dell 24" Full HD monitor',
+     'Dell P2422H, 24" IPS 1080p, includes HDMI cable. A couple of pixels stuck near the top edge, otherwise clean.', 12000, 'Fair', true, 'Merkato', 20),
+    (6, seller_phone, 'electronics', 'JBL Flip 5 speaker',
+     'Portable Bluetooth speaker, waterproof. Tiny cosmetic scratch on the mesh. Battery holds a full day of playback.', 6500, 'Lightly Used', false, 'Bole', 7),
+    (7, seller_fayda, 'electronics', 'Canon EOS 250D camera',
+     'Entry DSLR with 18-55mm lens, extra battery and 32GB SD card. Shutter count 4,200. Perfect for a beginner photographer.', 45000, 'Lightly Used', true, 'Yeka', 15),
+    ------------------------------------------------------------------ Furniture
+    (8, seller_phone, 'furniture', '3+2 sofa set',
+     'Modern grey fabric sofa set, 3-seater plus 2-seater. Bought two years ago, no stains or tears. Available for pickup in Bole.', 38000, 'Lightly Used', true, 'Bole', 30),
+    (9, seller_fayda, 'furniture', 'Office desk with drawers',
+     'L-shaped wooden office desk with three drawers and cable tray. Solid build, some scratches on the top surface.', 8500, 'Fair', false, 'Kazanchis', 25),
+    (10, seller_phone, 'furniture', 'Queen bed frame + mattress',
+     'Wooden queen bed frame with brand-new mattress, still sealed. Assembly service can be arranged.', 22000, 'Brand New', true, 'Piassa', 4),
+    (11, seller_plain, 'furniture', '5-tier bookshelf',
+     'Sturdy 5-tier wooden bookshelf, 180cm tall. Good condition, a few scuffs on the back panel.', 6000, 'Fair', false, 'Merkato', 40),
+    (12, seller_phone, 'furniture', 'Dining table + 4 chairs',
+     'Round wooden dining table with four upholstered chairs. Slight wobble on one leg that is easily fixed.', 18000, 'Lightly Used', true, 'Bole', 18),
+    (13, seller_fayda, 'furniture', 'TV stand with shelves',
+     'Low wooden TV stand, 160cm wide with two open shelves. Minor scratches on the top, hardware all included.', 4500, 'Fair', false, 'Yeka', 22),
+    (14, seller_phone, 'furniture', 'Leather recliner chair',
+     'Brown genuine-leather recliner in excellent condition, no tears. Comfortable lounge chair for a living room corner.', 9800, 'Lightly Used', true, 'Bole', 11),
+    ------------------------------------------------------------------ Home Appliances
+    (15, seller_phone, 'home-appliances', 'LG 7kg washing machine',
+     'Front-loading washing machine, 7kg capacity, 1200 rpm. Runs a full cycle quietly, recently serviced.', 32000, 'Lightly Used', true, 'Bole', 14),
+    (16, seller_fayda, 'home-appliances', 'Samsung double-door fridge',
+     '486L double-door refrigerator with water dispenser. Still under warranty until 2027. Reason for sale: moving abroad.', 58000, 'Brand New', true, 'Kazanchis', 6),
+    (17, seller_phone, 'home-appliances', 'Electric kettle 1.7L',
+     'Stainless steel electric kettle, 2200W, boils fast. Used a handful of times, box included.', 2200, 'Brand New', false, 'Piassa', 2),
+    (18, seller_plain, 'home-appliances', '4-burner gas cooker',
+     'Freestanding 4-burner gas cooker with oven. Works well, oven door seal needs replacing.', 9000, 'Fair', true, 'Merkato', 35),
+    (19, seller_phone, 'home-appliances', '1.5HP inverter air conditioner',
+     'Inverter split AC, 1.5HP, cooling only. Includes installation. Used one season, filters cleaned monthly.', 45000, 'Brand New', true, 'Bole', 8),
+    (20, seller_fayda, 'home-appliances', 'Microwave oven 30L',
+     '30L microwave with grill function, 900W. Glass turntable and manual included. No issues.', 9500, 'Lightly Used', false, 'Yeka', 16),
+    (21, seller_phone, 'home-appliances', 'Rice cooker 5L',
+     '5L electric rice cooker with steamer basket and non-stick pot. Works perfectly, only the measuring cup is lost.', 4000, 'Lightly Used', false, 'Piassa', 10),
+    ------------------------------------------------------------------ Vehicles
+    (22, seller_phone, 'vehicles', 'Toyota Corolla 2015',
+     'Toyota Corolla 2015, 1.8L automatic, 92,000 km. Full service history, new tires. Bought for family, selling due to import.', 2850000, 'Lightly Used', true, 'Bole', 21),
+    (23, seller_plain, 'vehicles', 'Bajaj Boxer 150cc',
+     'Bajaj Boxer 150, 2019, 23,000 km, always serviced. New chain and sprockets. Transfer documents ready.', 165000, 'Lightly Used', true, 'Merkato', 28),
+    (24, seller_fayda, 'vehicles', 'Toyota Vitz 2012',
+     'Toyota Vitz 2012 automatic, 118,000 km. Runs well, minor body scratches and a dent on the rear door.', 1450000, 'Fair', true, 'Kazanchis', 33),
+    (25, seller_phone, 'vehicles', 'Honda PCX 125cc scooter',
+     'Honda PCX 125, 2023, zero kilometers, still crated. White color. Documents in hand.', 310000, 'Brand New', false, 'Bole', 1),
+    (26, seller_phone, 'vehicles', 'Maruti Suzuki Celerio 2018',
+     'Celerio 2018, 1.0L manual, 64,000 km, single owner. Very economical on fuel. Serviced at the dealer throughout.', 1900000, 'Lightly Used', true, 'Yeka', 17),
+    (27, seller_fayda, 'vehicles', 'Mountain bike 26"',
+     'Giant 26" mountain bike, 21-speed, disc brakes. New rear tire and brake pads. Rides smooth.', 18000, 'Lightly Used', false, 'Piassa', 13),
+    (28, seller_plain, 'vehicles', 'Isuzu pickup 4x4',
+     'Isuzu D-Max 4x4, 2016, 145,000 km, diesel. Workhorse in good mechanical condition; cabin AC needs a recharge.', 3200000, 'Fair', true, 'Merkato', 45),
+    ------------------------------------------------------------------ Fashion
+    (29, seller_phone, 'fashion', 'Mens leather jacket',
+     'Genuine black leather jacket, size M. Worn a few times, no tears, lining intact.', 3800, 'Lightly Used', false, 'Bole', 6),
+    (30, seller_fayda, 'fashion', 'Womens ankle boots',
+     'Brown leather ankle boots, size 38. Never worn outdoors, box included.', 2900, 'Brand New', false, 'Piassa', 3),
+    (31, seller_phone, 'fashion', 'Habesha kemis (handwoven)',
+     'Handwoven white habesha kemis with intricate embroidered chest and hem. Made-to-order quality, size free fit.', 6500, 'Brand New', true, 'Merkato', 2),
+    (32, seller_fayda, 'fashion', 'Nike running shoes 42',
+     'Nike Pegasus running shoes, EU 42, used for one race season. Soles have plenty of life left.', 4200, 'Lightly Used', false, 'Bole', 19),
+    (33, seller_phone, 'fashion', 'Designer handbag',
+     'Genuine leather handbag, taupe, good brand. Small scuff on the corner, hardware still shines.', 5500, 'Lightly Used', true, 'Kazanchis', 9),
+    (34, seller_fayda, 'fashion', 'Traditional shemma scarf',
+     'Handwoven white and yellow shemma scarf, soft and warm. Perfect as a gift or for weddings.', 1200, 'Brand New', false, 'Arada', 1),
+    ------------------------------------------------------------------ Books
+    (35, seller_phone, 'books', 'Amharic childrens book set',
+     'Set of 8 colorful Amharic children story books with illustrations, ages 4-8. Gently read.', 1500, 'Brand New', false, 'Bole', 5),
+    (36, seller_fayda, 'books', 'Computer science textbooks',
+     'Bundle of 5 undergraduate CS textbooks: algorithms, databases, networks, OS. Clean, some margin notes.', 3500, 'Fair', true, 'Kazanchis', 24),
+    (37, seller_phone, 'books', 'English-Amharic dictionary',
+     'Compact English-Amharic dictionary, 45,000 entries. Useful for students and translators.', 800, 'Lightly Used', false, 'Piassa', 12),
+    (38, seller_plain, 'books', 'Business & economics books',
+     '4 paperback books on economics and small-business management. Good reading condition.', 2400, 'Fair', false, 'Merkato', 30),
+    (39, seller_phone, 'books', 'Fiction novels bundle',
+     'Bundle of 10 international fiction novels (paperback). Great value for a reading library.', 2000, 'Lightly Used', true, 'Yeka', 20),
+    (40, seller_fayda, 'books', 'Medical textbooks set',
+     '3 core medical textbooks (anatomy, physiology, pharmacology). 2020-2022 editions, light highlights only.', 8000, 'Lightly Used', true, 'Bole', 26),
+    ------------------------------------------------------------------ Sports
+    (41, seller_phone, 'sports', 'Wilson basketball',
+     'Wilson NCAA game ball, lightly used indoors. Good grip, plenty of bounce left.', 2600, 'Brand New', false, 'Bole', 4),
+    (42, seller_fayda, 'sports', 'Folding treadmill',
+     'Foldable treadmill, max speed 12 km/h, incline adjust. Used lightly for a year, serviced. Heavy, pickup required.', 65000, 'Lightly Used', true, 'Kazanchis', 27),
+    (43, seller_phone, 'sports', '20kg dumbbell set',
+     'Adjustable dumbbells with plates up to 20kg total, includes storage rack. Rubber coated.', 9000, 'Lightly Used', false, 'Piassa', 15),
+    (44, seller_fayda, 'sports', 'Yoga mat',
+     '6mm TPE yoga mat, teal, with carry strap. Barely used, still in the tube.', 1100, 'Brand New', false, 'Merkato', 2),
+    (45, seller_phone, 'sports', 'Table tennis table',
+     'Full-size indoor table tennis table, 25mm top, folds for storage. Nets and two bats included.', 14000, 'Fair', true, 'Bole', 32),
+    (46, seller_plain, 'sports', 'Soccer ball (FIFA quality)',
+     'FIFA quality soccer ball, size 5, used a handful of times on grass. No wear to the panels.', 1900, 'Brand New', false, 'Yeka', 8),
+    ------------------------------------------------------------------ Baby & Kids
+    (47, seller_phone, 'baby-and-kids', '3-in-1 baby stroller',
+     '3-in-1 stroller (carrycot, pushchair, car seat) by a trusted brand. One small tear on the canopy, all parts work.', 14500, 'Lightly Used', true, 'Bole', 29),
+    (48, seller_fayda, 'baby-and-kids', 'Baby crib + mattress',
+     'White wooden crib with adjustable mattress height and brand-new firm mattress. Meets safety standards.', 8000, 'Lightly Used', false, 'Kazanchis', 18),
+    (49, seller_phone, 'baby-and-kids', 'Kids bunk bed',
+     'Solid wooden bunk bed, white, with a small built-in ladder. Some paint chips on the edges.', 11000, 'Fair', true, 'Piassa', 36),
+    (50, seller_fayda, 'baby-and-kids', 'Car seat 0-4 years',
+     'Group 0+1 car seat, rear- and forward-facing, ISOFIX compatible. Never in an accident.', 9500, 'Brand New', false, 'Bole', 7),
+    (51, seller_phone, 'baby-and-kids', 'Wooden toy set 50 pcs',
+     '50-piece natural wooden toy set: blocks, sorting shapes, animals. Safe, non-toxic finish.', 2800, 'Brand New', false, 'Merkato', 3),
+    (52, seller_fayda, 'baby-and-kids', 'Baby clothes bundle 0-6m',
+     'Bundle of 15 baby outfits, sizes 0-6 months, mix of brands. Washed, in great shape.', 3200, 'Lightly Used', true, 'Yeka', 10),
+    ------------------------------------------------------------------ Other
+    (53, seller_phone, 'other', 'Acoustic guitar',
+     'Yamaha acoustic guitar with soft case and picks. Slight action adjustment needed, otherwise excellent.', 7500, 'Lightly Used', true, 'Bole', 23),
+    (54, seller_fayda, 'other', 'Art easel + supplies',
+     'Wooden studio easel with a box of paints, brushes and 10 canvases. Great for a new hobbyist.', 4200, 'Brand New', false, 'Kazanchis', 5),
+    (55, seller_phone, 'other', 'Luggage set 3 pcs',
+     '3-piece spinner luggage set (cabin, medium, large). Light scratches from a few flights, wheels roll smoothly.', 6800, 'Lightly Used', true, 'Piassa', 14),
+    (56, seller_plain, 'other', 'Sewing machine',
+     'Electric sewing machine with table, several stitch patterns and attachments. Serviced and tested.', 12000, 'Fair', true, 'Merkato', 31),
+    (57, seller_phone, 'other', 'DSLR camera bag + tripod',
+     'Large padded camera bag plus aluminum tripod. Both in good condition, padding intact.', 5000, 'Lightly Used', false, 'Yeka', 12),
+    (58, seller_fayda, 'other', 'Ergonomic office chair',
+     'Ergonomic mesh office chair with lumbar support, adjustable height and armrests. One caster replaced.', 6500, 'Fair', false, 'Bole', 21)
+  ) as t(k int, seller_id uuid, category_slug text, title text, description text,
+        price numeric, condition public.listing_condition, negotiable boolean, sub_city text, age_days int)
+  loop
+    insert into public.listings (id, seller_id, category_id, title, description, price,
+                                 condition, negotiable, city, sub_city, status, published_at)
+    values (
+      ('20000000-0000-0000-0000-' || lpad(rec.k::text, 12, '0'))::uuid,
+      rec.seller_id,
+      (select id from public.categories where slug = rec.category_slug limit 1),
+      rec.title, rec.description, rec.price, rec.condition, rec.negotiable,
+      'Addis Ababa', rec.sub_city, 'published',
+      now() - make_interval(days => rec.age_days)
+    )
+    on conflict (id) do nothing;
+  end loop;
+
+  -- One stand-in image per demo listing that does not already have one
+  -- (covers the T12 three listings and the ~58 above). Rows are numbered to
+  -- rotate between a few local assets so cards look varied during the demo.
+  with ranked as (
+    select l.id, l.title,
+           row_number() over (order by l.id) as rn
+    from public.listings l
+    where l.seller_id in (seller_phone, seller_fayda, seller_plain)
+      and not exists (select 1 from public.listing_images where listing_id = l.id)
+  )
+  insert into public.listing_images (listing_id, image_url, display_order, alt_text)
+  select id,
+         (array[
+           '/images/illustrations/trust-safe-transactions.svg',
+           '/images/photos/photo-modern-apartment.svg',
+           '/images/photos/photo-seller-taking-photos.svg',
+           '/images/photos/photo-buyer-meeting-seller.svg'
+         ])[1 + mod(rn - 1, 4)],
+         0,
+         coalesce(title, 'Demo listing image')
+  from ranked;
+end $$;


### PR DESCRIPTION
## Summary

T16 — README, docs & demo prep (issue #20).

- **README.md** (root): what-is-this, tech stack table, system architecture diagram, repo layout, doc map.
- **web/README.md**: tech stack + architecture sections, demo accounts table, expanded seed description.
- **docs/03-engineering/12-deployment-guide.md** (new): hosted Supabase + Vercel, migrations/seed application, env vars, rollback.
- **docs/03-engineering/13-demo-script.md** (new): 3–5 min shot-by-shot walkthrough with time budget and demo accounts.
- **web/supabase/seed.sql**: ~58 Addis Ababa listings across every category (Bole, Piassa, Merkato, Kazanchis, Arada, Yeka) + a few Dire Dawa rows to exercise the city filter; deterministic IDs keep the seed idempotent; per-listing stand-in images rotate across local assets.

## Acceptance criteria

- [x] README: setup guide, system architecture, tech stack, local dev run commands
- [x] Architecture, database, and API documentation consistent with the docs pack (links verified; links to the existing pack docs)
- [x] Deployment guide for hosted Supabase + Vercel with env setup
- [x] Addis Ababa seed data + demo accounts ready for the walkthrough
- [x] Demo script outlines the 3-5 min core-feature flow

## Notes

- Only docs + seed SQL changed; lint and typecheck pass. Seed not run against a DB here (no Docker/Supabase CLI in this environment) — it follows the existing T12 seed pattern and constraint rules from the DB spec.
- Deployment guide is a plan for T17 (hosting is a separate ticket).

Closes #20