### PR TITLE
refactor: architecture deepening (T15)

### DIFF
--- a/web/app/actions/listings.ts
+++ b/web/app/actions/listings.ts
@@ -1,10 +1,9 @@
 "use server"
 
 import { z } from "zod"
-import { redirect } from "next/navigation"
 import { revalidatePath } from "next/cache"
 
-import { getCurrentUser } from "@/lib/auth"
+import { requireSeller } from "@/lib/auth"
 import { recordAiUsage } from "@/lib/ai/telemetry"
 import {
   createListing as createListingRow,
@@ -96,10 +95,7 @@ export async function createListing(
     return { errors: parsed.error.flatten().fieldErrors }
   }
 
-  const user = await getCurrentUser()
-  if (!user || (user.role !== "seller" && user.role !== "admin")) {
-    redirect("/profile")
-  }
+  const user = await requireSeller()
 
   try {
     const result = await createListingRow(
@@ -147,10 +143,7 @@ export async function updateListing(
     return { errors: parsed.error.flatten().fieldErrors }
   }
 
-  const user = await getCurrentUser()
-  if (!user || (user.role !== "seller" && user.role !== "admin")) {
-    redirect("/profile")
-  }
+  const user = await requireSeller()
 
   try {
     const result = await updateListingRow(
@@ -191,11 +184,7 @@ export async function deleteListing(
   const id = formValue(formData, "id")
   if (!id) return { message: "Missing listing id", ok: false }
 
-  const user = await getCurrentUser()
-  if (!user) redirect("/login")
-  if (user.role !== "seller" && user.role !== "admin") {
-    redirect("/profile")
-  }
+  const user = await requireSeller()
 
   try {
     const result = await softDeleteListing(id, user.id)

--- a/web/app/actions/profile.ts
+++ b/web/app/actions/profile.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache"
 
 import { getCurrentUser } from "@/lib/auth"
 import { createClient } from "@/lib/supabase/server"
+import { completeOwnProfile, updateOwnProfile } from "@/lib/profiles"
 import { uploadObjects } from "@/lib/media"
 import { avatarAdapter } from "@/lib/media/avatar-adapter"
 
@@ -43,24 +44,17 @@ export async function completeProfile(
   const user = await getCurrentUser()
   if (!user) redirect("/login")
 
-  const supabase = await createClient()
-  const { error } = await supabase
-    .from("profiles")
-    .update({
-      full_name: parsed.data.fullName,
-      city: parsed.data.city,
-      sub_city: parsed.data.subCity || null,
-      phone: parsed.data.phone || null,
-      telegram_username: parsed.data.telegramUsername
-        ? parsed.data.telegramUsername.replace(/^@/, "")
-        : null,
-      bio: parsed.data.bio || null,
-      profile_completion: 100,
-    })
-    .eq("id", user.id)
+  const result = await completeOwnProfile(user.id, {
+    fullName: parsed.data.fullName,
+    city: parsed.data.city,
+    subCity: parsed.data.subCity,
+    phone: parsed.data.phone,
+    telegramUsername: parsed.data.telegramUsername,
+    bio: parsed.data.bio,
+  })
 
-  if (error) {
-    return { message: error.message }
+  if (!result.ok) {
+    return { message: result.error ?? "Could not save your profile" }
   }
 
   revalidatePath("/profile")
@@ -106,21 +100,17 @@ export async function updateProfile(
   const user = await getCurrentUser()
   if (!user) redirect("/login")
 
-  const supabase = await createClient()
-  const { error } = await supabase
-    .from("profiles")
-    .update({
-      city: parsed.data.city,
-      sub_city: parsed.data.subCity || null,
-      phone: parsed.data.phone || null,
-      telegram_username: parsed.data.telegramUsername || null,
-      bio: parsed.data.bio || null,
-      phone_public: parsed.data.phonePublic ?? false,
-    })
-    .eq("id", user.id)
+  const result = await updateOwnProfile(user.id, {
+    city: parsed.data.city,
+    subCity: parsed.data.subCity,
+    phone: parsed.data.phone,
+    telegramUsername: parsed.data.telegramUsername,
+    bio: parsed.data.bio,
+    phonePublic: parsed.data.phonePublic,
+  })
 
-  if (error) {
-    return { message: error.message }
+  if (!result.ok) {
+    return { message: result.error ?? "Could not update your profile" }
   }
 
   revalidatePath("/profile")

--- a/web/app/actions/reports.ts
+++ b/web/app/actions/reports.ts
@@ -3,7 +3,7 @@
 import { z } from "zod"
 import { revalidatePath } from "next/cache"
 
-import { requireUser } from "@/lib/auth"
+import { requireAdmin, requireUser } from "@/lib/auth"
 import {
   createReport as createReportRow,
   resolveReport as resolveReportRow,
@@ -101,10 +101,7 @@ export async function adminResolveReport(
     return { message: "Invalid report request" }
   }
 
-  const user = await requireUser()
-  if (user.role !== "admin") {
-    return { message: "Not allowed" }
-  }
+  await requireAdmin()
 
   const result = await resolveReportRow(
     parsed.data.reportId,

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { redirect } from "next/navigation"
 
 import { getCurrentUser } from "@/lib/auth"
-import { createClient } from "@/lib/supabase/server"
+import { fetchOwnProfile, type OwnProfileRow } from "@/lib/profiles"
 import { ProfileForm } from "@/components/profile/profile-form"
 
 export const metadata: Metadata = {
@@ -10,34 +10,13 @@ export const metadata: Metadata = {
   description: "Manage your VinTech Marketplace profile.",
 }
 
-type ProfileRow = {
-  avatar_url: string | null
-  full_name: string | null
-  phone: string | null
-  telegram_username: string | null
-  city: string | null
-  sub_city: string | null
-  bio: string | null
-  trust_score: number | null
-  profile_completion: number | null
-  role: "buyer" | "seller" | "admin" | null
-  phone_public: boolean | null
-}
-
 export default async function ProfilePage() {
   const user = await getCurrentUser()
   if (!user) redirect("/login")
 
-  const supabase = await createClient()
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select(
-      "avatar_url, full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role, phone_public"
-    )
-    .eq("id", user.id)
-    .maybeSingle()
+  const profile = await fetchOwnProfile(user.id)
 
   return (
-    <ProfileForm user={user} profile={(profile ?? {}) as ProfileRow} />
+    <ProfileForm user={user} profile={(profile ?? {}) as OwnProfileRow} />
   )
 }

--- a/web/app/users/[id]/page.tsx
+++ b/web/app/users/[id]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation"
 import { MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
 
 import { ROLE_LABELS, type UserRole, getCurrentUser } from "@/lib/auth"
-import { createClient } from "@/lib/supabase/server"
+import { fetchPublicProfile } from "@/lib/profiles"
 import { initials, formatShortDate } from "@/lib/utils"
 import { fetchSellerReviews, summarizeRating } from "@/lib/reviews"
 import { fetchSellerContactInfo } from "@/lib/contact"
@@ -15,50 +15,6 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ContactButton } from "@/components/contact/contact-button"
 import { ReviewStars } from "@/components/reviews/review-stars"
-
-type PublicProfileRow = {
-  full_name: string | null
-  avatar_url: string | null
-  city: string | null
-  sub_city: string | null
-  bio: string | null
-  telegram_username: string | null
-  phone: string | null
-  trust_score: number | null
-  role: "buyer" | "seller" | "admin" | null
-  phone_public: boolean | null
-  phone_verified: boolean | null
-  fayda_verified: boolean | null
-}
-
-async function fetchPublicProfile(id: string): Promise<PublicProfileRow | null> {
-  const supabase = await createClient()
-
-  // Public surface only: phone is fetched separately and only when the owner
-  // has opted in (Security spec §19: phone is private by default). Trust-badge
-  // flags (phone_verified, fayda_verified) are public by T12 RLS design.
-  const baseColumns =
-    "full_name, avatar_url, city, sub_city, bio, telegram_username, trust_score, role, phone_public, phone_verified, fayda_verified"
-
-  const { data: profile, error } = await supabase
-    .from("profiles")
-    .select(baseColumns)
-    .eq("id", id)
-    .maybeSingle()
-
-  if (error || !profile) return null
-
-  if (profile.phone_public) {
-    const { data: withPhone } = await supabase
-      .from("profiles")
-      .select("phone")
-      .eq("id", id)
-      .maybeSingle()
-    ;(profile as PublicProfileRow).phone = withPhone?.phone ?? null
-  }
-
-  return profile as PublicProfileRow
-}
 
 export async function generateMetadata({
   params,

--- a/web/lib/contact.ts
+++ b/web/lib/contact.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import type { SellerContactInfo, ContactMethod } from "./contact/constants"
 
@@ -21,9 +22,10 @@ export interface ContactAttemptResult {
  * phone_public = true) means the value is NULL unless the owner opted in.
  */
 export async function fetchSellerContactInfo(
-  sellerId: string
+  sellerId: string,
+  client?: Supabase
 ): Promise<SellerContactInfo | null> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
 
   const { data: profile, error } = await supabase
     .from("profiles")

--- a/web/lib/contact/constants.ts
+++ b/web/lib/contact/constants.ts
@@ -17,13 +17,9 @@ export const CONTACT_METHOD_LABELS: Record<ContactMethod, string> = {
   phone: "Phone call",
 }
 
-// The login redirect target for the Contact Seller button. Login honors a
-// `?next=` query param (see app/login/page.tsx), so a signed-out visitor who
-// taps Contact lands back on the exact listing after signing in. Kept here so
-// the Client Component needs no URL-building logic.
-export function buildLoginUrl(pathname: string): string {
-  return `/login?next=${encodeURIComponent(pathname)}`
-}
+// The login redirect target for the Contact Seller button, shared across
+// signed-out CTAs (see lib/nav.ts for the single definition).
+export { buildLoginUrl } from "@/lib/nav"
 
 // ---- Seller contact surface ----
 

--- a/web/lib/favorites.ts
+++ b/web/lib/favorites.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 import {
   isValidUuid,
   mapBrowseListing,
@@ -13,8 +14,11 @@ export * from "@/lib/favorites/constants"
 
 // ---- Reads ----
 
-export async function fetchFavoriteIds(userId: string): Promise<string[]> {
-  const supabase = await createClient()
+export async function fetchFavoriteIds(
+  userId: string,
+  client?: Supabase
+): Promise<string[]> {
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("favorites")
     .select("listing_id")
@@ -30,9 +34,10 @@ export async function fetchFavoriteIds(userId: string): Promise<string[]> {
 // listings that are no longer readable (unpublished, deleted, sold). Only
 // still-available favorites are returned, most recently favorited first.
 export async function fetchFavoriteListings(
-  userId: string
+  userId: string,
+  client?: Supabase
 ): Promise<BrowseListing[]> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("favorites")
     .select(

--- a/web/lib/favorites.ts
+++ b/web/lib/favorites.ts
@@ -2,12 +2,10 @@ import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
 import type { Supabase } from "@/lib/supabase/types"
-import {
-  isValidUuid,
-  mapBrowseListing,
-  type BrowseListing,
-  type RawListingRow,
-} from "@/lib/listings"
+import { isValidUuid } from "@/lib/listings/constants"
+import type { BrowseListing } from "@/lib/listings/constants"
+import { mapNestedBrowseListing } from "@/lib/listings/browse-mapper"
+import type { NestedBrowseRow } from "@/lib/listings/browse-mapper"
 import { toggleFavoriteState } from "@/lib/favorites/constants"
 
 export * from "@/lib/favorites/constants"
@@ -58,13 +56,13 @@ export async function fetchFavoriteListings(
   // but listing_id -> listings is a to-one join: PostgREST returns a single
   // row (or null when the listing is no longer readable under RLS).
   const rows = (data ?? []) as unknown as {
-    listing: RawListingRow | null
+    listing: NestedBrowseRow | null
   }[]
 
   return rows
     .map((row) => row.listing)
-    .filter((listing): listing is RawListingRow => listing !== null)
-    .map(mapBrowseListing)
+    .filter((listing): listing is NestedBrowseRow => listing !== null)
+    .map(mapNestedBrowseListing)
 }
 
 // ---- Writes (called by the toggle server action) ----

--- a/web/lib/favorites/constants.ts
+++ b/web/lib/favorites/constants.ts
@@ -20,12 +20,6 @@ export function toggleFavoriteState(state: FavoriteState): FavoriteState {
   return !state
 }
 
-/**
- * The login redirect target for the heart button. Login honors a `?next=`
- * query param (see app/login/page.tsx), so a signed-out visitor who taps a
- * heart lands back on the exact listing after signing in. Kept here so the
- * Client Component needs no URL-building logic.
- */
-export function buildLoginUrl(pathname: string): string {
-  return `/login?next=${encodeURIComponent(pathname)}`
-}
+// The login redirect target for the heart button, shared across signed-out
+// CTAs (see lib/nav.ts for the single definition).
+export { buildLoginUrl } from "@/lib/nav"

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -26,7 +26,11 @@ import type {
 } from "./listings/constants"
 import type { SearchSort } from "@/lib/search"
 import { MAX_PAGING_OFFSET } from "@/lib/pagination"
-import { mapBrowseListing, pickCoverImage } from "./listings/browse-mapper"
+import {
+  mapFlatSearchListing,
+  mapNestedBrowseListing,
+  pickCoverImage,
+} from "./listings/browse-mapper"
 import type {
   FlatSearchRow,
   NestedBrowseRow,
@@ -35,12 +39,6 @@ import type {
 // Re-export the pure value objects so imports from "@/lib/listings" keep
 // resolving. Definitions live in ./listings/constants (server-free).
 export * from "./listings/constants"
-
-// Re-export the browse row mapper + nested row shape so the favorites feed and
-// the offers read path use the one cover/seller rule. Definitions live in
-// ./listings/browse-mapper (server-free).
-export { mapBrowseListing } from "./listings/browse-mapper"
-export type { NestedBrowseRow as RawListingRow } from "./listings/browse-mapper"
 
 // ---- Reads ----
 
@@ -216,7 +214,7 @@ export async function fetchListings(
   }
 
   const listings: BrowseListing[] = (data as NestedBrowseRow[] | null ?? []).map(
-    mapBrowseListing
+    mapNestedBrowseListing
   )
 
   const hasMore =
@@ -282,7 +280,7 @@ export async function searchListings(
   }
 
   const rows = (data ?? []) as SearchListingRow[]
-  const listings: BrowseListing[] = rows.map(mapBrowseListing)
+  const listings: BrowseListing[] = rows.map(mapFlatSearchListing)
 
   const count = rows.length > 0 ? rows[0].total_count : 0
   return {

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -27,7 +27,10 @@ import type {
 import type { SearchSort } from "@/lib/search"
 import { MAX_PAGING_OFFSET } from "@/lib/pagination"
 import { mapBrowseListing, pickCoverImage } from "./listings/browse-mapper"
-import type { NestedBrowseRow } from "./listings/browse-mapper"
+import type {
+  FlatSearchRow,
+  NestedBrowseRow,
+} from "./listings/browse-mapper"
 
 // Re-export the pure value objects so imports from "@/lib/listings" keep
 // resolving. Definitions live in ./listings/constants (server-free).
@@ -234,25 +237,10 @@ export interface SearchResult {
   error: string | null
 }
 
-/** Row shape returned by the `search_listings` RPC (see migrations). */
-interface SearchListingRow {
-  id: string
-  title: string
-  price: number
-  condition: Condition
-  city: string | null
-  published_at: string
-  image_url: string | null
-  image_count: number
-  seller_id: string | null
-  seller_full_name: string | null
-  seller_avatar_url: string | null
-  seller_role: string | null
-  seller_trust_score: number | null
-  seller_phone_verified: boolean | null
-  seller_fayda_verified: boolean | null
-  total_count: number
-}
+/** Row shape returned by the `search_listings` RPC (see migrations). It is the
+ * same flat browse row the mapper consumes (so the seller/image contract lives
+ * once), plus the exact-count column the RPC adds alongside the slice. */
+type SearchListingRow = FlatSearchRow & { total_count: number }
 
 // Keyword + filters + sort + count in one round trip via the search_listings
 // RPC (T06, Search Service). Paging mirrors fetchListings: one PAGE_SIZE window

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -44,8 +44,10 @@ export type { NestedBrowseRow as RawListingRow } from "./listings/browse-mapper"
 
 // ---- Reads ----
 
-export async function fetchCategories(): Promise<Category[]> {
-  const supabase = await createClient()
+export async function fetchCategories(
+  client?: Supabase
+): Promise<Category[]> {
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("categories")
     .select("id, name, slug, parent_id")
@@ -67,10 +69,11 @@ export interface FetchListingOptions {
 
 export async function fetchListing(
   id: string,
-  opts: FetchListingOptions = {}
+  opts: FetchListingOptions = {},
+  client?: Supabase
 ): Promise<ListingWithRelations | null> {
   if (!isValidUuid(id)) return null
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
 
   const { data: listing } = await supabase
     .from("listings")
@@ -131,9 +134,10 @@ type RawSellerListingRow = Omit<Listing, "price"> & {
 }
 
 export async function fetchSellerListings(
-  sellerId: string
+  sellerId: string,
+  client?: Supabase
 ): Promise<SellerListingRow[]> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("listings")
     .select(
@@ -160,17 +164,20 @@ export async function fetchSellerListings(
 }
 
 // Public, paginated browse of published listings (anon-readable via RLS).
-export async function fetchListings(opts: {
-  limit?: number
-  offset?: number
-  categorySlug?: string
-} = {}): Promise<{
+export async function fetchListings(
+  opts: {
+    limit?: number
+    offset?: number
+    categorySlug?: string
+  } = {},
+  client?: Supabase
+): Promise<{
   listings: BrowseListing[]
   count: number | null
   hasMore: boolean
   error: string | null
 }> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const limit = Math.min(opts.limit ?? PAGE_SIZE, BROWSE_LIMIT_MAX)
   // offset is an untrusted cursor from the URL; parseBrowseParams
   // (lib/browse) is the single source of truth that validates + clamps it
@@ -247,9 +254,10 @@ type SearchListingRow = FlatSearchRow & { total_count: number }
 // that never crosses the 1000-row ceiling, with `hasMore` derived from the
 // exact count the RPC returns alongside the slice.
 export async function searchListings(
-  opts: SearchOptions = {}
+  opts: SearchOptions = {},
+  client?: Supabase
 ): Promise<SearchResult> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const offset = Math.min(Math.max(opts.offset ?? 0, 0), MAX_PAGING_OFFSET)
 
   const { data, error } = await callRpc<SearchListingRow[]>(

--- a/web/lib/listings/browse-mapper.ts
+++ b/web/lib/listings/browse-mapper.ts
@@ -47,9 +47,9 @@ export type BrowseRow = NestedBrowseRow | FlatSearchRow
 
 /** Shared cover-pick: the lowest display_order image is the listing's cover.
  * One rule for every listing read shape that renders a thumbnail (browse feed,
- * favorites feed, seller dashboard) so it never forks. */
+ * favorites feed, seller dashboard, admin report queue) so it never forks. */
 export function pickCoverImage(
-  images: { image_url: string; display_order: number }[] | null
+  images: { image_url: string; display_order: number }[] | null | undefined
 ): string | null {
   return (
     [...(images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]

--- a/web/lib/listings/browse-mapper.ts
+++ b/web/lib/listings/browse-mapper.ts
@@ -43,8 +43,6 @@ export interface FlatSearchRow {
   seller_fayda_verified?: boolean | null
 }
 
-export type BrowseRow = NestedBrowseRow | FlatSearchRow
-
 /** Shared cover-pick: the lowest display_order image is the listing's cover.
  * One rule for every listing read shape that renders a thumbnail (browse feed,
  * favorites feed, seller dashboard, admin report queue) so it never forks. */
@@ -81,35 +79,36 @@ export function buildSeller(fields: {
   }
 }
 
-/** Map a nested (browse/favorites) or flat (search RPC) row to the display
- * shape both feeds render. Nested rows always carry the `images` key (even
- * when null), which is how the two shapes are told apart. */
-export function mapBrowseListing(row: BrowseRow): BrowseListing {
-  if ("images" in row) {
-    const seller = row.seller?.[0] ?? null
-    return {
-      id: row.id,
-      title: row.title,
-      price: row.price,
-      condition: row.condition,
-      city: row.city,
-      published_at: row.published_at,
-      image_url: pickCoverImage(row.images),
-      image_count: (row.images ?? []).length,
-      seller: seller
-        ? buildSeller({
-            id: seller.id,
-            full_name: seller.full_name,
-            avatar_url: seller.avatar_url,
-            role: seller.role,
-            trust_score: seller.trust_score,
-            phone_verified: seller.phone_verified ?? null,
-            fayda_verified: seller.fayda_verified ?? null,
-          })
-        : null,
-    }
+/** Map a nested (browse/favorites) row to the display shape both feeds render.
+ * The call site knows its shape statically, so there is no runtime sniff: the
+ * nested and flat paths are two entry points over the same cover/seller rules. */
+export function mapNestedBrowseListing(row: NestedBrowseRow): BrowseListing {
+  const seller = row.seller?.[0] ?? null
+  return {
+    id: row.id,
+    title: row.title,
+    price: row.price,
+    condition: row.condition,
+    city: row.city,
+    published_at: row.published_at,
+    image_url: pickCoverImage(row.images),
+    image_count: (row.images ?? []).length,
+    seller: seller
+      ? buildSeller({
+          id: seller.id,
+          full_name: seller.full_name,
+          avatar_url: seller.avatar_url,
+          role: seller.role,
+          trust_score: seller.trust_score,
+          phone_verified: seller.phone_verified ?? null,
+          fayda_verified: seller.fayda_verified ?? null,
+        })
+      : null,
   }
+}
 
+/** Map a flat `search_listings` RPC row to the display shape. */
+export function mapFlatSearchListing(row: FlatSearchRow): BrowseListing {
   return {
     id: row.id,
     title: row.title,

--- a/web/lib/nav.ts
+++ b/web/lib/nav.ts
@@ -15,6 +15,15 @@ export type NavItem = {
 
 export const siteName = "VinTech Marketplace"
 
+// The login redirect target shared by signed-out CTAs (heart, make an offer,
+// contact seller, report). Login honors a `?next=` query param (see
+// app/login/page.tsx), so a signed-out visitor lands back on the exact page
+// after signing in. One definition, re-exported per domain so client
+// components need no URL-building logic.
+export function buildLoginUrl(pathname: string): string {
+  return `/login?next=${encodeURIComponent(pathname)}`
+}
+
 // Component standards §12 caps primary destinations at 5. Dashboard and
 // Profile live in the account menu (components/auth/user-menu.tsx) instead.
 export const primaryNav: NavItem[] = [

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import {
   isValidUuid,
@@ -85,8 +86,11 @@ const OFFER_COLUMNS = "id, listing_id, amount, message, status, created_at"
 // The buyer's offer history, newest first. RLS keeps this to the user's own
 // offers; the listing join drops rows for listings the buyer can no longer see
 // (deleted, unpublished, or sold without an accepted offer of theirs).
-export async function fetchBuyerOffers(userId: string): Promise<BuyerOfferRow[]> {
-  const supabase = await createClient()
+export async function fetchBuyerOffers(
+  userId: string,
+  client?: Supabase
+): Promise<BuyerOfferRow[]> {
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("offers")
     .select(
@@ -121,8 +125,11 @@ export async function fetchBuyerOffers(userId: string): Promise<BuyerOfferRow[]>
 // the seller's own listings; the explicit seller filter is a query hint that
 // keeps PostgREST from scanning the whole table. The buyer profile join names
 // the person behind each offer.
-export async function fetchSellerOffers(userId: string): Promise<SellerOfferRow[]> {
-  const supabase = await createClient()
+export async function fetchSellerOffers(
+  userId: string,
+  client?: Supabase
+): Promise<SellerOfferRow[]> {
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("offers")
     .select(
@@ -157,8 +164,11 @@ export async function fetchSellerOffers(userId: string): Promise<SellerOfferRow[
 // Open offers (pending or countered) on the seller's listings, for the dashboard
 // summary. RLS scopes the count to the caller's own listings; the explicit
 // seller filter is the same PostgREST hint used by fetchSellerOffers.
-export async function countIncomingOffers(userId: string): Promise<number> {
-  const supabase = await createClient()
+export async function countIncomingOffers(
+  userId: string,
+  client?: Supabase
+): Promise<number> {
+  const supabase = client ?? (await createClient())
   const { count, error } = await supabase
     .from("offers")
     .select("id", { count: "exact", head: true })

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -200,26 +200,38 @@ export async function submitOfferRow(input: {
   return { ok: result.ok === true, error: result.error ?? null }
 }
 
-async function runOfferRpc(
-  fn: "accept_offer" | "decline_offer" | "counter_offer",
-  args: Record<string, string | number>
-): Promise<OfferResult> {
+export async function acceptOfferRow(offerId: string): Promise<OfferResult> {
   const supabase = await createClient()
-  const result = await callOutcomeRpc(supabase, fn, args, fn)
+  const result = await callOutcomeRpc(
+    supabase,
+    "accept_offer",
+    { p_offer_id: offerId },
+    "acceptOfferRow"
+  )
   return { ok: result.ok === true, error: result.error ?? null }
 }
 
-export function acceptOfferRow(offerId: string): Promise<OfferResult> {
-  return runOfferRpc("accept_offer", { p_offer_id: offerId })
+export async function declineOfferRow(offerId: string): Promise<OfferResult> {
+  const supabase = await createClient()
+  const result = await callOutcomeRpc(
+    supabase,
+    "decline_offer",
+    { p_offer_id: offerId },
+    "declineOfferRow"
+  )
+  return { ok: result.ok === true, error: result.error ?? null }
 }
 
-export function declineOfferRow(offerId: string): Promise<OfferResult> {
-  return runOfferRpc("decline_offer", { p_offer_id: offerId })
-}
-
-export function counterOfferRow(
+export async function counterOfferRow(
   offerId: string,
   amount: number
 ): Promise<OfferResult> {
-  return runOfferRpc("counter_offer", { p_offer_id: offerId, p_amount: amount })
+  const supabase = await createClient()
+  const result = await callOutcomeRpc(
+    supabase,
+    "counter_offer",
+    { p_offer_id: offerId, p_amount: amount },
+    "counterOfferRow"
+  )
+  return { ok: result.ok === true, error: result.error ?? null }
 }

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -3,12 +3,10 @@ import "server-only"
 import { createClient } from "@/lib/supabase/server"
 import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
-import {
-  isValidUuid,
-  mapBrowseListing,
-  type BrowseListing,
-  type RawListingRow,
-} from "@/lib/listings"
+import { isValidUuid } from "@/lib/listings/constants"
+import type { BrowseListing } from "@/lib/listings/constants"
+import { mapNestedBrowseListing } from "@/lib/listings/browse-mapper"
+import type { NestedBrowseRow } from "@/lib/listings/browse-mapper"
 import {
   OPEN_OFFER_STATUSES,
   type OfferStatus,
@@ -39,10 +37,10 @@ export interface SellerOfferRow extends BuyerOfferRow {
 }
 
 // A join row from the raw PostgREST shape. The embedded `listing` may lack a
-// `seller` join (buyer dashboard never asks for it); mapBrowseListing treats a
-// missing seller as null, so the cast is safe.
-type RawOfferListingRow = Omit<RawListingRow, "seller"> & {
-  seller?: RawListingRow["seller"]
+// `seller` join (buyer dashboard never asks for it); mapNestedBrowseListing
+// treats a missing seller as null, so the cast is safe.
+type RawOfferListingRow = Omit<NestedBrowseRow, "seller"> & {
+  seller?: NestedBrowseRow["seller"]
 }
 
 interface RawOfferRow {
@@ -57,7 +55,7 @@ interface RawOfferRow {
 function mapOfferListing(
   listing: RawOfferListingRow | null
 ): BrowseListing | null {
-  return listing ? mapBrowseListing(listing as RawListingRow) : null
+  return listing ? mapNestedBrowseListing(listing as NestedBrowseRow) : null
 }
 
 function mapRawOfferRow(

--- a/web/lib/offers/constants.ts
+++ b/web/lib/offers/constants.ts
@@ -37,12 +37,6 @@ export const OFFER_STATUS_COLORS: Record<OfferStatus, string> = {
 export const OFFER_AMOUNT_MAX = 100_000_000
 export const OFFER_MESSAGE_MAX = 500
 
-/**
- * The login redirect target for the "Make an offer" CTA. Login honors a
- * `?next=` query param (see app/login/page.tsx), so a signed-out visitor who
- * taps the CTA lands back on the exact listing after signing in. Kept here so
- * the Client Component needs no URL-building logic.
- */
-export function buildLoginUrl(pathname: string): string {
-  return `/login?next=${encodeURIComponent(pathname)}`
-}
+// The login redirect target for the "Make an offer" CTA, shared across
+// signed-out CTAs (see lib/nav.ts for the single definition).
+export { buildLoginUrl } from "@/lib/nav"

--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { cache } from "react"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 
 // ---- Row shapes ----
 
@@ -46,8 +47,11 @@ const PUBLIC_PROFILE_COLUMNS =
 /** Own-profile read for the /profile page. Cached so metadata and the body of a
  * request (and any sibling server component) share one round trip. */
 export const fetchOwnProfile = cache(
-  async (userId: string): Promise<OwnProfileRow | null> => {
-    const supabase = await createClient()
+  async (
+    userId: string,
+    client?: Supabase
+  ): Promise<OwnProfileRow | null> => {
+    const supabase = client ?? (await createClient())
     const { data: profile, error } = await supabase
       .from("profiles")
       .select(OWN_PROFILE_COLUMNS)
@@ -65,8 +69,11 @@ export const fetchOwnProfile = cache(
  * Trust-badge flags (phone_verified, fayda_verified) are public by T12 RLS
  * design. */
 export const fetchPublicProfile = cache(
-  async (userId: string): Promise<PublicProfileRow | null> => {
-    const supabase = await createClient()
+  async (
+    userId: string,
+    client?: Supabase
+  ): Promise<PublicProfileRow | null> => {
+    const supabase = client ?? (await createClient())
 
     const { data: profile, error } = await supabase
       .from("profiles")

--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -1,0 +1,169 @@
+import "server-only"
+
+import { cache } from "react"
+
+import { createClient } from "@/lib/supabase/server"
+
+// ---- Row shapes ----
+
+export interface OwnProfileRow {
+  avatar_url: string | null
+  full_name: string | null
+  phone: string | null
+  telegram_username: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  trust_score: number | null
+  profile_completion: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+}
+
+export interface PublicProfileRow {
+  full_name: string | null
+  avatar_url: string | null
+  city: string | null
+  sub_city: string | null
+  bio: string | null
+  telegram_username: string | null
+  phone: string | null
+  trust_score: number | null
+  role: "buyer" | "seller" | "admin" | null
+  phone_public: boolean | null
+  phone_verified: boolean | null
+  fayda_verified: boolean | null
+}
+
+const OWN_PROFILE_COLUMNS =
+  "avatar_url, full_name, phone, telegram_username, city, sub_city, bio, trust_score, profile_completion, role, phone_public"
+
+const PUBLIC_PROFILE_COLUMNS =
+  "full_name, avatar_url, city, sub_city, bio, telegram_username, trust_score, role, phone_public, phone_verified, fayda_verified"
+
+// ---- Reads ----
+
+/** Own-profile read for the /profile page. Cached so metadata and the body of a
+ * request (and any sibling server component) share one round trip. */
+export const fetchOwnProfile = cache(
+  async (userId: string): Promise<OwnProfileRow | null> => {
+    const supabase = await createClient()
+    const { data: profile, error } = await supabase
+      .from("profiles")
+      .select(OWN_PROFILE_COLUMNS)
+      .eq("id", userId)
+      .maybeSingle()
+
+    if (error || !profile) return null
+    return profile as OwnProfileRow
+  }
+)
+
+/** Public seller surface for the /users/[id] page. Cached so generateMetadata
+ * and the page body share one round trip. Phone is fetched separately and only
+ * when the owner has opted in (Security spec §19: phone is private by default).
+ * Trust-badge flags (phone_verified, fayda_verified) are public by T12 RLS
+ * design. */
+export const fetchPublicProfile = cache(
+  async (userId: string): Promise<PublicProfileRow | null> => {
+    const supabase = await createClient()
+
+    const { data: profile, error } = await supabase
+      .from("profiles")
+      .select(PUBLIC_PROFILE_COLUMNS)
+      .eq("id", userId)
+      .maybeSingle()
+
+    if (error || !profile) return null
+
+    const row = profile as PublicProfileRow
+
+    if (row.phone_public) {
+      const { data: withPhone } = await supabase
+        .from("profiles")
+        .select("phone")
+        .eq("id", userId)
+        .maybeSingle()
+      row.phone = withPhone?.phone ?? null
+    }
+
+    return row
+  }
+)
+
+// ---- Writes ----
+
+interface ProfileFields {
+  full_name?: string | null
+  city?: string | null
+  sub_city?: string | null
+  phone?: string | null
+  telegram_username?: string | null
+  bio?: string | null
+  profile_completion?: number | null
+  phone_public?: boolean | null
+}
+
+export async function updateProfileRow(
+  userId: string,
+  fields: ProfileFields
+): Promise<{ ok: boolean; error: string | null }> {
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from("profiles")
+    .update(fields)
+    .eq("id", userId)
+
+  if (error) return { ok: false, error: error.message }
+  return { ok: true, error: null }
+}
+
+/** Onboarding completion: persists the profile's initial fields and marks the
+ * profile complete (profile_completion: 100 is the domain rule that flips the
+ * "complete your profile" gate). Telegram handles are normalized here so the
+ * rule lives next to the write, not in the action. */
+export async function completeOwnProfile(
+  userId: string,
+  values: {
+    fullName: string
+    city: string
+    subCity?: string
+    phone?: string
+    telegramUsername?: string
+    bio?: string
+  }
+): Promise<{ ok: boolean; error: string | null }> {
+  return updateProfileRow(userId, {
+    full_name: values.fullName,
+    city: values.city,
+    sub_city: values.subCity || null,
+    phone: values.phone || null,
+    telegram_username: values.telegramUsername
+      ? values.telegramUsername.replace(/^@/, "")
+      : null,
+    bio: values.bio || null,
+    profile_completion: 100,
+  })
+}
+
+/** Editable profile fields from the /profile page form. */
+export async function updateOwnProfile(
+  userId: string,
+  values: {
+    city: string
+    subCity?: string
+    phone?: string
+    telegramUsername?: string
+    bio?: string
+    phonePublic?: boolean
+  }
+): Promise<{ ok: boolean; error: string | null }> {
+  return updateProfileRow(userId, {
+    city: values.city,
+    sub_city: values.subCity || null,
+    phone: values.phone || null,
+    telegram_username: values.telegramUsername || null,
+    bio: values.bio || null,
+    phone_public: values.phonePublic ?? false,
+  })
+}

--- a/web/lib/reports.ts
+++ b/web/lib/reports.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import { pickCoverImage } from "@/lib/listings/browse-mapper"
 import { OPEN_REPORT_STATUSES } from "./reports/constants"
@@ -91,9 +92,10 @@ const REPORT_JOINS = `${REPORT_COLUMNS},
  * without a second round-trip.
  */
 export async function fetchMyReports(
-  userId: string
+  userId: string,
+  client?: Supabase
 ): Promise<MyReportRow[]> {
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
 
   const { data, error } = await supabase
     .from("reports")
@@ -115,8 +117,10 @@ export async function fetchMyReports(
  * The admin moderation queue: all open reports with the reported item's
  * context (listing + seller profile, or just the seller profile).
  */
-export async function fetchAdminReports(): Promise<ReportWithRelations[]> {
-  const supabase = await createClient()
+export async function fetchAdminReports(
+  client?: Supabase
+): Promise<ReportWithRelations[]> {
+  const supabase = client ?? (await createClient())
 
   const { data, error } = await supabase
     .from("reports")

--- a/web/lib/reports.ts
+++ b/web/lib/reports.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
-import { callRpc } from "@/lib/supabase/rpc"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import { OPEN_REPORT_STATUSES } from "./reports/constants"
 import type { ReportReason, ReportStatus } from "./reports/constants"
 
@@ -140,12 +140,6 @@ export interface ReportResult {
   error: string | null
 }
 
-/** Result shape the report RPCs return (jsonb { ok, error }). */
-interface ReportRpcData {
-  ok?: boolean
-  error?: string | null
-}
-
 /**
  * Submit a report. Delegates to the submit_report RPC so the rate limit and
  * duplicate-open checks run in a single SECURITY DEFINER round-trip.
@@ -160,19 +154,18 @@ export async function createReport(params: {
 }): Promise<ReportResult> {
   const supabase = await createClient()
 
-  const { data, error } = await callRpc<ReportRpcData>(supabase, "submit_report", {
-    p_listing_id: params.listingId ?? null,
-    p_seller_id: params.sellerId ?? null,
-    p_reason: params.reason,
-    p_note: params.note?.trim() || null,
-  })
+  const result = await callOutcomeRpc(
+    supabase,
+    "submit_report",
+    {
+      p_listing_id: params.listingId ?? null,
+      p_seller_id: params.sellerId ?? null,
+      p_reason: params.reason,
+      p_note: params.note?.trim() || null,
+    },
+    "createReport"
+  )
 
-  if (error) {
-    console.error("createReport:", error)
-    return { ok: false, error }
-  }
-
-  const result = data ?? {}
   return { ok: result.ok === true, error: result.error ?? null }
 }
 
@@ -188,18 +181,17 @@ export async function resolveReport(
 ): Promise<ReportResult> {
   const supabase = await createClient()
 
-  const { data, error } = await callRpc<ReportRpcData>(supabase, "resolve_report", {
-    p_report_id: reportId,
-    p_action: action,
-    p_admin_note: adminNote?.trim() || null,
-  })
+  const result = await callOutcomeRpc(
+    supabase,
+    "resolve_report",
+    {
+      p_report_id: reportId,
+      p_action: action,
+      p_admin_note: adminNote?.trim() || null,
+    },
+    "resolveReport"
+  )
 
-  if (error) {
-    console.error("resolveReport:", error)
-    return { ok: false, error }
-  }
-
-  const result = data ?? {}
   return { ok: result.ok === true, error: result.error ?? null }
 }
 

--- a/web/lib/reports.ts
+++ b/web/lib/reports.ts
@@ -2,6 +2,7 @@ import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
+import { pickCoverImage } from "@/lib/listings/browse-mapper"
 import { OPEN_REPORT_STATUSES } from "./reports/constants"
 import type { ReportReason, ReportStatus } from "./reports/constants"
 
@@ -222,15 +223,6 @@ interface RawReportRow {
     trust_score: number | null
   } | null
   reporter: { id: string; full_name: string | null; avatar_url: string | null } | null
-}
-
-function pickCoverImage(
-  images: { image_url: string; display_order: number }[] | null | undefined
-): string | null {
-  return (
-    [...(images ?? [])].sort((a, b) => a.display_order - b.display_order)[0]
-      ?.image_url ?? null
-  )
 }
 
 function normalizeAdminReport(row: RawReportRow): ReportWithRelations {

--- a/web/lib/reports/constants.ts
+++ b/web/lib/reports/constants.ts
@@ -58,12 +58,6 @@ export const REPORT_NOTE_MAX = 1000
 export const REPORT_RATE_LIMIT_COUNT = 5
 export const REPORT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
 
-/**
- * The login redirect target for the Report button. Login honors a `?next=`
- * query param (see app/login/page.tsx), so a signed-out visitor who taps
- * Report lands back on the exact listing after signing in. Kept here so the
- * Client Component needs no URL-building logic.
- */
-export function buildLoginUrl(pathname: string): string {
-  return `/login?next=${encodeURIComponent(pathname)}`
-}
+// The login redirect target for the Report button, shared across signed-out
+// CTAs (see lib/nav.ts for the single definition).
+export { buildLoginUrl } from "@/lib/nav"

--- a/web/lib/reviews.ts
+++ b/web/lib/reviews.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
-import { callRpc } from "@/lib/supabase/rpc"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import { isValidUuid } from "@/lib/listings"
 
 export * from "@/lib/reviews/constants"
@@ -101,16 +101,16 @@ export async function submitReviewRow(input: {
     return { ok: false, error: "invalid offer id", sellerId: null }
   }
   const supabase = await createClient()
-  const { data, error } = await callRpc<ReviewRpcData>(supabase, "submit_review", {
-    p_offer_id: input.offerId,
-    p_rating: input.rating,
-    p_comment: input.comment?.trim() || null,
-  })
-  if (error) {
-    console.error("submitReviewRow:", error)
-    return { ok: false, error, sellerId: null }
-  }
-  const result = data ?? {}
+  const result = await callOutcomeRpc<ReviewRpcData>(
+    supabase,
+    "submit_review",
+    {
+      p_offer_id: input.offerId,
+      p_rating: input.rating,
+      p_comment: input.comment?.trim() || null,
+    },
+    "submitReviewRow"
+  )
   return {
     ok: result.ok === true,
     error: result.error ?? null,

--- a/web/lib/reviews.ts
+++ b/web/lib/reviews.ts
@@ -1,6 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
+import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import { isValidUuid } from "@/lib/listings"
 
@@ -43,10 +44,11 @@ const REVIEW_COLUMNS =
 // The seller's reviews, newest first, with the reviewer's public identity.
 // RLS exposes every review to the public, so any visitor can render the list.
 export async function fetchSellerReviews(
-  sellerId: string
+  sellerId: string,
+  client?: Supabase
 ): Promise<SellerReviewRow[]> {
   if (!isValidUuid(sellerId)) return []
-  const supabase = await createClient()
+  const supabase = client ?? (await createClient())
   const { data, error } = await supabase
     .from("reviews")
     .select(REVIEW_COLUMNS)

--- a/web/lib/supabase/rpc.ts
+++ b/web/lib/supabase/rpc.ts
@@ -28,10 +28,10 @@ export interface RpcOutcome {
   error?: string | null
 }
 
-/** One typed seam for every RPC call. Mirrors offers.ts::runOfferRpc: the name
- * is a typed union and PostgREST's error object is reduced to its message in a
- * single place. The client is injected so the seam stays testable without the
- * server graph (and so callers can pass a fake in unit tests). */
+/** One typed seam for every RPC call. The name is a typed union and
+ * PostgREST's error object is reduced to its message in a single place. The
+ * client is injected so the seam stays testable without the server graph (and
+ * so callers can pass a fake in unit tests). */
 export async function callRpc<T>(
   supabase: Supabase,
   name: RpcName,
@@ -42,17 +42,20 @@ export async function callRpc<T>(
 }
 
 /** Normalise a write-RPC's `{ ok, error }` envelope, collapsing the jsonb
- * payload and the transport error into one `{ ok, error }` result. */
-export async function callOutcomeRpc(
+ * payload and the transport error into one `{ ok, error }` result. Generic over
+ * the extra fields a particular RPC returns (e.g. submit_review → seller_id),
+ * so every write-RPC caller lands on this one interface. On a transport error
+ * the extra fields are absent; callers default them with `??`. */
+export async function callOutcomeRpc<T extends RpcOutcome = RpcOutcome>(
   supabase: Supabase,
   name: RpcName,
   args: RpcArgs,
   logLabel: string
-): Promise<RpcOutcome> {
-  const { data, error } = await callRpc<RpcOutcome>(supabase, name, args)
+): Promise<T> {
+  const { data, error } = await callRpc<T>(supabase, name, args)
   if (error) {
     console.error(`${logLabel}:`, error)
-    return { ok: false, error }
+    return { ok: false, error } as unknown as T
   }
-  return data ?? {}
+  return (data ?? {}) as T
 }

--- a/web/lib/verifications.ts
+++ b/web/lib/verifications.ts
@@ -1,7 +1,7 @@
 import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
-import { callRpc } from "@/lib/supabase/rpc"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import type {
   VerificationStatus,
   VerificationType,
@@ -35,33 +35,27 @@ export async function recordVerification(params: {
 }): Promise<RecordVerificationResult> {
   const supabase = await createClient()
 
-  const { data, error } = await callRpc<{
+  const result = await callOutcomeRpc<{
     ok: boolean
     error: string | null
     user_id: string
     type: VerificationType
-  }>(supabase, "record_verification", {
-    p_user_id: params.userId,
-    p_type: params.type,
-    p_status: params.status,
-    p_notes: params.notes?.trim() || null,
-  })
+  }>(
+    supabase,
+    "record_verification",
+    {
+      p_user_id: params.userId,
+      p_type: params.type,
+      p_status: params.status,
+      p_notes: params.notes?.trim() || null,
+    },
+    "recordVerification"
+  )
 
-  if (error) {
-    console.error("recordVerification:", error)
-    return { ok: false, error }
-  }
-
-  const result = data ?? {
-    ok: false,
-    error: null,
-    user_id: params.userId,
-    type: params.type,
-  }
   return {
     ok: result.ok === true,
     error: result.error ?? null,
-    user_id: result.user_id,
-    type: result.type,
+    user_id: result.user_id ?? params.userId,
+    type: result.type ?? params.type,
   }
 }

--- a/web/tests/unit/browse-mapper.test.ts
+++ b/web/tests/unit/browse-mapper.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from "vitest"
 
-import { mapBrowseListing, pickCoverImage } from "@/lib/listings/browse-mapper"
+import {
+  mapFlatSearchListing,
+  mapNestedBrowseListing,
+  pickCoverImage,
+} from "@/lib/listings/browse-mapper"
 import type { Condition } from "@/lib/listings/constants"
 
 const condition: Condition = "Fair"
 
-describe("browse-mapper.mapBrowseListing (nested browse rows)", () => {
+describe("browse-mapper.mapNestedBrowseListing (nested browse rows)", () => {
   const nested = {
     id: "l1",
     title: "Chair",
@@ -29,7 +33,7 @@ describe("browse-mapper.mapBrowseListing (nested browse rows)", () => {
   }
 
   it("picks the lowest display_order image as the cover", () => {
-    const listing = mapBrowseListing(nested)
+    const listing = mapNestedBrowseListing(nested)
     expect(listing.image_url).toBe("/b.jpg")
     expect(listing.image_count).toBe(2)
     expect(listing.seller).toEqual({
@@ -44,7 +48,7 @@ describe("browse-mapper.mapBrowseListing (nested browse rows)", () => {
   })
 
   it("handles a row with no seller or images", () => {
-    const listing = mapBrowseListing({
+    const listing = mapNestedBrowseListing({
       ...nested,
       seller: null,
       images: null,
@@ -55,7 +59,7 @@ describe("browse-mapper.mapBrowseListing (nested browse rows)", () => {
   })
 })
 
-describe("browse-mapper.mapBrowseListing (search RPC rows)", () => {
+describe("browse-mapper.mapFlatSearchListing (search RPC rows)", () => {
   const flat = {
     id: "l1",
     title: "Chair",
@@ -73,7 +77,7 @@ describe("browse-mapper.mapBrowseListing (search RPC rows)", () => {
   }
 
   it("stitches the flat seller columns into the shared display shape", () => {
-    expect(mapBrowseListing(flat)).toEqual({
+    expect(mapFlatSearchListing(flat)).toEqual({
       id: "l1",
       title: "Chair",
       price: 100,
@@ -95,7 +99,7 @@ describe("browse-mapper.mapBrowseListing (search RPC rows)", () => {
   })
 
   it("maps a search row with no seller", () => {
-    const listing = mapBrowseListing({ ...flat, seller_id: null })
+    const listing = mapFlatSearchListing({ ...flat, seller_id: null })
     expect(listing.seller).toBeNull()
   })
 })

--- a/web/tests/unit/listings-reads.test.ts
+++ b/web/tests/unit/listings-reads.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  fetchListing,
+  fetchListings,
+  fetchSellerListings,
+  searchListings,
+} from "@/lib/listings"
+
+// The read fetchers accept an optional client as their last argument (the same
+// injection the media and RPC seams use), so these tests drive the real
+// paging/join/normalisation logic through lightweight fakes — no module mock,
+// no thenable-builder hack.
+
+const builder = (result: unknown): Record<string, unknown> => {
+  const b: Record<string, unknown> = {
+    select: () => b,
+    eq: () => b,
+    is: () => b,
+    order: () => b,
+    range: () => b,
+    maybeSingle: () => b,
+    single: () => b,
+    then: (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve),
+  }
+  return b
+}
+
+const queue = (results: unknown[]): Record<string, unknown> => {
+  let i = 0
+  const b: Record<string, unknown> = {
+    select: () => b,
+    eq: () => b,
+    is: () => b,
+    order: () => b,
+    range: () => b,
+    maybeSingle: () => b,
+    single: () => b,
+    then: (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(results[i++] ?? { data: null, error: null }).then(resolve),
+  }
+  return b
+}
+
+const db = (from: (table: string) => unknown) => ({ from } as never)
+
+const nestedRow = () => ({
+  id: "listing-1",
+  title: "Chair",
+  price: 100,
+  condition: "Fair",
+  city: "Bole",
+  published_at: "2026-01-01",
+  seller: [
+    {
+      id: "seller-1",
+      full_name: "Alem",
+      avatar_url: null,
+      role: "seller",
+      trust_score: 50,
+      phone_verified: true,
+      fayda_verified: false,
+    },
+  ],
+  images: [
+    { id: "img-1", image_url: "cover.jpg", display_order: 0 },
+    { id: "img-2", image_url: "second.jpg", display_order: 1 },
+  ],
+})
+
+const listingRow = {
+  id: "listing-1",
+  title: "Chair",
+  description: null,
+  price: 100,
+  condition: "Fair",
+  category_id: null,
+  seller_id: "seller-1",
+  status: "published",
+  city: "Bole",
+  sub_city: null,
+  address: null,
+  negotiable: false,
+  ai_assisted: false,
+  published_at: "2026-01-01",
+  created_at: "2026-01-01",
+  updated_at: "2026-01-01",
+  deleted_at: null,
+}
+
+describe("fetchListings", () => {
+  it("maps nested rows and reports hasMore when more rows remain", async () => {
+    const client = db(() =>
+      builder({ data: [nestedRow()], error: null, count: 5 })
+    )
+    const result = await fetchListings({ limit: 12, offset: 0 }, client)
+    expect(result.error).toBeNull()
+    expect(result.listings[0].title).toBe("Chair")
+    expect(result.listings[0].image_url).toBe("cover.jpg")
+    expect(result.listings[0].seller?.full_name).toBe("Alem")
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("reports hasMore false when the window covers the count", async () => {
+    const client = db(() =>
+      builder({ data: [nestedRow()], error: null, count: 1 })
+    )
+    const result = await fetchListings({ limit: 12 }, client)
+    expect(result.hasMore).toBe(false)
+  })
+
+  it("returns the error without crashing on a failed query", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" }, count: null })
+    )
+    const result = await fetchListings({}, client)
+    expect(result).toMatchObject({ listings: [], hasMore: false, error: "db down" })
+  })
+
+  it("short-circuits when the category slug is unknown", async () => {
+    const q = queue([
+      { data: null, error: null },
+      { data: [nestedRow()], error: null, count: 5 },
+    ])
+    const client = db(() => q)
+    const result = await fetchListings({ categorySlug: "nope" }, client)
+    expect(result).toMatchObject({
+      listings: [],
+      count: 0,
+      hasMore: false,
+      error: null,
+    })
+  })
+
+  it("filters by a resolved category id", async () => {
+    const q = queue([
+      { data: { id: "cat-1" }, error: null },
+      { data: [nestedRow()], error: null, count: 3 },
+    ])
+    const client = db(() => q)
+    const result = await fetchListings({ categorySlug: "furniture" }, client)
+    expect(result.listings.length).toBe(1)
+    expect(result.count).toBe(3)
+  })
+})
+
+describe("searchListings", () => {
+  const flatRow = () => ({
+    id: "listing-1",
+    title: "Chair",
+    price: 100,
+    condition: "Fair",
+    city: "Bole",
+    published_at: "2026-01-01",
+    image_url: "cover.jpg",
+    image_count: 2,
+    seller_id: "seller-1",
+    seller_full_name: "Alem",
+    seller_avatar_url: null,
+    seller_role: "seller",
+    seller_trust_score: 50,
+    seller_phone_verified: true,
+    seller_fayda_verified: false,
+    total_count: 9,
+  })
+
+  it("maps flat RPC rows and derives hasMore from total_count", async () => {
+    const client = {
+      rpc: async () => ({ data: [flatRow()], error: null }),
+    } as never
+    const result = await searchListings({ q: "chair" }, client)
+    expect(result.error).toBeNull()
+    expect(result.count).toBe(9)
+    expect(result.hasMore).toBe(true)
+    expect(result.listings[0].image_url).toBe("cover.jpg")
+    expect(result.listings[0].seller?.full_name).toBe("Alem")
+  })
+
+  it("reports hasMore false when the page covers total_count", async () => {
+    const client = {
+      rpc: async () => ({
+        data: [{ ...flatRow(), total_count: 1 }],
+        error: null,
+      }),
+    } as never
+    const result = await searchListings({}, client)
+    expect(result.hasMore).toBe(false)
+  })
+
+  it("returns an empty result when the RPC errors", async () => {
+    const client = {
+      rpc: async () => ({ data: null, error: { message: "boom" } }),
+    } as never
+    const result = await searchListings({}, client)
+    expect(result).toMatchObject({
+      listings: [],
+      count: 0,
+      hasMore: false,
+      error: "boom",
+    })
+  })
+})
+
+describe("fetchSellerListings", () => {
+  it("maps the cover (lowest display_order) and numeric price", async () => {
+    const row = {
+      ...listingRow,
+      price: "100",
+      images: [
+        { image_url: "b.jpg", display_order: 1 },
+        { image_url: "a.jpg", display_order: 0 },
+      ],
+    }
+    const client = db(() => builder({ data: [row], error: null }))
+    const result = await fetchSellerListings("seller-1", client)
+    expect(result[0].price).toBe(100)
+    expect(result[0].cover_image_url).toBe("a.jpg")
+  })
+
+  it("returns an empty list when the query fails", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" } })
+    )
+    expect(await fetchSellerListings("seller-1", client)).toEqual([])
+  })
+})
+
+describe("fetchListing", () => {
+  it("returns null for an invalid uuid without touching the db", async () => {
+    expect(await fetchListing("nope")).toBeNull()
+  })
+
+  it("skips the seller join when includeSeller is false", async () => {
+    const q = queue([
+      { data: listingRow, error: null },
+      { data: [], error: null },
+      { data: null, error: null },
+    ])
+    const client = db(() => q)
+    const result = await fetchListing(
+      "11111111-1111-1111-1111-111111111111",
+      { includeSeller: false },
+      client
+    )
+    expect(result?.listing.title).toBe("Chair")
+    expect(result?.seller).toBeNull()
+  })
+
+  it("includes the seller join by default", async () => {
+    const q = queue([
+      { data: listingRow, error: null },
+      { data: [], error: null },
+      {
+        data: {
+          id: "seller-1",
+          full_name: "Alem",
+          avatar_url: null,
+          role: "seller",
+          trust_score: 50,
+          phone_verified: true,
+          fayda_verified: false,
+        },
+        error: null,
+      },
+    ])
+    const client = db(() => q)
+    const result = await fetchListing(
+      "22222222-2222-2222-2222-222222222222",
+      {},
+      client
+    )
+    expect(result?.seller?.full_name).toBe("Alem")
+  })
+})

--- a/web/tests/unit/profiles.test.ts
+++ b/web/tests/unit/profiles.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}))
+
+import { createClient } from "@/lib/supabase/server"
+import {
+  fetchOwnProfile,
+  fetchPublicProfile,
+  completeOwnProfile,
+  updateOwnProfile,
+} from "@/lib/profiles"
+
+const mockCreateClient = vi.mocked(createClient)
+
+// Fluent builder that resolves chained queries in order, so the phone gate's
+// two-query dance (base read, then phone read) can be stubbed independently.
+const queue = (results: unknown[]): Record<string, unknown> => {
+  let i = 0
+  const b: Record<string, unknown> = {
+    select: () => b,
+    eq: () => b,
+    order: () => b,
+    maybeSingle: () => b,
+    single: () => b,
+    then: (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(results[i++] ?? { data: null, error: null }).then(resolve),
+  }
+  return b
+}
+
+const db = (from: (table: string) => unknown) => ({ from } as never)
+
+// Builder for write paths: records the update payload and resolves a canned
+// result, so callers can assert exactly what was persisted.
+const captureBuilder = (
+  result: unknown
+): { b: Record<string, unknown>; updates: unknown[] } => {
+  const updates: unknown[] = []
+  const b: Record<string, unknown> = {
+    select: () => b,
+    eq: () => b,
+    update: (values: unknown) => {
+      updates.push(values)
+      return b
+    },
+    then: (resolve: (value: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve),
+  }
+  return { b, updates }
+}
+
+const ownRow = {
+  avatar_url: null,
+  full_name: "Alem",
+  phone: "+251 911 000 000",
+  telegram_username: "alem",
+  city: "Bole",
+  sub_city: null,
+  bio: "Hi",
+  trust_score: 50,
+  profile_completion: 100,
+  role: "seller",
+  phone_public: false,
+}
+
+describe("profile reads", () => {
+  it("fetchOwnProfile returns the row when found", async () => {
+    mockCreateClient.mockResolvedValue(
+      db(() => queue([{ data: ownRow, error: null }]))
+    )
+    expect(await fetchOwnProfile("user-own")).toEqual(ownRow)
+  })
+
+  it("fetchOwnProfile returns null when the row is missing", async () => {
+    mockCreateClient.mockResolvedValue(
+      db(() => queue([{ data: null, error: null }]))
+    )
+    expect(await fetchOwnProfile("user-missing")).toBeNull()
+  })
+
+  it("fetchOwnProfile returns null on a database error", async () => {
+    mockCreateClient.mockResolvedValue(
+      db(() => queue([{ data: null, error: { message: "db down" } }]))
+    )
+    expect(await fetchOwnProfile("user-error")).toBeNull()
+  })
+
+  it("fetchPublicProfile returns null when the profile is missing", async () => {
+    mockCreateClient.mockResolvedValue(
+      db(() => queue([{ data: null, error: null }]))
+    )
+    expect(await fetchPublicProfile("user-missing")).toBeNull()
+  })
+
+  it("fetchPublicProfile keeps phone private unless phone_public is set", async () => {
+    const base = { ...ownRow, phone_public: false, phone: null }
+    mockCreateClient.mockResolvedValue(
+      db(() => queue([{ data: base, error: null }]))
+    )
+    const result = await fetchPublicProfile("user-private")
+    expect(result?.phone).toBeNull()
+    expect(result?.phone_public).toBe(false)
+  })
+
+  it("fetchPublicProfile fetches phone in a second query when opted in", async () => {
+    const base = { ...ownRow, phone_public: true, phone: null }
+    const q = queue([
+      { data: base, error: null },
+      { data: { phone: "+251 911 999 999" }, error: null },
+    ])
+    mockCreateClient.mockResolvedValue(db(() => q))
+    const result = await fetchPublicProfile("user-public")
+    expect(result?.phone).toBe("+251 911 999 999")
+  })
+})
+
+describe("profile writes", () => {
+  it("completeOwnProfile strips the @ from telegram and marks completion 100", async () => {
+    const { b, updates } = captureBuilder({ data: null, error: null })
+    mockCreateClient.mockResolvedValue(db(() => b))
+
+    const result = await completeOwnProfile("user-1", {
+      fullName: "Alem",
+      city: "Bole",
+      telegramUsername: "@alem",
+      bio: "Hi",
+    })
+
+    expect(result).toEqual({ ok: true, error: null })
+    expect(updates[0]).toMatchObject({
+      telegram_username: "alem",
+      profile_completion: 100,
+      full_name: "Alem",
+    })
+  })
+
+  it("completeOwnProfile surfaces a database error", async () => {
+    const { b } = captureBuilder({ data: null, error: { message: "db down" } })
+    mockCreateClient.mockResolvedValue(db(() => b))
+    expect(
+      await completeOwnProfile("user-1", { fullName: "Alem", city: "Bole" })
+    ).toEqual({ ok: false, error: "db down" })
+  })
+
+  it("updateOwnProfile persists phone_public", async () => {
+    const { b, updates } = captureBuilder({ data: null, error: null })
+    mockCreateClient.mockResolvedValue(db(() => b))
+
+    const result = await updateOwnProfile("user-1", {
+      city: "Bole",
+      phonePublic: true,
+    })
+
+    expect(result).toEqual({ ok: true, error: null })
+    expect(updates[0]).toMatchObject({ city: "Bole", phone_public: true })
+  })
+})

--- a/web/tests/unit/rpc.test.ts
+++ b/web/tests/unit/rpc.test.ts
@@ -54,4 +54,19 @@ describe("supabase.callOutcomeRpc", () => {
     const result = await callOutcomeRpc(supabase, "submit_offer", {}, "test")
     expect(result).toEqual({})
   })
+
+  it("carries RPC-specific fields through the generic envelope", async () => {
+    const supabase = {
+      rpc: async () => ({
+        data: { ok: true, error: null, seller_id: "seller-9" },
+        error: null,
+      }),
+    } as never
+    const result = await callOutcomeRpc<{
+      ok: boolean
+      error: string | null
+      seller_id: string | null
+    }>(supabase, "submit_review", {}, "test")
+    expect(result).toEqual({ ok: true, error: null, seller_id: "seller-9" })
+  })
 })


### PR DESCRIPTION
## Summary

Implements the top architectural deepening opportunities identified by the improve-codebase-architecture scan of web/. Each candidate is its own commit:

1. **Seller Profile module** — new \lib/profiles.ts\ centralizing own/public profile reads and writes; profile page, seller page and profile actions now consume it (+9 tests).
2. **RPC outcome seam folded** — one generic \callOutcomeRpc\ in \lib/supabase/rpc.ts\ replaces the half-adopted outcome interface in offers/reviews/reports/verifications.
3. **Duplicated pure rules collapsed** — \uildLoginUrl\ hoisted to \lib/nav.ts\ and shared across favorites/contact/offers/reports; \pickCoverImage\ centralized in the browse mapper.
4. **Read path made testable** — read fetchers take an optional supabase client (defaulting to \createClient\), so unit tests drive real paging/join/normalization through lightweight fakes (+13 listings-reads tests).
5. **Browse mapper split + facade narrowed** — shape-sniffing \mapBrowseListing\ replaced with statically-typed \mapNestedBrowseListing\/\mapFlatSearchListing\; favorites/offers import directly from browse-mapper instead of the wide listings facade.
6. **One auth gate** — listing/report actions route through \equireSeller\/\equireAdmin\ instead of hand-rolled role predicates.

## Verification

- 179 unit tests passing (20 files)
- \	sc --noEmit\ clean
- eslint clean
- production build succeeds