### PR TITLE
fix(supabase): make local stack actually run (first real execution of migrations/seed)

### DIFF
--- a/web/lib/contact.ts
+++ b/web/lib/contact.ts
@@ -17,9 +17,10 @@ export interface ContactAttemptResult {
 // ---- Reads ----
 
 /**
- * Fetch the contact surface for a seller. Phone is always selected from the DB
- * but the column-level RLS policy on profiles.phone (grants only when
- * phone_public = true) means the value is NULL unless the owner opted in.
+ * Fetch the contact surface for a seller. Phone is fetched separately and only
+ * when the owner has opted in (Security spec §19: phone is private by default),
+ * matching fetchPublicProfile. The row policy is row-level only, so phone is
+ * never selected in a public query unless phone_public is set.
  */
 export async function fetchSellerContactInfo(
   sellerId: string,
@@ -29,15 +30,25 @@ export async function fetchSellerContactInfo(
 
   const { data: profile, error } = await supabase
     .from("profiles")
-    .select("telegram_username, phone, phone_public")
+    .select("telegram_username, phone_public")
     .eq("id", sellerId)
     .maybeSingle()
 
   if (error || !profile) return null
 
+  let phone: string | null = null
+  if (profile.phone_public) {
+    const { data: withPhone } = await supabase
+      .from("profiles")
+      .select("phone")
+      .eq("id", sellerId)
+      .maybeSingle()
+    phone = withPhone?.phone ?? null
+  }
+
   return {
     telegram_username: profile.telegram_username ?? null,
-    phone: profile.phone ?? null,
+    phone,
     phone_public: profile.phone_public ?? false,
   }
 }

--- a/web/lib/favorites.ts
+++ b/web/lib/favorites.ts
@@ -41,7 +41,7 @@ export async function fetchFavoriteListings(
     .select(
       `created_at,
         listing:listings(id, title, price, condition, city, published_at,
-          seller:profiles(id, full_name, avatar_url, role, trust_score, phone_verified, fayda_verified),
+          seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url, role, trust_score, phone_verified, fayda_verified),
           images:listing_images(id, image_url, display_order))`
     )
     .eq("user_id", userId)

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -197,7 +197,7 @@ export async function fetchListings(
     .from("listings")
     .select(
       `id, title, price, condition, city, published_at,
-       seller:profiles(id, full_name, avatar_url, role, trust_score, phone_verified, fayda_verified),
+       seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url, role, trust_score, phone_verified, fayda_verified),
        images:listing_images(id, image_url, display_order)`,
       { count: "exact" }
     )

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -133,7 +133,7 @@ export async function fetchSellerOffers(
     .select(
       `${OFFER_COLUMNS},
        listing:listings(id, title, price, condition, city, published_at,
-         seller:profiles(id, full_name, avatar_url, role, trust_score),
+         seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url, role, trust_score),
          images:listing_images(id, image_url, display_order)),
        buyer:profiles(id, full_name, avatar_url)`
     )

--- a/web/lib/reviews.ts
+++ b/web/lib/reviews.ts
@@ -39,7 +39,7 @@ interface RawReviewRow {
 }
 
 const REVIEW_COLUMNS =
-  "id, rating, comment, created_at, buyer:profiles(id, full_name, avatar_url)"
+  "id, rating, comment, created_at, buyer:profiles!reviews_buyer_id_fkey(id, full_name, avatar_url)"
 
 // The seller's reviews, newest first, with the reviewer's public identity.
 // RLS exposes every review to the public, so any visitor can render the list.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -22,6 +22,8 @@ const imageHost = supabaseImageHost();
 
 const nextConfig: NextConfig = {
   experimental: { serverActions: { bodySizeLimit: "50mb" } },
+  // localhost/127.0.0.1 are allowed by default; add your LAN IP here only if
+  // you open the dev server from another device on the network.
   images: {
     remotePatterns: imageHost
       ? [{ protocol: imageHost.protocol, hostname: imageHost.hostname, pathname: "/**" }]

--- a/web/supabase/config.toml
+++ b/web/supabase/config.toml
@@ -85,14 +85,14 @@ allowed_cidrs_v6 = ["::/0"]
 # enabled = true
 
 [realtime]
-enabled = true
+enabled = false
 # Bind realtime via either IPv4 or IPv6. (default: IPv4)
 # ip_version = "IPv6"
 # The maximum length in bytes of HTTP request headers. (default: 4096)
 # max_header_length = 4096
 
 [studio]
-enabled = true
+enabled = false
 # Port to use for Supabase Studio.
 port = 54323
 # External URL of the API server that frontend connects to.
@@ -372,7 +372,7 @@ authorization_url_path = "/oauth/consent"
 allow_dynamic_registration = false
 
 [edge_runtime]
-enabled = true
+enabled = false
 # Supported request policies: `oneshot`, `per_worker`.
 # `per_worker` (default) — enables hot reload during local development.
 # `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
@@ -386,7 +386,7 @@ deno_version = 2
 # secret_key = "env(SECRET_VALUE)"
 
 [analytics]
-enabled = true
+enabled = false
 port = 54327
 # Configure one of the supported backends: `postgres`, `bigquery`.
 backend = "postgres"

--- a/web/supabase/migrations/20260812120000_profile_phone_public.sql
+++ b/web/supabase/migrations/20260812120000_profile_phone_public.sql
@@ -11,28 +11,14 @@
 -- Public-opt-in for phone visibility.
 alter table public.profiles add column if not exists phone_public boolean not null default false;
 
--- Public profiles are readable (rows) by anyone. Sensitive columns are masked
--- separately via column-level policies below so phone is never exposed without
--- the owner's consent, even if a caller explicitly selects it (column-level RLS).
-create policy if not exists "Profiles are publicly readable"
+-- Public profiles are readable (rows) by anyone. Postgres has no column-level
+-- RLS, so phone exposure is gated at the data-access layer (Privacy §18/19):
+-- fetchPublicProfile in lib/profiles.ts selects phone only when the owner's
+-- phone_public flag is set; public queries never include the column.
+create policy "Profiles are publicly readable"
   on public.profiles for select
   to authenticated, anon
   using (true);
-
--- Column-level security for phone (Privacy §18/19): never expose it without
--- consent. Authenticated callers may read their OWN phone; all others need
--- the owner's phone_public opt-in. Anonymous never see phone unless public.
-create policy if not exists "Phone visible to owner or when public (authenticated)"
-  on public.profiles for select
-  to authenticated
-  columns (phone)
-  using (phone_public or auth.uid() = id);
-
-create policy if not exists "Phone visible only when public (anon)"
-  on public.profiles for select
-  to anon
-  columns (phone)
-  using (phone_public);
 
 -- Keep the existing owner/admin policies (they remain in force; row policies are
 -- additive). No changes to insert/update/delete policies here — owners still
@@ -47,21 +33,21 @@ on conflict (id) do update
 
 -- Allow any reader to resolve public avatar URLs (public bucket reads are
 -- served without RLS checks at /storage/v1/object/public/profiles/...).
-create policy if not exists "Profile avatars are publicly readable"
+create policy "Profile avatars are publicly readable"
   on storage.objects for select
   to authenticated, anon
   using (bucket_id = 'profiles');
 
 -- Owners may manage their own avatar objects only (path prefix avatars/{uid}).
-create policy if not exists "Profile avatars are writable by the owner"
+create policy "Profile avatars are writable by the owner"
   on storage.objects for all
   to authenticated
-  with check (
+  using (
     bucket_id = 'profiles'
     and (storage.foldername(name))[0] = 'avatars'
     and (storage.foldername(name))[1] = auth.uid()::text
   )
-  using (
+  with check (
     bucket_id = 'profiles'
     and (storage.foldername(name))[0] = 'avatars'
     and (storage.foldername(name))[1] = auth.uid()::text

--- a/web/supabase/migrations/20260812200000_create_listings.sql
+++ b/web/supabase/migrations/20260812200000_create_listings.sql
@@ -17,8 +17,8 @@ create table if not exists public.categories (
 );
 
 -- Listing condition + status constrained to the documented value sets.
-create type if not exists public.listing_condition as enum ('Brand New', 'Lightly Used', 'Fair');
-create type if not exists public.listing_status as enum ('draft', 'published', 'sold', 'archived');
+create type public.listing_condition as enum ('Brand New', 'Lightly Used', 'Fair');
+create type public.listing_status as enum ('draft', 'published', 'sold', 'archived');
 
 create table if not exists public.listings (
   id uuid primary key default gen_random_uuid(),
@@ -74,7 +74,7 @@ create index if not exists listing_images_listing_id_idx on public.listing_image
 create index if not exists listing_images_display_order_idx on public.listing_images (listing_id, display_order);
 
 -- Keep listings.updated_at in sync (reuse the generic trigger from T02).
-create trigger if not exists listings_set_updated_at
+create trigger listings_set_updated_at
   before update on public.listings
   for each row execute function public.handle_updated_at();
 
@@ -87,39 +87,39 @@ create trigger if not exists listings_set_updated_at
 alter table public.listings enable row level security;
 alter table public.listing_images enable row level security;
 
-create policy if not exists "Listings are readable when published"
+create policy "Listings are readable when published"
   on public.listings for select
   to authenticated, anon
   using (status = 'published' and deleted_at is null);
 
-create policy if not exists "Listings are readable by the owner"
+create policy "Listings are readable by the owner"
   on public.listings for select
   to authenticated
   using ((select auth.uid()) = seller_id);
 
-create policy if not exists "Listings are insertable by the owner"
+create policy "Listings are insertable by the owner"
   on public.listings for insert
   to authenticated
   with check ((select auth.uid()) = seller_id);
 
-create policy if not exists "Listings are updatable by the owner"
+create policy "Listings are updatable by the owner"
   on public.listings for update
   to authenticated
   using ((select auth.uid()) = seller_id)
   with check ((select auth.uid()) = seller_id);
 
-create policy if not exists "Listings are deletable by the owner"
+create policy "Listings are deletable by the owner"
   on public.listings for delete
   to authenticated
   using ((select auth.uid()) = seller_id);
 
-create policy if not exists "Listings are manageable by admins"
+create policy "Listings are manageable by admins"
   on public.listings for all
   to authenticated
   using (public.is_admin())
   with check (public.is_admin());
 
-create policy if not exists "Listing images are readable with published listings"
+create policy "Listing images are readable with published listings"
   on public.listing_images for select
   to authenticated, anon
   using (
@@ -131,7 +131,7 @@ create policy if not exists "Listing images are readable with published listings
     )
   );
 
-create policy if not exists "Listing images are writable by the listing owner"
+create policy "Listing images are writable by the listing owner"
   on public.listing_images for insert
   to authenticated
   with check (
@@ -142,7 +142,7 @@ create policy if not exists "Listing images are writable by the listing owner"
     )
   );
 
-create policy if not exists "Listing images are updatable by the listing owner"
+create policy "Listing images are updatable by the listing owner"
   on public.listing_images for update
   to authenticated
   using (
@@ -153,7 +153,7 @@ create policy if not exists "Listing images are updatable by the listing owner"
     )
   );
 
-create policy if not exists "Listing images are deletable by the listing owner"
+create policy "Listing images are deletable by the listing owner"
   on public.listing_images for delete
   to authenticated
   using (
@@ -164,7 +164,7 @@ create policy if not exists "Listing images are deletable by the listing owner"
     )
   );
 
-create policy if not exists "Listing image admins full access"
+create policy "Listing image admins full access"
   on public.listing_images for all
   to authenticated
   using (public.is_admin())
@@ -187,21 +187,21 @@ values ('listing-images', 'listing-images', true, 5242880)
 on conflict (id) do update
   set public = excluded.public, file_size_limit = excluded.file_size_limit;
 
-create policy if not exists "Listing photos are publicly readable"
+create policy "Listing photos are publicly readable"
   on storage.objects for select
   to authenticated, anon
   using (bucket_id = 'listing-images');
 
-create policy if not exists "Listing photos are writable by the listing owner"
+create policy "Listing photos are writable by the listing owner"
   on storage.objects for all
   to authenticated
-  with check (
+  using (
     bucket_id = 'listing-images'
     and (storage.foldername(name))[0]::uuid in (
       select l.id from public.listings l where l.seller_id = (select auth.uid())
     )
   )
-  using (
+  with check (
     bucket_id = 'listing-images'
     and (storage.foldername(name))[0]::uuid in (
       select l.id from public.listings l where l.seller_id = (select auth.uid())

--- a/web/supabase/migrations/20260813090000_create_favorites.sql
+++ b/web/supabase/migrations/20260813090000_create_favorites.sql
@@ -33,7 +33,7 @@ begin
 end;
 $$;
 
-create trigger if not exists favorites_sync_listing_count
+create trigger favorites_sync_listing_count
   after insert or delete on public.favorites
   for each row execute function public.sync_favorite_count();
 
@@ -43,17 +43,17 @@ create trigger if not exists favorites_sync_listing_count
 -----------------------------------------------------------------------------
 alter table public.favorites enable row level security;
 
-create policy if not exists "Favorites are readable by the owner"
+create policy "Favorites are readable by the owner"
   on public.favorites for select
   to authenticated
   using ((select auth.uid()) = user_id);
 
-create policy if not exists "Favorites are insertable by the owner"
+create policy "Favorites are insertable by the owner"
   on public.favorites for insert
   to authenticated
   with check ((select auth.uid()) = user_id);
 
-create policy if not exists "Favorites are deletable by the owner"
+create policy "Favorites are deletable by the owner"
   on public.favorites for delete
   to authenticated
   using ((select auth.uid()) = user_id);

--- a/web/supabase/migrations/20260813110000_create_offers.sql
+++ b/web/supabase/migrations/20260813110000_create_offers.sql
@@ -21,7 +21,7 @@
 -- policy references listings one way — no policy queries the other table, so
 -- RLS expansion cannot recurse.
 
-create type if not exists public.offer_status as enum ('pending', 'countered', 'accepted', 'declined');
+create type public.offer_status as enum ('pending', 'countered', 'accepted', 'declined');
 
 create table if not exists public.offers (
   id uuid primary key default gen_random_uuid(),
@@ -35,13 +35,13 @@ create table if not exists public.offers (
 );
 
 alter table public.offers
-  add constraint if not exists offers_message_length
+  add constraint offers_message_length
   check (message is null or char_length(message) between 1 and 500);
 
 -- App-side ceiling (app/lib/offers/constants.ts OFFER_AMOUNT_MAX), enforced at
 -- the write boundary so submit and counter both reject absurd amounts.
 alter table public.offers
-  add constraint if not exists offers_amount_cap
+  add constraint offers_amount_cap
   check (amount <= 100000000);
 
 -- ListingMarkedSold bookkeeping: who won the sale, stamped by accept_offer.
@@ -55,7 +55,7 @@ create index if not exists offers_buyer_id_idx on public.offers (buyer_id);
 create index if not exists offers_listing_id_idx on public.offers (listing_id);
 create index if not exists offers_status_idx on public.offers (status);
 
-create trigger if not exists offers_set_updated_at
+create trigger offers_set_updated_at
   before update on public.offers
   for each row execute function public.handle_updated_at();
 
@@ -66,7 +66,7 @@ create trigger if not exists offers_set_updated_at
 -----------------------------------------------------------------------------
 alter table public.offers enable row level security;
 
-create policy if not exists "Offers are readable by the buyer or the listing seller"
+create policy "Offers are readable by the buyer or the listing seller"
   on public.offers for select
   to authenticated
   using (
@@ -81,7 +81,7 @@ create policy if not exists "Offers are readable by the buyer or the listing sel
 -- INV-005 + ListingMarkedSold: offers only land on published, live listings the
 -- buyer does not own. Blocking the insert for non-published listings is what
 -- stops new offers once a listing is sold (its status flips to 'sold').
-create policy if not exists "Offers are insertable by the buyer"
+create policy "Offers are insertable by the buyer"
   on public.offers for insert
   to authenticated
   with check (
@@ -97,7 +97,7 @@ create policy if not exists "Offers are insertable by the buyer"
 
 -- DB spec §20: admins can read and write any offer. The transition RPCs below
 -- accept admins too (each guards on public.is_admin()).
-create policy if not exists "Offers are manageable by admins"
+create policy "Offers are manageable by admins"
   on public.offers for all
   to authenticated
   using (public.is_admin())
@@ -110,12 +110,12 @@ create policy if not exists "Offers are manageable by admins"
 -- Both policies read only the sold_to_buyer_id stamp (see header note) so they
 -- stay out of the offers policy graph.
 -----------------------------------------------------------------------------
-create policy if not exists "Sold listings are readable by the accepted-offer buyer"
+create policy "Sold listings are readable by the accepted-offer buyer"
   on public.listings for select
   to authenticated
   using ((select auth.uid()) = sold_to_buyer_id);
 
-create policy if not exists "Listing images are readable by the seller or accepted-offer buyer"
+create policy "Listing images are readable by the seller or accepted-offer buyer"
   on public.listing_images for select
   to authenticated
   using (

--- a/web/supabase/migrations/20260813120000_create_reviews.sql
+++ b/web/supabase/migrations/20260813120000_create_reviews.sql
@@ -20,7 +20,7 @@ create table if not exists public.reviews (
 );
 
 alter table public.reviews
-  add constraint if not exists reviews_comment_length
+  add constraint reviews_comment_length
   check (comment is null or char_length(comment) between 1 and 1000);
 
 -- Lookup paths: the seller's profile review list and "recent first".
@@ -35,7 +35,7 @@ create index if not exists reviews_seller_created_idx on public.reviews (seller_
 ------------------------------------------------------------------------------
 alter table public.reviews enable row level security;
 
-create policy if not exists "Reviews are publicly readable"
+create policy "Reviews are publicly readable"
   on public.reviews for select
   to authenticated, anon
   using (true);

--- a/web/supabase/migrations/20260813130000_create_reports.sql
+++ b/web/supabase/migrations/20260813130000_create_reports.sql
@@ -9,11 +9,11 @@
 -- so a single action atomically closes the report and applies the moderation
 -- verdict to the targeted listing/seller.
 
-create type if not exists public.report_reason as enum (
+create type public.report_reason as enum (
   'spam', 'fraud', 'duplicate', 'wrong_category', 'offensive_content', 'other'
 );
 
-create type if not exists public.report_status as enum (
+create type public.report_status as enum (
   'open', 'resolved', 'rejected'
 );
 
@@ -43,7 +43,7 @@ create index if not exists reports_seller_id_idx on public.reports (reported_sel
 create index if not exists reports_status_idx on public.reports (status);
 create index if not exists reports_created_at_idx on public.reports (created_at);
 
-create trigger if not exists reports_set_updated_at
+create trigger reports_set_updated_at
   before update on public.reports
   for each row execute function public.handle_updated_at();
 
@@ -53,17 +53,17 @@ create trigger if not exists reports_set_updated_at
 ------------------------------------------------------------------------------
 alter table public.reports enable row level security;
 
-create policy if not exists "Reports are readable by the reporter"
+create policy "Reports are readable by the reporter"
   on public.reports for select
   to authenticated
   using ((select auth.uid()) = reporter_id);
 
-create policy if not exists "Reports are readable by admins"
+create policy "Reports are readable by admins"
   on public.reports for select
   to authenticated
   using (public.is_admin());
 
-create policy if not exists "Reports are manageable by admins"
+create policy "Reports are manageable by admins"
   on public.reports for all
   to authenticated
   using (public.is_admin())
@@ -82,9 +82,9 @@ grant select on public.reports to authenticated;
 -- Returns jsonb { ok, error } so the caller gets a single result.
 ------------------------------------------------------------------------------
 create or replace function public.submit_report(
+  p_reason public.report_reason,
   p_listing_id uuid default null,
   p_seller_id uuid default null,
-  p_reason public.report_reason,
   p_note text default null
 )
 returns jsonb

--- a/web/supabase/migrations/20260814000000_create_verifications.sql
+++ b/web/supabase/migrations/20260814000000_create_verifications.sql
@@ -25,8 +25,8 @@
 -- ownership model), so a seller IS the verified-seller badge. A profile with
 -- role='buyer' (or one with no flags) renders the "Not verified yet" empty state.
 
-create type if not exists public.verification_type as enum ('email', 'phone', 'telegram', 'fayda');
-create type if not exists public.verification_status as enum ('pending', 'verified', 'rejected');
+create type public.verification_type as enum ('email', 'phone', 'telegram', 'fayda');
+create type public.verification_status as enum ('pending', 'verified', 'rejected');
 
 create table if not exists public.verifications (
   id uuid primary key default gen_random_uuid(),
@@ -49,7 +49,7 @@ create unique index if not exists verifications_one_active_per_type
   on public.verifications (user_id, type)
   where status in ('pending', 'verified') and deleted_at is null;
 
-create trigger if not exists verifications_set_updated_at
+create trigger verifications_set_updated_at
   before update on public.verifications
   for each row execute function public.handle_updated_at();
 
@@ -70,7 +70,7 @@ alter table public.profiles
 ------------------------------------------------------------------------------
 alter table public.verifications enable row level security;
 
-create policy if not exists "Users read their own non-deleted verification records"
+create policy "Users read their own non-deleted verification records"
   on public.verifications for select
   to authenticated
   using ((select auth.uid()) = user_id and deleted_at is null);
@@ -79,7 +79,7 @@ create policy if not exists "Users read their own non-deleted verification recor
 -- record_verification RPC (admin-gated) is the sole writer, so an approved
 -- record can never be mutated (INV-009). Admins read the full audit trail,
 -- including superseded rows, but never touch verified rows' status directly.
-create policy if not exists "Admins read verification records"
+create policy "Admins read verification records"
   on public.verifications for select
   to authenticated
   using (public.is_admin() and deleted_at is null);
@@ -171,8 +171,9 @@ $$;
 ------------------------------------------------------------------------------
 -- Extend the public search RPC (T06) to expose seller verification flags so
 -- search-result listing cards render the same badge set as browse/favorites.
--- `create or replace` preserves the existing anon/authenticated EXECUTE grants.
-------------------------------------------------------------------------------
+-- The return type changes (two added columns), so the old function must be
+-- dropped before re-creating; the EXECUTE grants are re-applied below.
+drop function if exists public.search_listings(text, text, numeric, numeric, public.listing_condition, text, text, int, int);
 create or replace function public.search_listings(
   p_query text default null,
   p_category_slug text default null,

--- a/web/supabase/migrations/20260814010000_create_contact_attempts.sql
+++ b/web/supabase/migrations/20260814010000_create_contact_attempts.sql
@@ -4,11 +4,12 @@
 -- §22 (migration naming). The contact method and listing context are captured
 -- so the admin queue and trust-score RPC can audit contact-driven traffic.
 --
--- Phone privacy is enforced by column-level RLS on profiles.phone (see the
--- T03 migration 20260812120000_profile_phone_public.sql: "Phone visible to
--- owner or when public"); the column evaluates to NULL for callers without
--- consent, so select-time masking is handled by the database, not app code.
--- (Security spec §19: phone is private by default.)
+-- Phone privacy is enforced at the data-access layer: the app fetches phone
+-- only when the owner opted in (see the T03 migration 20260812120000
+-- profile_phone_public.sql and lib/profiles.ts fetchPublicProfile /
+-- lib/contact.ts fetchSellerContactInfo). Postgres row policies do not
+-- restrict columns, so phone is never selected in a public query unless
+-- phone_public is set. (Security spec §19: phone is private by default.)
 
 create type public.contact_method as enum ('telegram', 'phone');
 

--- a/web/supabase/migrations/20260814010000_create_contact_attempts.sql
+++ b/web/supabase/migrations/20260814010000_create_contact_attempts.sql
@@ -10,7 +10,7 @@
 -- consent, so select-time masking is handled by the database, not app code.
 -- (Security spec §19: phone is private by default.)
 
-create type if not exists public.contact_method as enum ('telegram', 'phone');
+create type public.contact_method as enum ('telegram', 'phone');
 
 create table if not exists public.contact_attempts (
   id uuid primary key default gen_random_uuid(),
@@ -35,7 +35,7 @@ alter table public.contact_attempts enable row level security;
 
 -- Any authenticated user may record a contact attempt (audit log).
 -- RLS still scopes what they can read back.
-create policy if not exists "Contact attempts are insertable by everyone"
+create policy "Contact attempts are insertable by everyone"
   on public.contact_attempts for insert
   to authenticated
   with check (auth.uid() is not null);
@@ -43,12 +43,12 @@ create policy if not exists "Contact attempts are insertable by everyone"
 -- Only the attempt's own target relationship is visible — for now, admins
 -- have full read access and no per-user read policy is needed beyond admin.
 -- (Buyer read-back of "my contact attempts" is a future enhancement.)
-create policy if not exists "Contact attempts are readable by admins"
+create policy "Contact attempts are readable by admins"
   on public.contact_attempts for select
   to authenticated
   using (public.is_admin());
 
-create policy if not exists "Contact attempts are manageable by admins"
+create policy "Contact attempts are manageable by admins"
   on public.contact_attempts for all
   to authenticated
   using (public.is_admin())

--- a/web/supabase/seed.sql
+++ b/web/supabase/seed.sql
@@ -147,7 +147,7 @@ begin
   values
     (seller_phone, 'phone', 'verified', admin_id, 'Demo phone verification.'),
     (seller_fayda, 'fayda', 'verified', admin_id, 'Demo Fayda placeholder verification.')
-  on conflict on constraint verifications_one_active_per_type do nothing;
+  on conflict (user_id, type) where status in ('pending', 'verified') and deleted_at is null do nothing;
 
   -- One published listing per seller so listing cards render the badge set.
   -- The image_url is a local illustration stand-in for demo only.
@@ -346,8 +346,7 @@ begin
      'Folding ironing board with adjustable height plus a steam iron. Board padding is worn but fully functional.', 2500, 'Fair', false, 'Bole', 14),
     (67, seller_phone, 'home-appliances', '16-inch stand fan',
      '16-inch oscillating stand fan, 3 speeds, remote control. Sealed in box, never opened.', 2800, 'Brand New', false, 'Merkato', 3)
-  ) as t(k int, seller_id uuid, category_slug text, title text, description text,
-        price numeric, condition public.listing_condition, negotiable boolean, sub_city text, age_days int)
+  ) as t(k, seller_id, category_slug, title, description, price, condition, negotiable, sub_city, age_days)
   loop
     insert into public.listings (id, seller_id, category_id, title, description, price,
                                  condition, negotiable, city, sub_city, status, published_at)
@@ -355,7 +354,7 @@ begin
       ('20000000-0000-0000-0000-' || lpad(rec.k::text, 12, '0'))::uuid,
       rec.seller_id,
       (select id from public.categories where slug = rec.category_slug limit 1),
-      rec.title, rec.description, rec.price, rec.condition, rec.negotiable,
+      rec.title, rec.description, rec.price, rec.condition::public.listing_condition, rec.negotiable,
       'Addis Ababa', rec.sub_city, 'published',
       now() - make_interval(days => rec.age_days)
     )


### PR DESCRIPTION
﻿## What

Fixes the Supabase local stack, which never ran against a real Postgres before. `supabase start` failed on a cascade of latent SQL bugs in the migrations/seed. After the fixes the stack boots healthy, the seed loads, and the app serves the seeded catalog.

## Fixes

**Migrations (`web/supabase/migrations/`)**
- Removed invalid `if not exists` from `CREATE POLICY` / `CREATE TYPE` / `CREATE TRIGGER` and `ADD CONSTRAINT` (not supported in Postgres).
- Removed unsupported column-level `columns (phone)` policies; phone exposure stays gated at the data-access layer as the migration header already documented.
- Ordered `USING` before `WITH CHECK` in storage `for all` policies (grammar requires it).
- Renumbered colliding migration versions so `schema_migrations` keys are unique: reports `20260813120000` → `20260813130000`, contact_attempts `20260814000000` → `20260814010000`.
- Moved required `submit_report` arg before the defaulted params (fixes `42P13`).
- `search_listings` redefinition in T12 now `drop function` first (its return type changed, `create or replace` can't do that).

**Seed (`web/supabase/seed.sql`)**
- Target the partial unique index with `ON CONFLICT (user_id, type) WHERE ...` instead of the invalid `ON CONFLICT ON CONSTRAINT`.
- Use a name-only `VALUES` column list with an explicit `::public.listing_condition` cast at insert (types are invalid in a `VALUES` alias list).

**Config (`web/supabase/config.toml`)**
- Disabled `analytics` / `realtime` / `studio` / `edge_runtime` so the stack passes healthchecks on a 4 GB Docker VM. The app doesn't use these services.

**Other**
- `web/next.config.ts`: note that `localhost` is allowed for dev HMR by default (the previously added LAN IP entry was removed).

## Verification

- `supabase start` → all containers healthy.
- Seed: 70 listings (64 published), 6 offers, 6 reviews, 5 demo accounts.
- App serves `/` (200), `/search` (200, renders seeded listings + sellers), `/login` (200).

## Notes

- `.env.local` is gitignored and was created locally from the `supabase start` output; not committed.