### PR TITLE
feat(payments): Chapa sandbox offer-transaction demo + payment recovery (stretch, #97)

### DIFF
--- a/docs/02-architecture/03-database-design-specification.md
+++ b/docs/02-architecture/03-database-design-specification.md
@@ -450,7 +450,9 @@ direct-payment ledger for accepted offers (test-mode only, out of MVP billing
 scope). See `web/supabase/migrations/20260817000000_create_payments.sql`; it
 adds the `payments` table and `begin/complete/fail_payment` +
 `confirm_payment_receipt` RPCs without touching the existing tables listed
-above.
+above. A follow-up `20260818000000_payment_recovery.sql` adds the
+seller-initiated `abandon_sale` RPC and stale-pending expiry so a stuck sale
+can be reopened.
 
 # 25. Summary
 

--- a/docs/02-architecture/03-database-design-specification.md
+++ b/docs/02-architecture/03-database-design-specification.md
@@ -445,6 +445,13 @@ The schema is designed to support:
 
 without breaking existing tables.
 
+**Implemented as a #97 demo exception:** `payments` — the Chapa sandbox
+direct-payment ledger for accepted offers (test-mode only, out of MVP billing
+scope). See `web/supabase/migrations/20260817000000_create_payments.sql`; it
+adds the `payments` table and `begin/complete/fail_payment` +
+`confirm_payment_receipt` RPCs without touching the existing tables listed
+above.
+
 # 25. Summary
 
 This database design provides a normalized, scalable, and secure foundation for the marketplace.

--- a/web/.env.example
+++ b/web/.env.example
@@ -19,3 +19,8 @@ FAYDA_MOCK=true
 # Real integration (partner onboarding): the RSA private JWK from partner.fayda.et.
 # Leave blank in dev — the mock path is used when FAYDA_MOCK=true.
 # FAYDA_CLIENT_PRIVATE_JWK=
+
+# Chapa sandbox payments (#97 demo to judges). Register a free test account at
+# dashboard.chapa.co, then use your test secret key (CHASECK_TEST-...).
+# CHAPA_SECRET_KEY=
+# CHAPA_DEMO_FALLBACK=true  # simulate payments offline, no network or account

--- a/web/app/(site)/offers/page.tsx
+++ b/web/app/(site)/offers/page.tsx
@@ -34,19 +34,33 @@ export default async function OffersPage({
   const params = await searchParams
   const offset = parseOffset(params.offset)
 
-  // #97 — the buyer returns here from Chapa's hosted checkout with the tx_ref
-  // in the URL. Verify server-side FIRST (fulfillment gated on test-mode
-  // success) so the offer list below — fetched after — reads the payment row
-  // as paid and shows the confirm-receipt step on the very first return. The
-  // banner reinforces the result. Idempotent on refresh.
-  const verifyResult =
-    typeof params.tx_ref === "string" && typeof params.offer === "string"
-      ? await verifyOfferPayment({ offerId: params.offer, txRef: params.tx_ref })
-      : null
-
   const { offers, hasMore, error } = await fetchBuyerOffers(user.id, {
     offset,
   })
+
+  // #97 — the buyer returns here from Chapa's hosted checkout with the tx_ref
+  // in the URL. The /payments/callback route already verified server-side, so
+  // by the time we render the row is terminal (paid/failed): banner from the
+  // embedded row, no second Chapa call (coding standard §20). The verify below
+  // only runs as the resume fallback when the callback was skipped (direct hit
+  // on a return URL with a still-pending payment).
+  let verifyResult: { ok: true; amount: number } | { ok: false; error: string } | null = null
+  if (typeof params.tx_ref === "string" && typeof params.offer === "string") {
+    const row = offers.find((o) => o.id === params.offer)?.payment
+    if (!row || row.status === "pending") {
+      const result = await verifyOfferPayment({
+        offerId: params.offer,
+        txRef: params.tx_ref,
+      })
+      verifyResult = result.ok
+        ? { ok: true, amount: result.amount }
+        : { ok: false, error: result.error }
+    } else if (row.status === "paid") {
+      verifyResult = { ok: true, amount: row.amount }
+    } else {
+      verifyResult = { ok: false, error: "Payment not completed" }
+    }
+  }
 
   let body: ReactNode
   if (error) {

--- a/web/app/(site)/offers/page.tsx
+++ b/web/app/(site)/offers/page.tsx
@@ -6,11 +6,13 @@ import { SendIcon } from "lucide-react"
 
 import { requireUser } from "@/lib/auth"
 import { fetchBuyerOffers } from "@/lib/offers"
+import { verifyOfferPayment } from "@/lib/payments"
 import { formatPrice } from "@/lib/listings"
 import { nextOffset, parseOffset } from "@/lib/pagination"
 import { formatShortDate } from "@/lib/utils"
 import { OfferStatusBadge } from "@/components/offers/offer-status-badge"
 import { BuyerOfferActions } from "@/components/offers/buyer-offer-actions"
+import { BuyerPayment } from "@/components/offers/buyer-payment"
 import { ReviewForm } from "@/components/reviews/review-form"
 import { ReviewStars } from "@/components/reviews/review-stars"
 import { Button } from "@/components/ui/button"
@@ -29,7 +31,19 @@ export default async function OffersPage({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const user = await requireUser()
-  const offset = parseOffset((await searchParams).offset)
+  const params = await searchParams
+  const offset = parseOffset(params.offset)
+
+  // #97 — the buyer returns here from Chapa's hosted checkout with the tx_ref
+  // in the URL. Verify server-side FIRST (fulfillment gated on test-mode
+  // success) so the offer list below — fetched after — reads the payment row
+  // as paid and shows the confirm-receipt step on the very first return. The
+  // banner reinforces the result. Idempotent on refresh.
+  const verifyResult =
+    typeof params.tx_ref === "string" && typeof params.offer === "string"
+      ? await verifyOfferPayment({ offerId: params.offer, txRef: params.tx_ref })
+      : null
+
   const { offers, hasMore, error } = await fetchBuyerOffers(user.id, {
     offset,
   })
@@ -60,6 +74,28 @@ export default async function OffersPage({
   } else {
     body = (
       <>
+        {verifyResult ? (
+          verifyResult.ok ? (
+            <div className="mb-6 rounded-md border border-green-200 bg-green-50 p-4 text-sm text-green-800">
+              <p className="font-medium">
+                Payment received —{" "}
+                {formatPrice(verifyResult.amount, { maxFractionDigits: 2 })}
+              </p>
+              <p className="mt-1">
+                Confirm receipt below once you have the item to close the deal.
+              </p>
+            </div>
+          ) : (
+            <div className="mb-6 rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+              <p className="font-medium">Payment not completed</p>
+              <p className="mt-1">
+                {verifyResult.error} You can try the payment again on the offer
+                below.
+              </p>
+            </div>
+          )
+        ) : null}
+
         <ul className="flex flex-col gap-4">
           {offers.map((offer) => (
             <li key={offer.id}>
@@ -124,21 +160,24 @@ export default async function OffersPage({
                   ) : null}
 
                   {offer.status === "accepted" ? (
-                    <div className="mt-4 border-t pt-3">
-                      {offer.review ? (
-                        <div className="flex items-center gap-2">
-                          <ReviewStars rating={offer.review.rating} />
-                          <span className="text-sm text-muted-foreground">
-                            You rated this transaction {offer.review.rating}/5
-                          </span>
-                        </div>
-                      ) : (
-                        <ReviewForm
-                          offerId={offer.id}
-                          listingTitle={offer.listing?.title}
-                        />
-                      )}
-                    </div>
+                    <>
+                      <BuyerPayment offer={offer} />
+                      <div className="mt-4 border-t pt-3">
+                        {offer.review ? (
+                          <div className="flex items-center gap-2">
+                            <ReviewStars rating={offer.review.rating} />
+                            <span className="text-sm text-muted-foreground">
+                              You rated this transaction {offer.review.rating}/5
+                            </span>
+                          </div>
+                        ) : (
+                          <ReviewForm
+                            offerId={offer.id}
+                            listingTitle={offer.listing?.title}
+                          />
+                        )}
+                      </div>
+                    </>
                   ) : null}
                 </CardContent>
               </Card>

--- a/web/app/(site)/offers/seller/page.tsx
+++ b/web/app/(site)/offers/seller/page.tsx
@@ -11,6 +11,7 @@ import { formatShortDate, initials } from "@/lib/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { OfferStatusBadge } from "@/components/offers/offer-status-badge"
 import { SellerOfferActions } from "@/components/offers/seller-offer-actions"
+import { SellerPaymentBadge } from "@/components/offers/seller-payment-badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -117,6 +118,7 @@ export default async function SellerOffersPage({
                   </div>
 
                   <div className="mt-4 border-t pt-3">
+                    <SellerPaymentBadge offer={offer} />
                     <SellerOfferActions offer={offer} />
                   </div>
                 </CardContent>

--- a/web/app/actions/offers.ts
+++ b/web/app/actions/offers.ts
@@ -9,6 +9,7 @@ import {
   counterOfferRow,
   declineOfferRow,
   submitOfferRow,
+  abandonSaleRow,
   OFFER_AMOUNT_MAX,
   OFFER_MESSAGE_MAX,
 } from "@/lib/offers"
@@ -118,6 +119,44 @@ export async function offerAction(
 
   if (!result.ok) {
     return { message: result.error ?? "Could not update the offer" }
+  }
+
+  revalidatePath(`/listings/${parsed.data.listingId}`)
+  revalidatePath("/offers")
+  revalidatePath("/offers/seller")
+  return { ok: true }
+}
+
+const abandonSaleSchema = z.object({
+  offerId: z.string().uuid(),
+  listingId: z.string().uuid(),
+})
+
+export type AbandonSaleState = {
+  message?: string
+  ok?: boolean
+}
+
+// The seller's recovery path: cancel an accepted sale that never got paid,
+// reopening the listing to the market (RPC-guarded on no paid payment having
+// landed). Shown on accepted offers with no paid payment once the buyer has
+// had time to complete the checkout.
+export async function abandonSaleAction(
+  _prevState: AbandonSaleState,
+  formData: FormData
+): Promise<AbandonSaleState> {
+  const parsed = abandonSaleSchema.safeParse({
+    offerId: formValue(formData, "offerId"),
+    listingId: formValue(formData, "listingId"),
+  })
+  if (!parsed.success) {
+    return { message: "Invalid request" }
+  }
+
+  await requireUser()
+  const result = await abandonSaleRow(parsed.data.offerId)
+  if (!result.ok) {
+    return { message: result.error ?? "Could not cancel the sale" }
   }
 
   revalidatePath(`/listings/${parsed.data.listingId}`)

--- a/web/app/actions/offers.ts
+++ b/web/app/actions/offers.ts
@@ -153,7 +153,7 @@ export async function abandonSaleAction(
     return { message: "Invalid request" }
   }
 
-  await requireUser()
+  await requireTrader()
   const result = await abandonSaleRow(parsed.data.offerId)
   if (!result.ok) {
     return { message: result.error ?? "Could not cancel the sale" }

--- a/web/app/actions/payments.ts
+++ b/web/app/actions/payments.ts
@@ -1,0 +1,73 @@
+"use server"
+
+import { z } from "zod"
+import { revalidatePath } from "next/cache"
+
+import { confirmOfferReceipt, payOffer } from "@/lib/payments"
+
+function formValue(formData: FormData, key: string): string | undefined {
+  const v = formData.get(key)
+  return typeof v === "string" && v.length > 0 ? v : undefined
+}
+
+const offerIdSchema = z.object({
+  offerId: z.string().uuid(),
+})
+
+export type PayOfferState = {
+  message?: string
+  checkoutUrl?: string
+  ok?: boolean
+}
+
+// #97 — the buyer starts payment for an accepted offer. On success the client
+// component redirects to Chapa's hosted checkout via the returned checkoutUrl.
+export async function payOfferAction(
+  _prevState: PayOfferState,
+  formData: FormData
+): Promise<PayOfferState> {
+  const parsed = offerIdSchema.safeParse({
+    offerId: formValue(formData, "offerId"),
+  })
+  if (!parsed.success) {
+    return { message: "Invalid request" }
+  }
+
+  const result = await payOffer(parsed.data.offerId)
+  if (!result.ok) {
+    return { message: result.error }
+  }
+
+  return {
+    ok: true,
+    checkoutUrl: result.checkoutUrl,
+  }
+}
+
+export type ConfirmReceiptState = {
+  message?: string
+  ok?: boolean
+}
+
+// #97 — the buyer-protection signal: the buyer confirms they received the item
+// after payment, closing the deal for both parties.
+export async function confirmReceiptAction(
+  _prevState: ConfirmReceiptState,
+  formData: FormData
+): Promise<ConfirmReceiptState> {
+  const parsed = offerIdSchema.safeParse({
+    offerId: formValue(formData, "offerId"),
+  })
+  if (!parsed.success) {
+    return { message: "Invalid request" }
+  }
+
+  const result = await confirmOfferReceipt(parsed.data.offerId)
+  if (!result.ok) {
+    return { message: result.error ?? "Could not confirm receipt" }
+  }
+
+  revalidatePath("/offers")
+  revalidatePath("/offers/seller")
+  return { ok: true }
+}

--- a/web/app/payments/callback/route.ts
+++ b/web/app/payments/callback/route.ts
@@ -23,7 +23,13 @@ export async function GET(request: Request): Promise<Response> {
 
   // Verify, then bounce to the offer list with the same params the page's own
   // verify-on-render reads — the banner is rendered there (idempotent refresh).
-  await verifyOfferPayment({ offerId, txRef })
+  const result = await verifyOfferPayment({ offerId, txRef })
+
+  if (!result.ok) {
+    // §11: the page banners the failure via the terminal row; the technical
+    // detail belongs in the server log, never in the redirect URL.
+    console.error("[payments] callback verify failed:", result.error)
+  }
 
   const dest = new URL("/offers", url.origin)
   dest.searchParams.set("offer", offerId)

--- a/web/app/payments/callback/route.ts
+++ b/web/app/payments/callback/route.ts
@@ -1,0 +1,32 @@
+import "server-only"
+
+import { NextResponse } from "next/server"
+
+import { verifyOfferPayment } from "@/lib/payments"
+
+export const dynamic = "force-dynamic"
+
+// The provider callback / return target for Chapa checkout (#97). This is the
+// PRIMARY verify trigger: the buyer lands here from Chapa's hosted checkout (or
+// the demo fallback) and the payment is verified server-side before they see
+// anything else. The /offers page keeps its own verify-on-render as an
+// idempotent resume fallback for the case where this route was skipped (e.g. a
+// refreshed return URL), so a verification can never be lost to a dropped tab.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  const txRef = url.searchParams.get("tx_ref")
+  const offerId = url.searchParams.get("offer")
+
+  if (!txRef || !offerId) {
+    return NextResponse.redirect(new URL("/offers", url.origin), { status: 303 })
+  }
+
+  // Verify, then bounce to the offer list with the same params the page's own
+  // verify-on-render reads — the banner is rendered there (idempotent refresh).
+  await verifyOfferPayment({ offerId, txRef })
+
+  const dest = new URL("/offers", url.origin)
+  dest.searchParams.set("offer", offerId)
+  dest.searchParams.set("tx_ref", txRef)
+  return NextResponse.redirect(dest, { status: 303 })
+}

--- a/web/components/offers/buyer-payment.tsx
+++ b/web/components/offers/buyer-payment.tsx
@@ -85,7 +85,7 @@ export function BuyerPayment({ offer }: { offer: BuyerOfferRow }) {
           <input type="hidden" name="offerId" value={offer.id} />
           <Button type="submit" disabled={payPending}>
             <CreditCardIcon className="size-4" />
-            {offer.payment?.status === "pending" ? "Retry payment" : "Pay"}{" "}
+            {offer.payment?.status === "failed" ? "Retry payment" : "Pay"}{" "}
             {formatPrice(amount, { maxFractionDigits: 2 })} with Chapa
           </Button>
           <p className="text-xs text-muted-foreground">

--- a/web/components/offers/buyer-payment.tsx
+++ b/web/components/offers/buyer-payment.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useActionState } from "react"
+import { CheckCircle2Icon, CreditCardIcon } from "lucide-react"
+
+import { confirmReceiptAction, payOfferAction } from "@/app/actions/payments"
+import type { BuyerOfferRow } from "@/lib/offers"
+import { formatPrice } from "@/lib/listings/constants"
+import { paymentPhase } from "@/lib/payments/constants"
+import { Button } from "@/components/ui/button"
+
+// #97 — the buyer's payment surface on an accepted offer. Starts the Chapa
+// sandbox checkout (redirecting on success) and, once paid, the buyer-confirm
+// step that closes the deal. States: not started / pending+failed (pay again)
+// / paid (confirm receipt) / confirmed (closed).
+export function BuyerPayment({ offer }: { offer: BuyerOfferRow }) {
+  const [payState, payFormAction, payPending] = useActionState(payOfferAction, {})
+  const [confirmState, confirmFormAction, confirmPending] = useActionState(
+    confirmReceiptAction,
+    {}
+  )
+
+  const redirected = useRef(false)
+  useEffect(() => {
+    if (payState.ok && payState.checkoutUrl && !redirected.current) {
+      redirected.current = true
+      window.location.assign(payState.checkoutUrl)
+    }
+  }, [payState])
+
+  if (offer.status !== "accepted") return null
+
+  const phase = paymentPhase(offer.payment)
+  const amount = offer.payment?.amount ?? offer.amount
+
+  if (phase === "confirmed") {
+    return (
+      <div className="mt-4 border-t pt-3">
+        <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+          <CheckCircle2Icon className="size-4" />
+          Paid {formatPrice(amount, { maxFractionDigits: 2 })} — you confirmed
+          receipt. Deal closed.
+        </p>
+      </div>
+    )
+  }
+
+  if (phase === "paid") {
+    return (
+      <div className="mt-4 border-t pt-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+            <CheckCircle2Icon className="size-4" />
+            Paid {formatPrice(amount, { maxFractionDigits: 2 })}
+          </p>
+          <form action={confirmFormAction}>
+            <input type="hidden" name="offerId" value={offer.id} />
+            <Button
+              type="submit"
+              variant="outline"
+              size="sm"
+              disabled={confirmPending}
+            >
+              Confirm receipt
+            </Button>
+            {confirmState.message ? (
+              <p role="alert" className="mt-2 text-sm text-destructive">
+                {confirmState.message}
+              </p>
+            ) : null}
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  // Unpaid: no payment begun yet, or a pending/failed attempt that can be retried.
+  return (
+    <div className="mt-4 border-t pt-3">
+      {payPending ? (
+        <p className="text-sm text-muted-foreground">Opening Chapa checkout…</p>
+      ) : (
+        <form action={payFormAction} className="flex flex-wrap items-center gap-3">
+          <input type="hidden" name="offerId" value={offer.id} />
+          <Button type="submit" disabled={payPending}>
+            <CreditCardIcon className="size-4" />
+            {offer.payment?.status === "pending" ? "Retry payment" : "Pay"}{" "}
+            {formatPrice(amount, { maxFractionDigits: 2 })} with Chapa
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Sandbox demo — pay with Chapa&apos;s test card (Visa 4200 0000 0000
+            0000, CVV 123, expiry 12/34).
+          </p>
+          {payState.message ? (
+            <p role="alert" className="w-full text-sm text-destructive">
+              {payState.message}
+            </p>
+          ) : null}
+        </form>
+      )}
+    </div>
+  )
+}

--- a/web/components/offers/seller-offer-actions.tsx
+++ b/web/components/offers/seller-offer-actions.tsx
@@ -63,11 +63,9 @@ export function SellerOfferActions({ offer }: { offer: SellerOfferRow }) {
       <p className="text-sm text-muted-foreground">
         {offer.status === "countered"
           ? "Countered — waiting for the buyer to respond."
-          : offer.status === "accepted"
-            ? "Accepted — the listing is now sold."
-            : offer.status === "expired"
-              ? "Expired — the offer lapsed and is no longer open."
-              : "Declined."}
+          : offer.status === "expired"
+            ? "Expired — the offer lapsed and is no longer open."
+            : "Declined."}
       </p>
     )
   }

--- a/web/components/offers/seller-offer-actions.tsx
+++ b/web/components/offers/seller-offer-actions.tsx
@@ -22,13 +22,19 @@ export function SellerOfferActions({ offer }: { offer: SellerOfferRow }) {
   // sale can be walked back. If the buyer never completes the checkout, the
   // seller can cancel the sale and reopen the listing to the market.
   if (offer.status === "accepted") {
-    const unpaid = paymentPhase(offer.payment) === "unpaid"
+    const phase = paymentPhase(offer.payment)
+    const canCancel = phase === "unpaid" && offer.payment?.status !== "pending"
     return (
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">
           Accepted — the listing is now sold.
         </p>
-        {unpaid ? (
+        {phase === "unpaid" && offer.payment?.status === "pending" ? (
+          <p className="text-sm text-muted-foreground">
+            The buyer is completing their payment.
+          </p>
+        ) : null}
+        {canCancel ? (
           <form action={abandonFormAction} className="flex flex-wrap items-center gap-2">
             <input type="hidden" name="offerId" value={offer.id} />
             <input type="hidden" name="listingId" value={offer.listing_id} />

--- a/web/components/offers/seller-offer-actions.tsx
+++ b/web/components/offers/seller-offer-actions.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react"
 import { useActionState } from "react"
 
-import { offerAction } from "@/app/actions/offers"
+import { offerAction, abandonSaleAction } from "@/app/actions/offers"
 import type { SellerOfferRow } from "@/lib/offers"
+import { paymentPhase } from "@/lib/payments/constants"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -12,6 +13,43 @@ import { Label } from "@/components/ui/label"
 export function SellerOfferActions({ offer }: { offer: SellerOfferRow }) {
   const [countering, setCountering] = useState(false)
   const [state, formAction, pending] = useActionState(offerAction, {})
+  const [abandonState, abandonFormAction, abandonPending] = useActionState(
+    abandonSaleAction,
+    {}
+  )
+
+  // Accepted offers: the listing is sold, but until money actually lands the
+  // sale can be walked back. If the buyer never completes the checkout, the
+  // seller can cancel the sale and reopen the listing to the market.
+  if (offer.status === "accepted") {
+    const unpaid = paymentPhase(offer.payment) === "unpaid"
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          Accepted — the listing is now sold.
+        </p>
+        {unpaid ? (
+          <form action={abandonFormAction} className="flex flex-wrap items-center gap-2">
+            <input type="hidden" name="offerId" value={offer.id} />
+            <input type="hidden" name="listingId" value={offer.listing_id} />
+            <Button
+              type="submit"
+              variant="ghost"
+              size="sm"
+              disabled={abandonPending}
+            >
+              Cancel sale and relist
+            </Button>
+            {abandonState.message ? (
+              <p role="alert" className="text-sm text-destructive">
+                {abandonState.message}
+              </p>
+            ) : null}
+          </form>
+        ) : null}
+      </div>
+    )
+  }
 
   // Settled offers need no actions; the badge on the card carries the state.
   if (offer.status !== "pending") {

--- a/web/components/offers/seller-payment-badge.tsx
+++ b/web/components/offers/seller-payment-badge.tsx
@@ -1,0 +1,25 @@
+import { CheckCircle2Icon } from "lucide-react"
+
+import type { SellerOfferRow } from "@/lib/offers"
+import { formatPrice } from "@/lib/listings/constants"
+import { paymentPhase } from "@/lib/payments/constants"
+
+// #97 — the paid-deal indicator on the seller's accepted offers. The buyer's
+// payment row is embedded on the offer fetch (RLS allows the seller to read
+// it); this surfaces the money moving (in Chapa test mode) at the deal.
+export function SellerPaymentBadge({ offer }: { offer: SellerOfferRow }) {
+  if (offer.status !== "accepted") return null
+
+  const phase = paymentPhase(offer.payment)
+  if (phase === "unpaid") return null
+
+  return (
+    <p className="flex items-center gap-2 text-sm font-medium text-green-700">
+      <CheckCircle2Icon className="size-4" />
+      Paid {formatPrice(offer.payment?.amount ?? offer.amount, { maxFractionDigits: 2 })}
+      {phase === "confirmed"
+        ? " — buyer confirmed receipt. Deal closed."
+        : " — awaiting buyer confirmation."}
+    </p>
+  )
+}

--- a/web/lib/chapa/index.ts
+++ b/web/lib/chapa/index.ts
@@ -1,0 +1,193 @@
+import "server-only"
+
+// Chapa sandbox payment seam (#97). Server-only: the secret key is read from
+// env per call and never leaves this module — no client component or action
+// ever receives it. The researched flow (initialize -> hosted checkout ->
+// verify, test cards, caveats) is captured in #97 and in
+// docs/agents/research/chapa-sandbox-payments.md on the research/chapa-sandbox
+// branch.
+//
+// Demo fallback (#97 AC): with CHAPA_DEMO_FALLBACK=true the initialize step
+// short-circuits straight to the return URL and verify simulates a success, so
+// the full state machine can be shown to judges with no network or account.
+// Simulation is gated on the env flag too: a `demo_` tx_ref only simulates
+// while the fallback is on, and never hits the real API either way.
+
+const CHAPA_BASE_URL = "https://api.chapa.co/v1"
+const CHAPA_TIMEOUT_MS = 15_000
+const DEMO_TX_PREFIX = "demo_"
+
+export type ChapaInitializeParams = {
+  txRef: string
+  amount: number
+  currency?: string
+  email: string
+  firstName?: string | null
+  lastName?: string | null
+  returnUrl: string
+}
+
+export type ChapaInitializeResult =
+  | { ok: true; checkoutUrl: string; demo: boolean }
+  | { ok: false; error: string }
+
+export type ChapaVerifyResult =
+  | {
+      ok: true
+      status: string
+      mode: string
+      amount: number
+      currency: string
+      demo: boolean
+    }
+  | { ok: false; error: string }
+
+export function chapaDemoMode(): boolean {
+  return process.env.CHAPA_DEMO_FALLBACK === "true"
+}
+
+export function isDemoTxRef(txRef: string): boolean {
+  return txRef.startsWith(DEMO_TX_PREFIX)
+}
+
+// A payment can only begin when a real key is present or the demo fallback is
+// on; without either, the pay action degrades with a safe message.
+export function chapaConfigured(): boolean {
+  return Boolean(process.env.CHAPA_SECRET_KEY) || chapaDemoMode()
+}
+
+export function chapaTxRef(): string {
+  return chapaDemoMode()
+    ? `${DEMO_TX_PREFIX}${crypto.randomUUID()}`
+    : `fm_${crypto.randomUUID()}`
+}
+
+/**
+ * Start a Chapa transaction and return the hosted checkout URL to redirect the
+ * buyer to. Every failure resolves to a safe { ok: false } result so the UI can
+ * surface a friendly message; no server-config detail ever leaks (mirrors
+ * lib/ai/listings.ts AC-3).
+ */
+export async function initializeChapaTransaction(
+  params: ChapaInitializeParams
+): Promise<ChapaInitializeResult> {
+  if (chapaDemoMode()) {
+    // No network: the "checkout" is the return page itself, which then
+    // verifies the demo tx_ref and simulates success.
+    return { ok: true, checkoutUrl: params.returnUrl, demo: true }
+  }
+
+  const secretKey = process.env.CHAPA_SECRET_KEY
+  if (!secretKey) {
+    return { ok: false, error: "Chapa is not configured" }
+  }
+
+  try {
+    const res = await fetch(`${CHAPA_BASE_URL}/transaction/initialize`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        amount: params.amount,
+        currency: params.currency ?? "ETB",
+        email: params.email,
+        first_name: params.firstName ?? "",
+        last_name: params.lastName ?? "",
+        tx_ref: params.txRef,
+        return_url: params.returnUrl,
+        customization: {
+          title: "VinTech Marketplace",
+          description: "Payment for your marketplace purchase",
+        },
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(CHAPA_TIMEOUT_MS),
+    })
+
+    if (!res.ok) {
+      return { ok: false, error: "Chapa could not start the payment" }
+    }
+
+    const json = (await res.json()) as {
+      status?: string
+      data?: { checkout_url?: string }
+    }
+    const checkoutUrl = json.data?.checkout_url
+    if (json.status !== "success" || !checkoutUrl) {
+      return { ok: false, error: "Chapa could not start the payment" }
+    }
+
+    return { ok: true, checkoutUrl, demo: false }
+  } catch {
+    return { ok: false, error: "Chapa is unreachable right now" }
+  }
+}
+
+/**
+ * Verify a transaction after the buyer returns from the hosted checkout. A
+ * `demo_` tx_ref is simulated (with the expected amount/currency so the
+ * complete_payment RPC's server-side match still holds) — but only while the
+ * demo fallback env flag is on, and never against the real API. A real tx_ref
+ * is checked against Chapa. The caller gates fulfillment on status ===
+ * "success" AND mode === "test" (AC: test-mode only).
+ */
+export async function verifyChapaTransaction(
+  txRef: string,
+  expected: { amount: number; currency: string }
+): Promise<ChapaVerifyResult> {
+  if (isDemoTxRef(txRef)) {
+    if (!chapaDemoMode()) {
+      return { ok: false, error: "Simulated payments are disabled" }
+    }
+    return {
+      ok: true,
+      status: "success",
+      mode: "test",
+      amount: expected.amount,
+      currency: expected.currency,
+      demo: true,
+    }
+  }
+
+  const secretKey = process.env.CHAPA_SECRET_KEY
+  if (!secretKey) {
+    return { ok: false, error: "Chapa is not configured" }
+  }
+
+  try {
+    const res = await fetch(
+      `${CHAPA_BASE_URL}/transaction/verify/${encodeURIComponent(txRef)}`,
+      {
+        headers: { Authorization: `Bearer ${secretKey}` },
+        cache: "no-store",
+        signal: AbortSignal.timeout(CHAPA_TIMEOUT_MS),
+      }
+    )
+
+    if (!res.ok) {
+      return { ok: false, error: "Chapa could not verify the payment" }
+    }
+
+    const json = (await res.json()) as {
+      status?: string
+      data?: { status?: string; mode?: string; amount?: number; currency?: string }
+    }
+    const data = json.data ?? {}
+    if (json.status !== "success" || !data.status) {
+      return { ok: false, error: "Chapa could not verify the payment" }
+    }
+
+    return {
+      ok: true,
+      status: String(data.status),
+      mode: String(data.mode ?? ""),
+      amount: Number(data.amount ?? 0),
+      currency: String(data.currency ?? ""),
+      demo: false,
+    }
+  } catch {
+    return { ok: false, error: "Chapa is unreachable right now" }
+  }
+}

--- a/web/lib/chapa/index.ts
+++ b/web/lib/chapa/index.ts
@@ -12,6 +12,11 @@ import "server-only"
 // the full state machine can be shown to judges with no network or account.
 // Simulation is gated on the env flag too: a `demo_` tx_ref only simulates
 // while the fallback is on, and never hits the real API either way.
+//
+// This module is the provider adapter: it knows the Chapa protocol (endpoints,
+// payloads, the success/test-mode gate) and the demo simulation policy. It does
+// NOT know the marketplace's brand or its deals — those come in through the
+// call params, so the adapter never hardcodes app policy.
 
 const CHAPA_BASE_URL = "https://api.chapa.co/v1"
 const CHAPA_TIMEOUT_MS = 15_000
@@ -25,6 +30,10 @@ export type ChapaInitializeParams = {
   firstName?: string | null
   lastName?: string | null
   returnUrl: string
+  // Checkout page branding — supplied by the caller (the payments seam owns the
+  // app's voice; the adapter only forwards it to Chapa).
+  title?: string
+  description?: string
 }
 
 export type ChapaInitializeResult =
@@ -34,8 +43,8 @@ export type ChapaInitializeResult =
 export type ChapaVerifyResult =
   | {
       ok: true
-      status: string
-      mode: string
+      status: "success"
+      mode: "test"
       amount: number
       currency: string
       demo: boolean
@@ -98,8 +107,8 @@ export async function initializeChapaTransaction(
         tx_ref: params.txRef,
         return_url: params.returnUrl,
         customization: {
-          title: "VinTech Marketplace",
-          description: "Payment for your marketplace purchase",
+          title: params.title ?? "Payment",
+          description: params.description ?? "",
         },
       }),
       cache: "no-store",
@@ -126,12 +135,16 @@ export async function initializeChapaTransaction(
 }
 
 /**
- * Verify a transaction after the buyer returns from the hosted checkout. A
- * `demo_` tx_ref is simulated (with the expected amount/currency so the
- * complete_payment RPC's server-side match still holds) — but only while the
- * demo fallback env flag is on, and never against the real API. A real tx_ref
- * is checked against Chapa. The caller gates fulfillment on status ===
- * "success" AND mode === "test" (AC: test-mode only).
+ * Verify a transaction after the buyer returns from the hosted checkout (or,
+ * in demo fallback mode, immediately). A `demo_` tx_ref is simulated (with the
+ * expected amount/currency so the complete_payment RPC's server-side match
+ * still holds) — but only while the demo fallback env flag is on, and never
+ * against the real API. A real tx_ref is checked against Chapa.
+ *
+ * The fulfillment gate lives HERE, in the adapter: a payment only counts as
+ * confirmed when Chapa reports status "success" AND mode "test" (AC: test-mode
+ * only). The caller can no longer forget this check — if the adapter returns
+ * ok, the payment is fulfillable.
  */
 export async function verifyChapaTransaction(
   txRef: string,
@@ -179,12 +192,23 @@ export async function verifyChapaTransaction(
       return { ok: false, error: "Chapa could not verify the payment" }
     }
 
+    const status = String(data.status)
+    const mode = String(data.mode ?? "")
+    const amount = Number(data.amount ?? 0)
+    const currency = String(data.currency ?? "")
+
+    // Fulfillment gate: only Chapa test-mode success counts. Anything else is
+    // a failed attempt the caller can mark failed and retry.
+    if (status !== "success" || mode !== "test") {
+      return { ok: false, error: "Payment was not completed in test mode" }
+    }
+
     return {
       ok: true,
-      status: String(data.status),
-      mode: String(data.mode ?? ""),
-      amount: Number(data.amount ?? 0),
-      currency: String(data.currency ?? ""),
+      status,
+      mode,
+      amount,
+      currency,
       demo: false,
     }
   } catch {

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -10,6 +10,10 @@ import {
   OPEN_OFFER_STATUSES,
   type OfferStatus,
 } from "@/lib/offers/constants"
+import {
+  type OfferPayment,
+  pickPayment,
+} from "@/lib/payments/constants"
 
 export * from "@/lib/offers/constants"
 
@@ -21,12 +25,14 @@ export interface BuyerOfferRow {
   amount: number
   message: string | null
   status: OfferStatus
-   created_at: string
-   expires_at: string | null
-   listing: BrowseListing | null
-   // The review on this offer, if the buyer has already rated the seller (T10).
-   review: { id: string; rating: number } | null
- }
+  created_at: string
+  expires_at: string | null
+  listing: BrowseListing | null
+  // The review on this offer, if the buyer has already rated the seller (T10).
+  review: { id: string; rating: number } | null
+  // The payment on this offer (#97); null until a payment is begun.
+  payment: OfferPayment | null
+}
 
 export interface SellerOfferRow extends BuyerOfferRow {
   buyer: {
@@ -79,6 +85,7 @@ function mapRawOfferRow(
     listing: RawOfferListingRow | null
     buyer?: { id: string; full_name: string | null; avatar_url: string | null } | null
     review?: { id: string; rating: number } | null
+    payment?: OfferPayment[] | null
   },
   withBuyer: boolean
 ): SellerOfferRow {
@@ -92,6 +99,7 @@ function mapRawOfferRow(
     expires_at: row.expires_at,
     listing: mapOfferListing(row.listing),
     review: row.review ?? null,
+    payment: pickPayment(row.payment),
     buyer: withBuyer ? (row.buyer ?? null) : null,
   }
 }
@@ -131,7 +139,8 @@ export async function fetchBuyerOffers(
       `${OFFER_COLUMNS},
        listing:listings(id, title, price, condition, city, published_at,
          images:listing_images(id, image_url, display_order)),
-       review:reviews(id, rating)`,
+review:reviews(id, rating),
+       payment:payments(id, amount, currency, status, mode, buyer_confirmed, paid_at, confirmed_at)`,
       { count: "exact" }
     )
     .eq("buyer_id", userId)
@@ -153,6 +162,7 @@ export async function fetchBuyerOffers(
     expires_at: string | null
     listing: RawOfferListingRow | null
     review: { id: string; rating: number } | null
+    payment: OfferPayment[] | null
   }[]
 
   const mapped = offers.map((row) => mapRawOfferRow(row, false))
@@ -178,7 +188,8 @@ export async function fetchSellerOffers(
        listing:listings(id, title, price, condition, city, published_at,
          seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url, role, trust_score),
          images:listing_images(id, image_url, display_order)),
-       buyer:profiles(id, full_name, avatar_url)`,
+buyer:profiles(id, full_name, avatar_url),
+       payment:payments(id, amount, currency, status, mode, buyer_confirmed, paid_at, confirmed_at)`,
       { count: "exact" }
     )
     .eq("listing.seller_id", userId)
@@ -200,6 +211,7 @@ export async function fetchSellerOffers(
     expires_at: string | null
     listing: RawOfferListingRow | null
     buyer: { id: string; full_name: string | null; avatar_url: string | null } | null
+    payment: OfferPayment[] | null
   }[]
 
   const mapped = offers.map((row) => mapRawOfferRow(row, true))

--- a/web/lib/offers.ts
+++ b/web/lib/offers.ts
@@ -303,3 +303,19 @@ export async function counterOfferRow(
   )
   return { ok: result.ok === true, error: result.error ?? null }
 }
+
+// The seller's recovery path after an accepted offer never gets paid: fails any
+// pending payment attempts, declines the offer, and reopens the listing to the
+// market (RPC-guarded on no paid payment having landed). This is what keeps the
+// "listing sold at accept" state machine from stranding a listing forever when
+// the buyer abandons the checkout (#97 / payment recovery migration).
+export async function abandonSaleRow(offerId: string): Promise<OfferResult> {
+  const supabase = await createClient()
+  const result = await callOutcomeRpc(
+    supabase,
+    "abandon_sale",
+    { p_offer_id: offerId },
+    "abandonSaleRow"
+  )
+  return { ok: result.ok === true, error: result.error ?? null }
+}

--- a/web/lib/payments.ts
+++ b/web/lib/payments.ts
@@ -16,7 +16,7 @@ import {
 import { etb } from "@/lib/payments/constants"
 
 export type PayOfferResult =
-  | { ok: true; checkoutUrl: string; amount: number; demo: boolean }
+  | { ok: true; checkoutUrl: string }
   | { ok: false; error: string }
 
 export type VerifyOfferPaymentResult =
@@ -97,8 +97,6 @@ export async function payOffer(offerId: string): Promise<PayOfferResult> {
   return {
     ok: true,
     checkoutUrl: init.checkoutUrl,
-    amount: offer.amount,
-    demo: init.demo,
   }
 }
 

--- a/web/lib/payments.ts
+++ b/web/lib/payments.ts
@@ -13,9 +13,7 @@ import {
   initializeChapaTransaction,
   verifyChapaTransaction,
 } from "@/lib/chapa"
-import { PAYMENT_CURRENCY } from "@/lib/payments/constants"
-
-export * from "@/lib/payments/constants"
+import { etb } from "@/lib/payments/constants"
 
 export type PayOfferResult =
   | { ok: true; checkoutUrl: string; amount: number; demo: boolean }
@@ -29,15 +27,17 @@ export type VerifyOfferPaymentResult =
 export type PaymentResult = OfferResult
 
 // The buyer returns here after Chapa's hosted checkout (or, in demo fallback
-// mode, immediately). The tx_ref in the query drives the verify on the /offers
-// page, so a refresh of the return URL just re-verifies idempotently.
+// mode, immediately). The tx_ref in the query drives the verify on the
+// /payments/callback route, so a refresh of the return URL just re-verifies
+// idempotently (and the /offers page keeps the same verify-on-render as a
+// resume fallback for the case where the callback was skipped).
 async function paymentReturnUrl(offerId: string, txRef: string): Promise<string> {
   const h = await headers()
   const host = h.get("host")
   const proto =
     h.get("x-forwarded-proto") ?? (host?.startsWith("localhost") ? "http" : "https")
   const base = host ? `${proto}://${host}` : SITE_URL
-  return `${base}/offers?tx_ref=${encodeURIComponent(txRef)}&offer=${encodeURIComponent(offerId)}`
+  return `${base}/payments/callback?tx_ref=${encodeURIComponent(txRef)}&offer=${encodeURIComponent(offerId)}`
 }
 
 // The buyer starts payment for an accepted offer. Pins the agreed amount in a
@@ -67,11 +67,12 @@ export async function payOffer(offerId: string): Promise<PayOfferResult> {
   }
 
   const txRef = chapaTxRef()
+  const money = etb(offer.amount)
   const begin = await callOutcomeRpc(supabase, "begin_payment", {
     p_offer_id: offerId,
     p_tx_ref: txRef,
-    p_amount: offer.amount,
-    p_currency: PAYMENT_CURRENCY,
+    p_amount: money.amount,
+    p_currency: money.currency,
   }, "payOffer")
   if (!begin.ok) {
     return { ok: false, error: begin.error ?? "Could not start the payment" }
@@ -79,11 +80,13 @@ export async function payOffer(offerId: string): Promise<PayOfferResult> {
 
   const init = await initializeChapaTransaction({
     txRef,
-    amount: offer.amount,
-    currency: PAYMENT_CURRENCY,
+    amount: money.amount,
+    currency: money.currency,
     email: user.email,
     firstName: user.fullName,
     returnUrl: await paymentReturnUrl(offerId, txRef),
+    title: "VinTech Marketplace",
+    description: "Payment for your marketplace purchase",
   })
 
   if (!init.ok) {
@@ -100,9 +103,11 @@ export async function payOffer(offerId: string): Promise<PayOfferResult> {
 }
 
 // Server-side verify after the buyer returns from checkout. Fulfillment is
-// gated on Chapa reporting success in test mode, and the complete_payment RPC
-// re-checks the reported mode/amount/currency against the row pinned at begin
-// time. Idempotent — re-verifying an already-paid tx_ref stays successful.
+// gated inside the Chapa adapter (status === "success" AND mode === "test");
+// the complete_payment RPC re-checks the reported mode/amount/currency against
+// the row pinned at begin time. Idempotent — re-verifying an already-paid
+// tx_ref stays successful. A failed verify marks the attempt failed so
+// begin_payment allows a retry.
 export async function verifyOfferPayment(params: {
   offerId: string
   txRef: string
@@ -137,13 +142,10 @@ export async function verifyOfferPayment(params: {
   })
   if (!verified.ok) {
     // The buyer came back without a completed payment (abandoned checkout,
-    // failed card). Mark the attempt failed so begin_payment allows a retry.
+    // failed card, or a live tx not in Chapa test mode). Mark the attempt
+    // failed so begin_payment allows a retry.
     await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: params.txRef }, "verifyOfferPayment")
     return { ok: false, error: verified.error }
-  }
-  if (verified.status !== "success" || verified.mode !== "test") {
-    await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: params.txRef }, "verifyOfferPayment")
-    return { ok: false, error: "Payment was not completed in test mode" }
   }
 
   const complete = await callOutcomeRpc(supabase, "complete_payment", {

--- a/web/lib/payments.ts
+++ b/web/lib/payments.ts
@@ -1,0 +1,173 @@
+import "server-only"
+
+import { headers } from "next/headers"
+
+import { createClient } from "@/lib/supabase/server"
+import { callOutcomeRpc } from "@/lib/supabase/rpc"
+import { requireUser } from "@/lib/auth"
+import { SITE_URL } from "@/lib/site"
+import type { OfferResult } from "@/lib/offers"
+import {
+  chapaConfigured,
+  chapaTxRef,
+  initializeChapaTransaction,
+  verifyChapaTransaction,
+} from "@/lib/chapa"
+import { PAYMENT_CURRENCY } from "@/lib/payments/constants"
+
+export * from "@/lib/payments/constants"
+
+export type PayOfferResult =
+  | { ok: true; checkoutUrl: string; amount: number; demo: boolean }
+  | { ok: false; error: string }
+
+export type VerifyOfferPaymentResult =
+  | { ok: true; amount: number }
+  | { ok: false; error: string }
+
+// Same { ok, error } envelope every write-RPC caller lands on (see OfferResult).
+export type PaymentResult = OfferResult
+
+// The buyer returns here after Chapa's hosted checkout (or, in demo fallback
+// mode, immediately). The tx_ref in the query drives the verify on the /offers
+// page, so a refresh of the return URL just re-verifies idempotently.
+async function paymentReturnUrl(offerId: string, txRef: string): Promise<string> {
+  const h = await headers()
+  const host = h.get("host")
+  const proto =
+    h.get("x-forwarded-proto") ?? (host?.startsWith("localhost") ? "http" : "https")
+  const base = host ? `${proto}://${host}` : SITE_URL
+  return `${base}/offers?tx_ref=${encodeURIComponent(txRef)}&offer=${encodeURIComponent(offerId)}`
+}
+
+// The buyer starts payment for an accepted offer. Pins the agreed amount in a
+// pending payment row (begin_payment), then sends the buyer to Chapa's hosted
+// checkout. If Chapa's initialize fails, the row is marked failed so the buyer
+// can retry (begin_payment allows a new row after a failed one).
+export async function payOffer(offerId: string): Promise<PayOfferResult> {
+  const user = await requireUser()
+  const supabase = await createClient()
+
+  if (!chapaConfigured()) {
+    return { ok: false, error: "Payments are not set up for this demo yet" }
+  }
+
+  const { data: offer } = await supabase
+    .from("offers")
+    .select("id, amount, status, buyer_id")
+    .eq("id", offerId)
+    .eq("buyer_id", user.id)
+    .maybeSingle()
+
+  if (!offer) {
+    return { ok: false, error: "Offer not found" }
+  }
+  if (offer.status !== "accepted") {
+    return { ok: false, error: "Only accepted offers can be paid" }
+  }
+
+  const txRef = chapaTxRef()
+  const begin = await callOutcomeRpc(supabase, "begin_payment", {
+    p_offer_id: offerId,
+    p_tx_ref: txRef,
+    p_amount: offer.amount,
+    p_currency: PAYMENT_CURRENCY,
+  }, "payOffer")
+  if (!begin.ok) {
+    return { ok: false, error: begin.error ?? "Could not start the payment" }
+  }
+
+  const init = await initializeChapaTransaction({
+    txRef,
+    amount: offer.amount,
+    currency: PAYMENT_CURRENCY,
+    email: user.email,
+    firstName: user.fullName,
+    returnUrl: await paymentReturnUrl(offerId, txRef),
+  })
+
+  if (!init.ok) {
+    await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: txRef }, "payOffer")
+    return { ok: false, error: init.error }
+  }
+
+  return {
+    ok: true,
+    checkoutUrl: init.checkoutUrl,
+    amount: offer.amount,
+    demo: init.demo,
+  }
+}
+
+// Server-side verify after the buyer returns from checkout. Fulfillment is
+// gated on Chapa reporting success in test mode, and the complete_payment RPC
+// re-checks the reported mode/amount/currency against the row pinned at begin
+// time. Idempotent — re-verifying an already-paid tx_ref stays successful.
+export async function verifyOfferPayment(params: {
+  offerId: string
+  txRef: string
+}): Promise<VerifyOfferPaymentResult> {
+  // Require a session (redirects signed-out users). Both participants (buyer
+  // and seller) can read a payment via RLS, so the fetch below is scoped by RLS
+  // rather than an explicit user filter; complete_payment re-checks the caller.
+  await requireUser()
+  const supabase = await createClient()
+  const { data: payment } = await supabase
+    .from("payments")
+    .select("id, offer_id, amount, currency, status")
+    .eq("tx_ref", params.txRef)
+    .maybeSingle()
+
+  if (!payment) {
+    return { ok: false, error: "Payment not found" }
+  }
+  if (payment.offer_id !== params.offerId) {
+    return { ok: false, error: "Payment does not match this offer" }
+  }
+  if (payment.status === "failed") {
+    return { ok: false, error: "This payment was not completed" }
+  }
+  if (payment.status === "paid") {
+    return { ok: true, amount: payment.amount }
+  }
+
+  const verified = await verifyChapaTransaction(params.txRef, {
+    amount: payment.amount,
+    currency: payment.currency,
+  })
+  if (!verified.ok) {
+    // The buyer came back without a completed payment (abandoned checkout,
+    // failed card). Mark the attempt failed so begin_payment allows a retry.
+    await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: params.txRef }, "verifyOfferPayment")
+    return { ok: false, error: verified.error }
+  }
+  if (verified.status !== "success" || verified.mode !== "test") {
+    await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: params.txRef }, "verifyOfferPayment")
+    return { ok: false, error: "Payment was not completed in test mode" }
+  }
+
+  const complete = await callOutcomeRpc(supabase, "complete_payment", {
+    p_tx_ref: params.txRef,
+    p_mode: verified.mode,
+    p_amount: verified.amount,
+    p_currency: verified.currency,
+  }, "verifyOfferPayment")
+  if (!complete.ok) {
+    // complete_payment rejected (e.g. currency/amount drift). The row is still
+    // pending, which would block a retry — fail it so the buyer can pay again.
+    await callOutcomeRpc(supabase, "fail_payment", { p_tx_ref: params.txRef }, "verifyOfferPayment")
+    return { ok: false, error: complete.error ?? "Could not confirm the payment" }
+  }
+
+  return { ok: true, amount: payment.amount }
+}
+
+// The buyer-protection signal: the buyer confirms they received the item,
+// closing the deal. Requires a paid payment on the offer (RPC-enforced).
+export async function confirmOfferReceipt(offerId: string): Promise<PaymentResult> {
+  const supabase = await createClient()
+  const result = await callOutcomeRpc(supabase, "confirm_payment_receipt", {
+    p_offer_id: offerId,
+  }, "confirmOfferReceipt")
+  return { ok: result.ok === true, error: result.error ?? null }
+}

--- a/web/lib/payments/constants.ts
+++ b/web/lib/payments/constants.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure payments domain value objects (#97).
+ *
+ * Client-safe: no `server-only` import and no Supabase client, so Client
+ * Components (e.g. BuyerPayment) can consume the status types, the offer's
+ * embedded payment row, and the pure helpers without pulling the server seam
+ * into the client graph.
+ */
+
+export const PAYMENT_STATUSES = ["pending", "paid", "failed"] as const
+
+export type PaymentStatus = (typeof PAYMENT_STATUSES)[number]
+
+// The demo only ever moves ETB (mirrors the payments_currency_etb check).
+export const PAYMENT_CURRENCY = "ETB"
+
+// The payment row embedded on an offer. Buyer and seller both read it via RLS;
+// the offer fetch embeds the raw rows and maps them with pickPayment.
+export interface OfferPayment {
+  id: string
+  amount: number
+  currency: string
+  status: PaymentStatus
+  mode: string
+  buyer_confirmed: boolean
+  paid_at: string | null
+  confirmed_at: string | null
+}
+
+export type PaymentPhase = "unpaid" | "paid" | "confirmed"
+
+// Where the deal stands from a participant's view: nothing has been paid, the
+// payment landed and awaits the buyer's confirm, or the buyer confirmed receipt
+// and the deal is closed. Shared by the buyer and seller surfaces.
+export function paymentPhase(payment: OfferPayment | null): PaymentPhase {
+  if (payment?.status !== "paid") return "unpaid"
+  return payment.buyer_confirmed ? "confirmed" : "paid"
+}
+
+// The offers table keeps one active payment per offer (begin_payment allows a
+// retry only after a failed attempt), but a retry leaves the failed row behind
+// so the embed is a small array. Pick the row that best describes the deal:
+// paid > pending > failed.
+const PAYMENT_PRIORITY: Record<PaymentStatus, number> = {
+  paid: 0,
+  pending: 1,
+  failed: 2,
+}
+
+export function pickPayment(
+  rows: OfferPayment[] | null | undefined
+): OfferPayment | null {
+  if (!rows?.length) return null
+  return rows.reduce((best, row) =>
+    PAYMENT_PRIORITY[row.status] < PAYMENT_PRIORITY[best.status] ? row : best
+  )
+}

--- a/web/lib/payments/constants.ts
+++ b/web/lib/payments/constants.ts
@@ -12,7 +12,22 @@ export const PAYMENT_STATUSES = ["pending", "paid", "failed"] as const
 export type PaymentStatus = (typeof PAYMENT_STATUSES)[number]
 
 // The demo only ever moves ETB (mirrors the payments_currency_etb check).
-export const PAYMENT_CURRENCY = "ETB"
+export const PAYMENT_CURRENCY = "ETB" as const
+
+// The domain's Money value object (domain model §11): a non-negative amount in
+// the marketplace's single supported currency. The currency literal is the TS
+// mirror of the DB's payments_currency_etb check — the DB stays the authority;
+// this is the one place TS names the rule.
+export interface Money {
+  amount: number
+  currency: typeof PAYMENT_CURRENCY
+}
+
+// The one construction site for the money pair, so callers never assemble
+// { amount, currency } by hand and drift the currency.
+export function etb(amount: number): Money {
+  return { amount, currency: PAYMENT_CURRENCY }
+}
 
 // The payment row embedded on an offer. Buyer and seller both read it via RLS;
 // the offer fetch embeds the raw rows and maps them with pickPayment.

--- a/web/lib/supabase/rpc.ts
+++ b/web/lib/supabase/rpc.ts
@@ -25,6 +25,7 @@ export type RpcName =
   | "complete_payment"
   | "fail_payment"
   | "confirm_payment_receipt"
+  | "abandon_sale"
 
 export type RpcArgs = Record<string, string | number | boolean | null | string[]>
 

--- a/web/lib/supabase/rpc.ts
+++ b/web/lib/supabase/rpc.ts
@@ -21,6 +21,10 @@ export type RpcName =
   | "current_ai_generation_count"
   | "record_ai_generation"
   | "boost_listing"
+  | "begin_payment"
+  | "complete_payment"
+  | "fail_payment"
+  | "confirm_payment_receipt"
 
 export type RpcArgs = Record<string, string | number | boolean | null | string[]>
 

--- a/web/supabase/migrations/20260817000000_create_payments.sql
+++ b/web/supabase/migrations/20260817000000_create_payments.sql
@@ -1,0 +1,291 @@
+-- #97 - Chapa sandbox payment demo (offer transaction)
+-- payments: one ledger row per payment attempt on an accepted offer. The
+-- marketplace MVP deliberately ships without billing (monetization §17/§18);
+-- this is the demo-only exception so judges can see real money (in Chapa test
+-- mode) move at the moment of the deal.
+--
+-- Flow: seller accepts an offer (accept_offer already marks the listing sold),
+-- the buyer clicks "Pay with Chapa", a server action begins a payment row here,
+-- redirects to Chapa's hosted checkout, then verifies the transaction on
+-- return. Direct payment semantics: buyer pays seller; the listing is already
+-- sold; a "Confirm receipt" flag closes the deal (buyer-protection signal,
+-- no escrow state machine).
+--
+-- Writes go through SECURITY DEFINER RPCs (begin/complete/fail/confirm) that
+-- re-check the caller against the offer/payment row, mirroring the offers
+-- pattern. RLS grants only SELECT to participants + admins; there is no
+-- INSERT/UPDATE grant at all, so a compromised anon key cannot write payments.
+
+create type public.payment_status as enum ('pending', 'paid', 'failed');
+
+create table if not exists public.payments (
+  id uuid primary key default gen_random_uuid(),
+  offer_id uuid not null references public.offers (id) on delete cascade,
+  listing_id uuid not null references public.listings (id) on delete cascade,
+  buyer_id uuid not null references public.profiles (id) on delete cascade,
+  seller_id uuid not null references public.profiles (id) on delete cascade,
+  amount numeric(12, 2) not null check (amount > 0),
+  currency text not null default 'ETB',
+  tx_ref text not null unique,
+  status public.payment_status not null default 'pending',
+  mode text not null default 'test',
+  buyer_confirmed boolean not null default false,
+  paid_at timestamptz,
+  confirmed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- The demo only ever moves ETB in Chapa test mode; a live integration would
+-- add a new migration, not loosen this check.
+alter table public.payments
+  add constraint payments_currency_etb
+  check (currency = 'ETB');
+
+alter table public.payments
+  add constraint payments_mode_test
+  check (mode = 'test');
+
+create index if not exists payments_offer_id_idx on public.payments (offer_id);
+create index if not exists payments_buyer_id_idx on public.payments (buyer_id);
+create index if not exists payments_seller_id_idx on public.payments (seller_id);
+
+create trigger payments_set_updated_at
+  before update on public.payments
+  for each row execute function public.handle_updated_at();
+
+-----------------------------------------------------------------------------
+-- RLS: the buyer and the seller can read the payment, admins have full
+-- access. No participant writes directly — every transition is an RPC below.
+-----------------------------------------------------------------------------
+alter table public.payments enable row level security;
+
+create policy "Payments are readable by the buyer or the seller"
+  on public.payments for select
+  to authenticated
+  using (
+    (select auth.uid()) = buyer_id
+    or (select auth.uid()) = seller_id
+    or public.is_admin()
+  );
+
+create policy "Payments are manageable by admins"
+  on public.payments for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-----------------------------------------------------------------------------
+-- Transition RPCs (SECURITY DEFINER; each one re-checks the caller). Rows are
+-- locked so a buyer cannot begin two payments on one offer at once and the
+-- verify path cannot race the retry path.
+-----------------------------------------------------------------------------
+
+-- Creates the pending payment for an accepted offer. Only the offer's buyer
+-- may begin, only on an accepted offer, only for the exact agreed amount, and
+-- only when no pending/paid payment already exists (a failed attempt may be
+-- retried). The server action supplies the Chapa tx_ref; the RPC pins the
+-- amount and currency so a tampered tx_ref still settles the agreed price.
+create or replace function public.begin_payment(
+  p_offer_id uuid,
+  p_tx_ref text,
+  p_amount numeric,
+  p_currency text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_existing uuid;
+  v_seller_id uuid;
+begin
+  if (select auth.uid()) is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  if p_tx_ref is null or p_tx_ref !~ '^[A-Za-z0-9_-]{8,64}$' then
+    return jsonb_build_object('ok', false, 'error', 'invalid tx ref');
+  end if;
+
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  if not (public.is_admin() or v_offer.buyer_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_offer.status <> 'accepted' then
+    return jsonb_build_object('ok', false, 'error', 'offer is not accepted');
+  end if;
+
+  -- The buyer pays exactly what the seller accepted; nothing else.
+  if p_amount is null or p_amount <> v_offer.amount then
+    return jsonb_build_object('ok', false, 'error', 'amount mismatch');
+  end if;
+  if p_currency is null or upper(p_currency) <> 'ETB' then
+    return jsonb_build_object('ok', false, 'error', 'currency not supported');
+  end if;
+
+  select id into v_existing from public.payments
+  where offer_id = p_offer_id and status in ('pending', 'paid')
+  order by created_at desc
+  limit 1;
+  if found then
+    return jsonb_build_object('ok', false, 'error', 'payment already exists');
+  end if;
+
+  select seller_id into v_seller_id
+  from public.listings where id = v_offer.listing_id;
+
+  insert into public.payments (
+    offer_id, listing_id, buyer_id, seller_id, amount, currency, tx_ref,
+    status, mode
+  ) values (
+    p_offer_id, v_offer.listing_id, v_offer.buyer_id, v_seller_id,
+    p_amount, 'ETB', p_tx_ref, 'pending', 'test'
+  );
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+-- Marks a pending payment paid after a successful Chapa verify. The server
+-- passes back exactly what Chapa reported (mode, amount, currency) and the RPC
+-- re-checks it against the row pinned at begin time, so a client can never
+-- mark its own payment paid. Idempotent: re-verifying an already-paid payment
+-- is a no-op success, so page refreshes on the return URL stay clean.
+create or replace function public.complete_payment(
+  p_tx_ref text,
+  p_mode text,
+  p_amount numeric,
+  p_currency text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_payment public.payments;
+begin
+  select * into v_payment from public.payments where tx_ref = p_tx_ref for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'payment not found');
+  end if;
+
+  -- Caller gate first: this is a SECURITY DEFINER RPC that bypasses RLS, so no
+  -- branch (including the idempotent already-paid path) may run for a
+  -- non-participant. Mirrors the offers transition RPCs.
+  if not (public.is_admin() or v_payment.buyer_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_payment.status = 'paid' then
+    return jsonb_build_object('ok', true, 'error', null);
+  end if;
+  if v_payment.status <> 'pending' then
+    return jsonb_build_object('ok', false, 'error', 'payment is not pending');
+  end if;
+
+  if p_mode <> v_payment.mode then
+    return jsonb_build_object('ok', false, 'error', 'mode mismatch');
+  end if;
+  if p_amount is null or p_amount <> v_payment.amount then
+    return jsonb_build_object('ok', false, 'error', 'amount mismatch');
+  end if;
+  if p_currency is null or upper(p_currency) <> v_payment.currency then
+    return jsonb_build_object('ok', false, 'error', 'currency mismatch');
+  end if;
+
+  update public.payments
+    set status = 'paid', paid_at = now()
+    where id = v_payment.id;
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+-- Marks a pending payment failed (e.g. the Chapa initialize call errored) so
+-- the buyer can retry. The buyer is the only participant who can fail a
+-- payment they began.
+create or replace function public.fail_payment(p_tx_ref text)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_payment public.payments;
+begin
+  select * into v_payment from public.payments where tx_ref = p_tx_ref for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'payment not found');
+  end if;
+
+  if v_payment.status <> 'pending' then
+    return jsonb_build_object('ok', false, 'error', 'payment is not pending');
+  end if;
+
+  if not (public.is_admin() or v_payment.buyer_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  update public.payments set status = 'failed' where id = v_payment.id;
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+-- The buyer-protection signal: the buyer confirms they received the item,
+-- closing the deal. Requires a paid payment on the offer; idempotent.
+create or replace function public.confirm_payment_receipt(p_offer_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_payment public.payments;
+begin
+  select * into v_payment from public.payments
+  where offer_id = p_offer_id and status = 'paid'
+  order by paid_at desc
+  limit 1
+  for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'no paid payment');
+  end if;
+
+  if not (public.is_admin() or v_payment.buyer_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_payment.buyer_confirmed then
+    return jsonb_build_object('ok', true, 'error', null);
+  end if;
+
+  update public.payments
+    set buyer_confirmed = true, confirmed_at = now()
+    where id = v_payment.id;
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+grant select on public.payments to authenticated;
+
+-- RPC grants: the payment RPCs are buyer/seller-scoped (not public), mirroring
+-- the offers grants; revoking from public keeps the implicit EXECUTE grant from
+-- exposing them.
+revoke all on function public.begin_payment(uuid, text, numeric, text) from public;
+revoke all on function public.complete_payment(text, text, numeric, text) from public;
+revoke all on function public.fail_payment(text) from public;
+revoke all on function public.confirm_payment_receipt(uuid) from public;
+grant execute on function public.begin_payment(uuid, text, numeric, text) to authenticated;
+grant execute on function public.complete_payment(text, text, numeric, text) to authenticated;
+grant execute on function public.fail_payment(text) to authenticated;
+grant execute on function public.confirm_payment_receipt(uuid) to authenticated;

--- a/web/supabase/migrations/20260818000000_payment_recovery.sql
+++ b/web/supabase/migrations/20260818000000_payment_recovery.sql
@@ -1,0 +1,173 @@
+-- #97 - Payment recovery: one "deal closed" state machine.
+--
+-- The offers flow marks a listing sold the instant the seller accepts an offer
+-- (accept_offer), before any money has moved. If the buyer then abandons the
+-- Chapa checkout, the listing would be stranded: sold forever, with a pending
+-- payment row that begin_payment refuses to replace (blocking a retry) and no
+-- path back to the market. The demo exception itself is recorded on main as
+-- ADR-021 (Transaction Handling): no in-app payments ship; Chapa is a demo-only
+-- beat for judges to see money move in test mode.
+--
+-- This migration makes the state machine recoverable without moving the
+-- terminal signal off accept_offer (the seller accepting an offer still takes
+-- the listing off the market; money then confirms the deal):
+--
+--   1. begin_payment auto-expires stale pending attempts (older than 30 min) so
+--      an abandoned checkout can never lock the buyer out of a retry.
+--   2. abandon_sale is the seller's recovery path: it fails any pending
+--      attempts, declines the accepted offer, and reopens the listing — but only
+--      while no payment has actually landed (a paid row makes the sale real).
+--
+-- The deal-closed decision therefore lives in one place: the payment row
+-- reaching 'paid' (money moved) or the buyer confirming receipt. 'sold' is the
+-- market-side intent; it can be walked back when no money moved.
+
+-- begin_payment: auto-expire stale pending attempts before the existing-row
+-- check. Only the offer's buyer can call this RPC, so the rows being expired
+-- are their own abandoned attempts on the same offer.
+create or replace function public.begin_payment(
+  p_offer_id uuid,
+  p_tx_ref text,
+  p_amount numeric,
+  p_currency text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_existing uuid;
+  v_seller_id uuid;
+begin
+  if (select auth.uid()) is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  if p_tx_ref is null or p_tx_ref !~ '^[A-Za-z0-9_-]{8,64}$' then
+    return jsonb_build_object('ok', false, 'error', 'invalid tx ref');
+  end if;
+
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  if not (public.is_admin() or v_offer.buyer_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_offer.status <> 'accepted' then
+    return jsonb_build_object('ok', false, 'error', 'offer is not accepted');
+  end if;
+
+  -- The buyer pays exactly what the seller accepted; nothing else.
+  if p_amount is null or p_amount <> v_offer.amount then
+    return jsonb_build_object('ok', false, 'error', 'amount mismatch');
+  end if;
+  if p_currency is null or upper(p_currency) <> 'ETB' then
+    return jsonb_build_object('ok', false, 'error', 'currency not supported');
+  end if;
+
+  -- An abandoned checkout leaves a pending row that would otherwise block a
+  -- retry forever (the verify trigger lives on the return callback, so a tab
+  -- closed mid-checkout may never fail the row). Expire stale pending attempts
+  -- so the buyer can try again.
+  update public.payments
+    set status = 'failed'
+    where offer_id = p_offer_id
+      and status = 'pending'
+      and created_at < now() - interval '30 minutes';
+
+  select id into v_existing from public.payments
+  where offer_id = p_offer_id and status in ('pending', 'paid')
+  order by created_at desc
+  limit 1;
+  if found then
+    return jsonb_build_object('ok', false, 'error', 'payment already exists');
+  end if;
+
+  select seller_id into v_seller_id
+  from public.listings where id = v_offer.listing_id;
+
+  insert into public.payments (
+    offer_id, listing_id, buyer_id, seller_id, amount, currency, tx_ref,
+    status, mode
+  ) values (
+    p_offer_id, v_offer.listing_id, v_offer.buyer_id, v_seller_id,
+    p_amount, 'ETB', p_tx_ref, 'pending', 'test'
+  );
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+-- abandon_sale: the seller's recovery path when the buyer never pays. Fails any
+-- pending attempts, declines the accepted offer, and reopens the listing to the
+-- market. Guarded on no paid payment having landed: once money moved, the sale
+-- is real and cannot be walked back by a seller who changed their mind.
+create or replace function public.abandon_sale(p_offer_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_offer public.offers;
+  v_listing public.listings;
+  v_paid uuid;
+begin
+  if (select auth.uid()) is null then
+    return jsonb_build_object('ok', false, 'error', 'not authenticated');
+  end if;
+
+  select * into v_offer from public.offers where id = p_offer_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'offer not found');
+  end if;
+
+  select * into v_listing from public.listings where id = v_offer.listing_id for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'listing not found');
+  end if;
+
+  -- Only the seller (or an admin) can abandon a sale they agreed to.
+  if not (public.is_admin() or v_listing.seller_id = (select auth.uid())) then
+    return jsonb_build_object('ok', false, 'error', 'not allowed');
+  end if;
+
+  if v_offer.status <> 'accepted' then
+    return jsonb_build_object('ok', false, 'error', 'offer is not accepted');
+  end if;
+
+  -- Money moved? Then the deal is closed; no recovery.
+  select id into v_paid from public.payments
+  where offer_id = p_offer_id and status = 'paid'
+  limit 1;
+  if found then
+    return jsonb_build_object('ok', false, 'error', 'payment already received');
+  end if;
+
+  -- Fail any pending attempts so they never block a future payment, decline the
+  -- offer, and put the listing back on the market.
+  update public.payments
+    set status = 'failed'
+    where offer_id = p_offer_id and status = 'pending';
+
+  update public.offers
+    set status = 'declined'
+    where id = p_offer_id;
+
+  update public.listings
+    set status = 'published', sold_to_buyer_id = null
+    where id = v_listing.id;
+
+  return jsonb_build_object('ok', true, 'error', null);
+end;
+$$;
+
+revoke all on function public.begin_payment(uuid, text, numeric, text) from public;
+revoke all on function public.abandon_sale(uuid) from public;
+grant execute on function public.begin_payment(uuid, text, numeric, text) to authenticated;
+grant execute on function public.abandon_sale(uuid) to authenticated;

--- a/web/tests/unit/payments.test.ts
+++ b/web/tests/unit/payments.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, afterEach } from "vitest"
 
 import {
   PAYMENT_CURRENCY,
@@ -9,6 +9,10 @@ import {
   type OfferPayment,
   type PaymentPhase,
 } from "@/lib/payments/constants"
+import {
+  verifyChapaTransaction,
+  isDemoTxRef,
+} from "@/lib/chapa"
 
 function payment(overrides: Partial<OfferPayment> = {}): OfferPayment {
   return {
@@ -91,5 +95,40 @@ describe("payments.paymentPhase", () => {
       ...PAYMENT_STATUSES.map((s) => paymentPhase(payment({ status: s }))),
     ])
     expect(phases).toEqual(new Set(["unpaid", "paid"]))
+  })
+})
+
+describe("chapa.verifyChapaTransaction (demo fallback)", () => {
+  afterEach(() => {
+    delete process.env.CHAPA_DEMO_FALLBACK
+  })
+
+  it("simulates test-mode success for a demo_ tx_ref while the fallback is on", async () => {
+    process.env.CHAPA_DEMO_FALLBACK = "true"
+    const result = await verifyChapaTransaction("demo_abc", {
+      amount: 500,
+      currency: "ETB",
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.status).toBe("success")
+      expect(result.mode).toBe("test")
+      expect(result.amount).toBe(500)
+      expect(result.currency).toBe("ETB")
+      expect(result.demo).toBe(true)
+    }
+  })
+
+  it("refuses a simulated tx_ref when the fallback is off", async () => {
+    const result = await verifyChapaTransaction("demo_abc", {
+      amount: 500,
+      currency: "ETB",
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it("never simulates a non-demo tx_ref", () => {
+    expect(isDemoTxRef("demo_1")).toBe(true)
+    expect(isDemoTxRef("fm_1")).toBe(false)
   })
 })

--- a/web/tests/unit/payments.test.ts
+++ b/web/tests/unit/payments.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest"
+
+import {
+  PAYMENT_CURRENCY,
+  PAYMENT_STATUSES,
+  paymentPhase,
+  pickPayment,
+  type OfferPayment,
+  type PaymentPhase,
+} from "@/lib/payments/constants"
+
+function payment(overrides: Partial<OfferPayment> = {}): OfferPayment {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    amount: 500,
+    currency: "ETB",
+    status: "pending",
+    mode: "test",
+    buyer_confirmed: false,
+    paid_at: null,
+    confirmed_at: null,
+    ...overrides,
+  }
+}
+
+describe("payments status surface", () => {
+  it("declares the three statuses", () => {
+    expect(PAYMENT_STATUSES).toEqual(["pending", "paid", "failed"])
+  })
+
+  it("only ever moves ETB (mirrors the payments_currency_etb check)", () => {
+    expect(PAYMENT_CURRENCY).toBe("ETB")
+  })
+})
+
+describe("payments.pickPayment", () => {
+  it("returns null for an empty embed", () => {
+    expect(pickPayment(null)).toBeNull()
+    expect(pickPayment([])).toBeNull()
+  })
+
+  it("prefers a paid row over pending and failed retries", () => {
+    const rows = [
+      payment({ id: "a", status: "failed" }),
+      payment({ id: "b", status: "pending" }),
+      payment({ id: "c", status: "paid" }),
+    ]
+    expect(pickPayment(rows)?.id).toBe("c")
+  })
+
+  it("prefers a pending attempt over a failed retry", () => {
+    const rows = [
+      payment({ id: "a", status: "failed" }),
+      payment({ id: "b", status: "pending" }),
+    ]
+    expect(pickPayment(rows)?.id).toBe("b")
+  })
+
+  it("returns a single row unchanged", () => {
+    const row = payment({ status: "paid", buyer_confirmed: true })
+    expect(pickPayment([row])).toEqual(row)
+  })
+})
+
+describe("payments.paymentPhase", () => {
+  it("treats null, pending, and failed payments as unpaid", () => {
+    expect(paymentPhase(null)).toBe("unpaid")
+    expect(paymentPhase(payment())).toBe("unpaid")
+    expect(paymentPhase(payment({ status: "failed" }))).toBe("unpaid")
+  })
+
+  it("is paid until the buyer confirms receipt", () => {
+    expect(paymentPhase(payment({ status: "paid" }))).toBe("paid")
+  })
+
+  it("is confirmed once the buyer confirms receipt", () => {
+    expect(paymentPhase(payment({ status: "paid", buyer_confirmed: true }))).toBe(
+      "confirmed"
+    )
+  })
+
+  it("covers every declared status", () => {
+    const phases = new Set<PaymentPhase>([
+      paymentPhase(null),
+      ...PAYMENT_STATUSES.map((s) => paymentPhase(payment({ status: s }))),
+    ])
+    expect(phases).toEqual(new Set(["unpaid", "paid"]))
+  })
+})

--- a/web/tests/unit/payments.test.ts
+++ b/web/tests/unit/payments.test.ts
@@ -5,6 +5,7 @@ import {
   PAYMENT_STATUSES,
   paymentPhase,
   pickPayment,
+  etb,
   type OfferPayment,
   type PaymentPhase,
 } from "@/lib/payments/constants"
@@ -30,6 +31,11 @@ describe("payments status surface", () => {
 
   it("only ever moves ETB (mirrors the payments_currency_etb check)", () => {
     expect(PAYMENT_CURRENCY).toBe("ETB")
+  })
+
+  it("builds Money pairs through the single etb() site", () => {
+    expect(etb(500)).toEqual({ amount: 500, currency: "ETB" })
+    expect(etb(0.01).currency).toBe(PAYMENT_CURRENCY)
   })
 })
 


### PR DESCRIPTION
## Issue

Implements **#97 — Stretch: Chapa sandbox payment integration (demo to judges)** (ADRs 020/021). 3 commits ahead of `main` (`origin/main` = PR #52).

## What this is

The offer-transaction payment demo: the buyer pays the agreed amount on an accepted offer via Chapa's hosted checkout in **test mode**, with the "Confirm receipt" step giving the buyer-protection moment without an escrow state machine. Direct payment semantics, no escrow, no webhook — verify-on-return is sufficient for the demo.

## What's included (from #97)

- **Ledger**: `payments` table (`20260817000000_create_payments.sql`) with RLS (participants + admins read); writes only via SECURITY DEFINER RPCs `begin_payment` / `complete_payment` / `fail_payment` / `confirm_payment_receipt`, each re-checking the caller and **pinning amount/currency** so a client can never settle a different price.
- **Adapter** (`web/lib/chapa/index.ts`): server-only seam — initialize → `checkout_url`, verify gated on `status === "success"` **and** `mode === "test"`; `demo_` tx_refs always simulated. Secret key is env-only, never leaves the server.
- **Flow**: Pay with Chapa (redirect) → test card (Visa `4200 0000 0000 0000`, CVV `123`, expiry `12/34`) → `/payments/callback` verifies server-side → paid state → buyer confirms receipt → seller sees **Paid ETB X — buyer confirmed receipt**.
- **Demo fallback**: `CHAPA_DEMO_FALLBACK=true` short-circuits initialize and simulates verify success — the full state machine works with no network or account. `web/.env.example` documents `CHAPA_SECRET_KEY` + `CHAPA_DEMO_FALLBACK`.

## New on this branch (hardening follow-ups, ADR-021)

- **Payment recovery** (`20260818000000_payment_recovery.sql`): seller-initiated `abandon_sale` RPC (seller-only, guarded on no paid payment — fails pending attempts, declines the offer, reopens the listing to `published`) + stale-pending auto-expiry (>30 min) in `begin_payment`; "Cancel sale and relist" button on the seller's accepted offer.
- **`/payments/callback` route** is the primary verify trigger; the `/offers` verify-on-render remains as the idempotent resume fallback (one Chapa verify per return).
- **`Money` value object** (`etb()`) in `web/lib/payments/constants.ts` as the single TS construction site for the amount/currency pair; removed a dead `export * from constants`.

## Acceptance criteria (from #97)

- [x] Initialize → hosted checkout → test-card payment → verify completes end-to-end in test mode
- [x] Fulfillment gated on verify (`status === "success"`, `mode === "test"`, amount/currency match the pinned row)
- [x] Buyer "Confirm receipt" closes the deal; seller sees paid state
- [x] Demo fallback toggle present; `demo_` tx_refs never hit the real API
- [x] Secret key never leaves the server (env-only, server-only module)
- [x] Retry works after a failed attempt (failed rows re-beginnable; "Retry payment" only shown for a failed attempt)

## Verification

- 193 unit tests pass (`npx vitest run`), `npx tsc --noEmit` clean, `npm run lint` clean
- Migrations to apply from `web/`: `20260817000000_create_payments.sql`, `20260818000000_payment_recovery.sql` — `cd web && npx supabase db push`
- Real (non-fallback) payments need `CHAPA_SECRET_KEY` from a registered Chapa test account

## Notes

- Webhook route deliberately not used (#97: verify-on-return is sufficient for the demo).
- The `abandon_sale` + recovery work exceeds #97's literal scope (ticket describes only the pay→confirm flow); it is the payment-recovery hardening recorded in ADR-021 and is gated so it cannot interfere with the core demo.