### PR TITLE
feat(pagination): window the remaining full-fetch lists (P1.14, #81)

### DIFF
--- a/web/app/(site)/dashboard/page.tsx
+++ b/web/app/(site)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { requireUser, ROLE_LABELS } from "@/lib/auth"
 import { fetchSellerListings } from "@/lib/listings"
 import { fetchAccountUsage } from "@/lib/usage"
 import { countIncomingOffers } from "@/lib/offers"
+import { nextOffset, parseOffset } from "@/lib/pagination"
 import { promoteToSeller } from "@/app/actions/profile"
 import { ListingManager } from "@/components/dashboard/listing-manager"
 import { AccountUsageCard } from "@/components/dashboard/account-usage-card"
@@ -18,17 +19,25 @@ export const metadata: Metadata = {
   description: "Your VinTech Marketplace dashboard.",
 }
 
-export default async function DashboardPage() {
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
   const user = await requireUser()
   // The seller home only makes sense for users who can sell; buyers land on the
   // profile gate instead of a dead-end /sell redirect (issue #13 AC5).
   const canSell = user.role === "seller" || user.role === "admin"
+  const offset = parseOffset((await searchParams).offset)
 
-  const [listings, openOfferCount, sellerUsage] = await Promise.all([
-    canSell ? fetchSellerListings(user.id) : Promise.resolve([]),
+  const [openOfferCount, sellerUsage, sellerListings] = await Promise.all([
     countIncomingOffers(user.id),
     canSell ? fetchAccountUsage(user.id) : Promise.resolve(null),
+    canSell
+      ? fetchSellerListings(user.id, { offset })
+      : Promise.resolve(null),
   ])
+  const listings = sellerListings?.listings ?? []
 
   const firstName = user.fullName?.split(" ")[0] ?? "there"
 
@@ -65,6 +74,17 @@ export default async function DashboardPage() {
           {sellerUsage ? <AccountUsageCard usage={sellerUsage} /> : null}
 
           <ListingManager listings={listings} />
+
+          {sellerListings?.hasMore ? (
+            <div className="mt-6 flex justify-center">
+              <Link
+                href={`/dashboard?offset=${nextOffset(offset)}`}
+                className="text-sm font-medium underline"
+              >
+                Load more
+              </Link>
+            </div>
+          ) : null}
         </section>
       ) : (
         <Card className="mb-10">

--- a/web/app/(site)/favorites/page.tsx
+++ b/web/app/(site)/favorites/page.tsx
@@ -3,15 +3,23 @@ import { Heart } from "lucide-react"
 
 import { requireUser } from "@/lib/auth"
 import { fetchFavoriteListings } from "@/lib/favorites"
+import { nextOffset, parseOffset } from "@/lib/pagination"
 import { Button } from "@/components/ui/button"
 import { ListingCard } from "@/components/listings/listing-card"
 import { FavoriteButton } from "@/components/favorites/favorite-button"
 
 export const dynamic = "force-dynamic"
 
-export default async function FavoritesPage() {
+export default async function FavoritesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
   const user = await requireUser()
-  const listings = await fetchFavoriteListings(user.id)
+  const offset = parseOffset((await searchParams).offset)
+  const { listings, hasMore, error } = await fetchFavoriteListings(user.id, {
+    offset,
+  })
 
   return (
     <main className="mx-auto w-full max-w-[1280px] px-4 py-10 sm:px-6 lg:py-12">
@@ -19,7 +27,11 @@ export default async function FavoritesPage() {
         Your favorites
       </h1>
 
-      {listings.length === 0 ? (
+      {error ? (
+        <p className="py-8 text-sm text-muted-foreground">
+          Could not load favorites. Try again.
+        </p>
+      ) : listings.length === 0 ? (
         <div className="flex flex-col items-center py-16 text-center">
           <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-muted">
             <Heart className="size-6 text-muted-foreground" />
@@ -36,18 +48,30 @@ export default async function FavoritesPage() {
           </Button>
         </div>
       ) : (
-        <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {listings.map((l) => (
-            <li key={l.id}>
-              <ListingCard
-                listing={l}
-                favoriteButton={
-                  <FavoriteButton listingId={l.id} initial={true} />
-                }
-              />
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {listings.map((l) => (
+              <li key={l.id}>
+                <ListingCard
+                  listing={l}
+                  favoriteButton={
+                    <FavoriteButton listingId={l.id} initial={true} />
+                  }
+                />
+              </li>
+            ))}
+          </ul>
+          {hasMore ? (
+            <div className="mt-8 flex justify-center">
+              <Link
+                href={`/favorites?offset=${nextOffset(offset)}`}
+                className="text-sm font-medium underline"
+              >
+                Load more
+              </Link>
+            </div>
+          ) : null}
+        </>
       )}
     </main>
   )

--- a/web/app/(site)/users/[id]/page.tsx
+++ b/web/app/(site)/users/[id]/page.tsx
@@ -6,8 +6,9 @@ import { MapPinIcon, PhoneIcon, SendIcon } from "lucide-react"
 import { ROLE_LABELS, type UserRole, getCurrentUser } from "@/lib/auth"
 import { fetchPublicProfile } from "@/lib/profiles"
 import { initials, formatShortDate } from "@/lib/utils"
-import { fetchSellerReviews, summarizeRating } from "@/lib/reviews"
+import { fetchSellerRatingSummary, fetchSellerReviews } from "@/lib/reviews"
 import { fetchSellerContactInfo } from "@/lib/contact"
+import { nextOffset, parseOffset } from "@/lib/pagination"
 import { SellerTrustBadges } from "@/components/verification/seller-trust-badges"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -39,8 +40,10 @@ export async function generateMetadata({
 
 export default async function UserProfilePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const { id } = await params
   const profile = await fetchPublicProfile(id)
@@ -48,8 +51,11 @@ export default async function UserProfilePage({
 
   const role = (profile.role ?? "buyer") as UserRole
   const roleLabel = ROLE_LABELS[role] ?? "Buyer"
-  const reviews = await fetchSellerReviews(id)
-  const rating = summarizeRating(reviews)
+  const offset = parseOffset((await searchParams).offset)
+  const [reviews, rating] = await Promise.all([
+    fetchSellerReviews(id, { offset }),
+    fetchSellerRatingSummary(id),
+  ])
   const user = await getCurrentUser()
   const contactInfo = user ? await fetchSellerContactInfo(id) : null
 
@@ -168,7 +174,18 @@ export default async function UserProfilePage({
         </CardContent>
        </Card>
 
-      {reviews.length > 0 ? (
+      {reviews.error ? (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Reviews</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Could not load reviews. Try again.
+            </p>
+          </CardContent>
+        </Card>
+      ) : reviews.reviews.length > 0 ? (
         <Card className="mt-6">
           <CardHeader>
             <CardTitle>Reviews</CardTitle>
@@ -184,7 +201,7 @@ export default async function UserProfilePage({
             </div>
 
             <ul className="mt-4 flex flex-col gap-4">
-              {reviews.map((review) => (
+              {reviews.reviews.map((review) => (
                 <li key={review.id} className="flex items-start gap-3 text-sm">
                   <Avatar className="size-8">
                     {review.buyer?.avatar_url ? (
@@ -213,6 +230,16 @@ export default async function UserProfilePage({
                 </li>
               ))}
             </ul>
+            {reviews.hasMore ? (
+              <div className="mt-6 flex justify-center">
+                <Link
+                  href={`/users/${id}?offset=${nextOffset(offset)}`}
+                  className="text-sm font-medium underline"
+                >
+                  Load more
+                </Link>
+              </div>
+            ) : null}
           </CardContent>
         </Card>
       ) : (

--- a/web/app/admin/listings/page.tsx
+++ b/web/app/admin/listings/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { ListIcon } from "lucide-react"
 
 import { fetchAdminListings } from "@/lib/admin"
+import { nextOffset, parseOffset } from "@/lib/pagination"
 import { AdminListingRow } from "@/components/admin/admin-listing-row"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -10,8 +12,15 @@ export const metadata: Metadata = {
   description: "Moderate marketplace listings.",
 }
 
-export default async function AdminListingsPage() {
-  const listings = await fetchAdminListings()
+export default async function AdminListingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const offset = parseOffset((await searchParams).offset)
+  const { listings, count, hasMore, error } = await fetchAdminListings({
+    offset,
+  })
 
   return (
     <div>
@@ -20,24 +29,48 @@ export default async function AdminListingsPage() {
           Listings
         </h1>
         <p className="mt-2 max-w-xl text-muted-foreground">
-          {listings.length} live {listings.length === 1 ? "listing" : "listings"}.
-          Use Remove to archive a listing and hide it from all readers.
+          {(count ?? 0).toLocaleString()} live{" "}
+          {(count ?? 0) === 1 ? "listing" : "listings"}. Use Remove to archive
+          a listing and hide it from all readers.
         </p>
       </div>
 
-      {listings.length === 0 ? (
+      {error ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12">
             <ListIcon className="size-8 text-muted-foreground" />
-            <h2 className="font-heading text-lg font-semibold">No listings yet</h2>
+            <h2 className="font-heading text-lg font-semibold">
+              Could not load listings
+            </h2>
+          </CardContent>
+        </Card>
+      ) : listings.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12">
+            <ListIcon className="size-8 text-muted-foreground" />
+            <h2 className="font-heading text-lg font-semibold">
+              No listings yet
+            </h2>
           </CardContent>
         </Card>
       ) : (
-        <ul className="flex flex-col gap-3">
-          {listings.map((listing) => (
-            <AdminListingRow key={listing.id} listing={listing} />
-          ))}
-        </ul>
+        <>
+          <ul className="flex flex-col gap-3">
+            {listings.map((listing) => (
+              <AdminListingRow key={listing.id} listing={listing} />
+            ))}
+          </ul>
+          {hasMore ? (
+            <div className="mt-8 flex justify-center">
+              <Link
+                href={`/admin/listings?offset=${nextOffset(offset)}`}
+                className="text-sm font-medium underline"
+              >
+                Load more
+              </Link>
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   )

--- a/web/app/admin/users/page.tsx
+++ b/web/app/admin/users/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { UsersIcon } from "lucide-react"
 
 import { fetchAdminUsers } from "@/lib/admin"
+import { nextOffset, parseOffset } from "@/lib/pagination"
 import { AdminUserRow } from "@/components/admin/admin-user-row"
 import { Card, CardContent } from "@/components/ui/card"
 
@@ -10,8 +12,13 @@ export const metadata: Metadata = {
   description: "Manage marketplace users.",
 }
 
-export default async function AdminUsersPage() {
-  const users = await fetchAdminUsers()
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const offset = parseOffset((await searchParams).offset)
+  const { users, count, hasMore, error } = await fetchAdminUsers({ offset })
 
   return (
     <div>
@@ -20,13 +27,23 @@ export default async function AdminUsersPage() {
           Users
         </h1>
         <p className="mt-2 max-w-xl text-muted-foreground">
-          {users.length} registered {users.length === 1 ? "user" : "users"}. Use
-          Suspend to demote a seller and archive their live listings; Restore
-          re-instates a suspended seller.
+          {(count ?? 0).toLocaleString()} registered{" "}
+          {(count ?? 0) === 1 ? "user" : "users"}. Use Suspend to demote a
+          seller and archive their live listings; Restore re-instates a
+          suspended seller.
         </p>
       </div>
 
-      {users.length === 0 ? (
+      {error ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12">
+            <UsersIcon className="size-8 text-muted-foreground" />
+            <h2 className="font-heading text-lg font-semibold">
+              Could not load users
+            </h2>
+          </CardContent>
+        </Card>
+      ) : users.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12">
             <UsersIcon className="size-8 text-muted-foreground" />
@@ -34,11 +51,23 @@ export default async function AdminUsersPage() {
           </CardContent>
         </Card>
       ) : (
-        <ul className="flex flex-col gap-3">
-          {users.map((user) => (
-            <AdminUserRow key={user.id} user={user} />
-          ))}
-        </ul>
+        <>
+          <ul className="flex flex-col gap-3">
+            {users.map((user) => (
+              <AdminUserRow key={user.id} user={user} />
+            ))}
+          </ul>
+          {hasMore ? (
+            <div className="mt-8 flex justify-center">
+              <Link
+                href={`/admin/users?offset=${nextOffset(offset)}`}
+                className="text-sm font-medium underline"
+              >
+                Load more
+              </Link>
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   )

--- a/web/lib/admin.ts
+++ b/web/lib/admin.ts
@@ -2,6 +2,11 @@ import "server-only"
 
 import { createClient } from "@/lib/supabase/server"
 import type { Supabase } from "@/lib/supabase/types"
+import {
+  pagedHasMore,
+  resolveWindow,
+  type PagingArgs,
+} from "@/lib/pagination"
 
 // ---- Admin module (T11 surface): users, listings, marketplace stats ----
 // All reads run as the signed-in admin; RLS grants admins full read access on
@@ -65,48 +70,90 @@ export interface StatsBreakdown {
 
 // ---- Reads ----
 
+export interface AdminUsersPage {
+  users: AdminUserRow[]
+  count: number | null
+  hasMore: boolean
+  error: string | null
+}
+
 export async function fetchAdminUsers(
+  args: PagingArgs = {},
   client?: Supabase
-): Promise<AdminUserRow[]> {
+): Promise<AdminUsersPage> {
   const supabase = client ?? (await createClient())
-  const { data, error } = await supabase
+  const { limit, offset } = resolveWindow(args)
+  const { data, error, count } = await supabase
     .from("profiles")
-    .select(ADMIN_USER_COLUMNS)
+    .select(ADMIN_USER_COLUMNS, { count: "exact" })
     .is("deleted_at", null)
     .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     console.error("fetchAdminUsers:", error.message)
-    return []
+    return { users: [], count, hasMore: false, error: error.message }
   }
 
-  return (data ?? []) as unknown as AdminUserRow[]
+  const users = (data ?? []) as unknown as AdminUserRow[]
+  return {
+    users,
+    count,
+    hasMore: pagedHasMore(offset, users.length, count),
+    error: null,
+  }
+}
+
+export interface AdminListingsPage {
+  listings: AdminListingRow[]
+  count: number | null
+  hasMore: boolean
+  error: string | null
 }
 
 export async function fetchAdminListings(
+  args: PagingArgs = {},
   client?: Supabase
-): Promise<AdminListingRow[]> {
+): Promise<AdminListingsPage> {
   const supabase = client ?? (await createClient())
-  const { data, error } = await supabase
+  const { limit, offset } = resolveWindow(args)
+  const { data, error, count } = await supabase
     .from("listings")
     .select(
       `id, title, price, condition, status, city, view_count, favorite_count,
        sold_to_buyer_id, created_at, published_at,
-       seller:profiles!listings_seller_id_fkey(id, full_name)`
+       seller:profiles!listings_seller_id_fkey(id, full_name)`,
+      { count: "exact" }
     )
     .is("deleted_at", null)
     .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     console.error("fetchAdminListings:", error.message)
-    return []
+    return { listings: [], count, hasMore: false, error: error.message }
   }
 
-  type RawAdminListingRow = Omit<AdminListingRow, "price"> & { price: string }
-  return ((data ?? []) as unknown as RawAdminListingRow[]).map((row) => ({
-    ...row,
-    price: Number(row.price),
-  }))
+  // PostgREST returns every embedded relation as an array, even a to-one join,
+  // so `seller:profiles!listings_seller_id_fkey` arrives as `{...}[] | null`;
+  // flatten to a single row like the review buyer join does.
+  type RawAdminListingRow = Omit<AdminListingRow, "price" | "seller"> & {
+    price: string
+    seller: { id: string; full_name: string | null }[] | null
+  }
+  const listings = ((data ?? []) as unknown as RawAdminListingRow[]).map(
+    (row) => ({
+      ...row,
+      price: Number(row.price),
+      seller: row.seller?.[0] ?? null,
+    })
+  )
+  return {
+    listings,
+    count,
+    hasMore: pagedHasMore(offset, listings.length, count),
+    error: null,
+  }
 }
 
 export async function fetchMarketplaceStats(

--- a/web/lib/favorites.ts
+++ b/web/lib/favorites.ts
@@ -7,6 +7,11 @@ import type { BrowseListing } from "@/lib/listings/constants"
 import { mapNestedBrowseListing } from "@/lib/listings/browse-mapper"
 import type { NestedBrowseRow } from "@/lib/listings/browse-mapper"
 import { toggleFavoriteState } from "@/lib/favorites/constants"
+import {
+  pagedHasMore,
+  resolveWindow,
+  type PagingArgs,
+} from "@/lib/pagination"
 
 export * from "@/lib/favorites/constants"
 
@@ -30,26 +35,39 @@ export async function fetchFavoriteIds(
 
 // The favorites feed: rows are joined against listings, so RLS already drops
 // listings that are no longer readable (unpublished, deleted, sold). Only
-// still-available favorites are returned, most recently favorited first.
+// still-available favorites are returned, most recently favorited first, one
+// PAGE_SIZE window at a time (P1.14, #81). `hasMore` is derived from the
+// server count so the UI can stop rendering "Load more" without guessing.
+export interface FavoritesPage {
+  listings: BrowseListing[]
+  count: number | null
+  hasMore: boolean
+  error: string | null
+}
+
 export async function fetchFavoriteListings(
   userId: string,
+  args: PagingArgs = {},
   client?: Supabase
-): Promise<BrowseListing[]> {
+): Promise<FavoritesPage> {
   const supabase = client ?? (await createClient())
-  const { data, error } = await supabase
+  const { limit, offset } = resolveWindow(args)
+  const { data, error, count } = await supabase
     .from("favorites")
     .select(
       `created_at,
         listing:listings(id, title, price, condition, city, published_at,
           seller:profiles!listings_seller_id_fkey(id, full_name, avatar_url, role, trust_score, phone_verified, fayda_verified),
-          images:listing_images(id, image_url, display_order))`
+          images:listing_images(id, image_url, display_order))`,
+      { count: "exact" }
     )
     .eq("user_id", userId)
     .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     console.error("fetchFavoriteListings:", error.message)
-    return []
+    return { listings: [], count, hasMore: false, error: error.message }
   }
 
   // supabase-js without generated types types embedded resources as arrays,
@@ -59,10 +77,17 @@ export async function fetchFavoriteListings(
     listing: NestedBrowseRow | null
   }[]
 
-  return rows
+  const listings = rows
     .map((row) => row.listing)
     .filter((listing): listing is NestedBrowseRow => listing !== null)
     .map(mapNestedBrowseListing)
+
+  return {
+    listings,
+    count,
+    hasMore: pagedHasMore(offset, listings.length, count),
+    error: null,
+  }
 }
 
 // ---- Writes (called by the toggle server action) ----

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -25,7 +25,12 @@ import type {
   ListingWithRelations,
 } from "./listings/constants"
 import type { SearchSort } from "@/lib/search"
-import { MAX_PAGING_OFFSET } from "@/lib/pagination"
+import {
+  MAX_PAGING_OFFSET,
+  pagedHasMore,
+  resolveWindow,
+  type PagingArgs,
+} from "@/lib/pagination"
 import {
   mapFlatSearchListing,
   mapNestedBrowseListing,
@@ -131,24 +136,35 @@ type RawSellerListingRow = Omit<Listing, "price"> & {
   images: { image_url: string; display_order: number }[] | null
 }
 
+export interface SellerListingsPage {
+  listings: SellerListingRow[]
+  count: number | null
+  hasMore: boolean
+  error: string | null
+}
+
 export async function fetchSellerListings(
   sellerId: string,
+  args: PagingArgs = {},
   client?: Supabase
-): Promise<SellerListingRow[]> {
+): Promise<SellerListingsPage> {
   const supabase = client ?? (await createClient())
-  const { data, error } = await supabase
+  const { limit, offset } = resolveWindow(args)
+  const { data, error, count } = await supabase
     .from("listings")
     .select(
       `${LISTING_COLUMNS},
-       images:listing_images(image_url, display_order)`
+       images:listing_images(image_url, display_order)`,
+      { count: "exact" }
     )
     .eq("seller_id", sellerId)
     .is("deleted_at", null)
     .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     console.error("fetchSellerListings:", error.message)
-    return []
+    return { listings: [], count, hasMore: false, error: error.message }
   }
 
   const rows = data as unknown as RawSellerListingRow[] | null ?? []
@@ -175,7 +191,7 @@ export async function fetchSellerListings(
     )
   }
 
-  return rows.map((row) => {
+  const listings = rows.map((row) => {
     const { images, ...rest } = row
     return {
       ...rest,
@@ -184,6 +200,12 @@ export async function fetchSellerListings(
       boosted_until: boosts[row.id] ?? null,
     }
   })
+  return {
+    listings,
+    count,
+    hasMore: pagedHasMore(offset, listings.length, count),
+    error: null,
+  }
 }
 
 // Public, paginated browse of published listings (anon-readable via RLS).

--- a/web/lib/pagination.ts
+++ b/web/lib/pagination.ts
@@ -27,3 +27,32 @@ export function parseOffset(raw: string | string[] | undefined): number {
 export function nextOffset(offset: number): number {
   return offset + PAGE_SIZE
 }
+
+// Shared paging args for every windowed read seam (P1.14, #81): favorites,
+// reviews, the seller manager, and the admin lists all page PAGE_SIZE rows per
+// request and derive "Load more" from a server count, so they share one
+// resolution rule instead of drifting on limit/offset semantics.
+export interface PagingArgs {
+  limit?: number
+  offset?: number
+}
+
+export function resolveWindow(args: PagingArgs = {}): {
+  limit: number
+  offset: number
+} {
+  return {
+    limit: Math.min(args.limit ?? PAGE_SIZE, PAGE_SIZE),
+    offset: Math.max(args.offset ?? 0, 0),
+  }
+}
+
+// A server-count-backed "is there another page?" test. Returns false whenever
+// the count is unknown, so the UI never renders a "Load more" it cannot serve.
+export function pagedHasMore(
+  offset: number,
+  returned: number,
+  count: number | null
+): boolean {
+  return typeof count === "number" && offset + returned < count
+}

--- a/web/lib/reviews.ts
+++ b/web/lib/reviews.ts
@@ -4,6 +4,11 @@ import { createClient } from "@/lib/supabase/server"
 import type { Supabase } from "@/lib/supabase/types"
 import { callOutcomeRpc } from "@/lib/supabase/rpc"
 import { isValidUuid } from "@/lib/uuid"
+import {
+  pagedHasMore,
+  resolveWindow,
+  type PagingArgs,
+} from "@/lib/pagination"
 
 export * from "@/lib/reviews/constants"
 
@@ -43,38 +48,80 @@ const REVIEW_COLUMNS =
 
 // The seller's reviews, newest first, with the reviewer's public identity.
 // RLS exposes every review to the public, so any visitor can render the list.
+// One PAGE_SIZE window per request (P1.14, #81); `hasMore` comes from the
+// server count so the UI can stop rendering "Load more" without guessing.
+export interface ReviewsPage {
+  reviews: SellerReviewRow[]
+  count: number | null
+  hasMore: boolean
+  error: string | null
+}
+
 export async function fetchSellerReviews(
   sellerId: string,
+  args: PagingArgs = {},
   client?: Supabase
-): Promise<SellerReviewRow[]> {
-  if (!isValidUuid(sellerId)) return []
+): Promise<ReviewsPage> {
+  if (!isValidUuid(sellerId)) {
+    return { reviews: [], count: 0, hasMore: false, error: null }
+  }
   const supabase = client ?? (await createClient())
-  const { data, error } = await supabase
+  const { limit, offset } = resolveWindow(args)
+  const { data, error, count } = await supabase
     .from("reviews")
-    .select(REVIEW_COLUMNS)
+    .select(REVIEW_COLUMNS, { count: "exact" })
     .eq("seller_id", sellerId)
     .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     console.error("fetchSellerReviews:", error.message)
-    return []
+    return { reviews: [], count, hasMore: false, error: error.message }
   }
   const rows = (data as RawReviewRow[] | null) ?? []
-  return rows.map((row) => ({
+  const reviews = rows.map((row) => ({
     id: row.id,
     rating: Number(row.rating),
     comment: row.comment,
     created_at: row.created_at,
     buyer: row.buyer?.[0] ?? null,
   }))
+  return {
+    reviews,
+    count,
+    hasMore: pagedHasMore(offset, reviews.length, count),
+    error: null,
+  }
 }
 
-// Aggregate rating for the profile header. Computed from the same rows the
-// review list renders, so the summary and list can never disagree.
-export function summarizeRating(reviews: SellerReviewRow[]): SellerRatingSummary {
-  if (reviews.length === 0) return { average: null, count: 0 }
-  const total = reviews.reduce((sum, r) => sum + r.rating, 0)
-  return { average: total / reviews.length, count: reviews.length }
+// Aggregate rating for the profile header. With the review list paginated the
+// summary can no longer be derived from the visible rows, so it is its own
+// cheap read over just the rating column — one number + count instead of the
+// full joined list (P1.14, #81).
+export async function fetchSellerRatingSummary(
+  sellerId: string,
+  client?: Supabase
+): Promise<SellerRatingSummary> {
+  if (!isValidUuid(sellerId)) return { average: null, count: 0 }
+  const supabase = client ?? (await createClient())
+  const { data, error } = await supabase
+    .from("reviews")
+    .select("rating")
+    .eq("seller_id", sellerId)
+
+  if (error) {
+    console.error("fetchSellerRatingSummary:", error.message)
+    return { average: null, count: 0 }
+  }
+  const ratings = ((data ?? []) as { rating: number | string }[]).map((r) =>
+    Number(r.rating)
+  )
+  const count = ratings.length
+  if (count === 0) return { average: null, count: 0 }
+  return {
+    average: ratings.reduce((sum, r) => sum + r, 0) / count,
+    count,
+  }
 }
 
 // ---- Writes ----

--- a/web/tests/unit/admin.test.ts
+++ b/web/tests/unit/admin.test.ts
@@ -5,7 +5,12 @@ vi.mock("@/lib/supabase/server", () => ({
 }))
 
 import { createClient } from "@/lib/supabase/server"
-import { restoreUserRow, suspendUserRow } from "@/lib/admin"
+import {
+  fetchAdminListings,
+  fetchAdminUsers,
+  restoreUserRow,
+  suspendUserRow,
+} from "@/lib/admin"
 
 const mockCreateClient = vi.mocked(createClient)
 
@@ -106,6 +111,112 @@ describe("admin suspend / restore (#86)", () => {
     expect(await restoreUserRow("user-1")).toEqual({
       ok: false,
       error: "db down",
+    })
+  })
+})
+
+describe("admin read pages (P1.14 #81)", () => {
+  // The list fetchers accept an optional client as their last argument (the
+  // same injection the listings-reads tests use), so paging logic runs against
+  // a lightweight fake without touching the module mock above.
+  const builder = (result: unknown): Record<string, unknown> => {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      is: () => b,
+      order: () => b,
+      range: () => b,
+      then: (resolve: (value: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve),
+    }
+    return b
+  }
+  const db = (from: (table: string) => unknown) => ({ from } as never)
+
+  describe("fetchAdminUsers", () => {
+    it("maps rows and derives hasMore from the server count", async () => {
+      const client = db(() =>
+        builder({
+          data: [
+            {
+              id: "u1",
+              full_name: "Alem",
+              role: "seller",
+              city: null,
+              phone: null,
+              telegram_username: null,
+              trust_score: 80,
+              profile_completion: 60,
+              phone_verified: true,
+              fayda_verified: false,
+              suspended_at: null,
+              created_at: "2026-01-01",
+            },
+          ],
+          error: null,
+          count: 30,
+        })
+      )
+      const result = await fetchAdminUsers({}, client)
+      expect(result.users[0].full_name).toBe("Alem")
+      expect(result.count).toBe(30)
+      expect(result.hasMore).toBe(true)
+    })
+
+    it("returns an empty page when the query fails", async () => {
+      const client = db(() =>
+        builder({ data: null, error: { message: "db down" }, count: null })
+      )
+      const result = await fetchAdminUsers({}, client)
+      expect(result).toMatchObject({
+        users: [],
+        hasMore: false,
+        error: "db down",
+      })
+    })
+  })
+
+  describe("fetchAdminListings", () => {
+    it("maps rows with the seller join and numeric price", async () => {
+      const client = db(() =>
+        builder({
+          data: [
+            {
+              id: "l1",
+              title: "Chair",
+              price: "100",
+              condition: "Fair",
+              status: "published",
+              city: "Bole",
+              view_count: 3,
+              favorite_count: 1,
+              sold_to_buyer_id: null,
+              created_at: "2026-01-01",
+              published_at: "2026-01-01",
+              seller: [{ id: "s1", full_name: "Alem" }],
+            },
+          ],
+          error: null,
+          count: 1,
+        })
+      )
+      const result = await fetchAdminListings({}, client)
+      expect(result.listings[0].title).toBe("Chair")
+      expect(result.listings[0].price).toBe(100)
+      expect(result.listings[0].seller?.full_name).toBe("Alem")
+      expect(result.count).toBe(1)
+      expect(result.hasMore).toBe(false)
+    })
+
+    it("returns an empty page when the query fails", async () => {
+      const client = db(() =>
+        builder({ data: null, error: { message: "db down" }, count: null })
+      )
+      const result = await fetchAdminListings({}, client)
+      expect(result).toMatchObject({
+        listings: [],
+        hasMore: false,
+        error: "db down",
+      })
     })
   })
 })

--- a/web/tests/unit/favorites.test.ts
+++ b/web/tests/unit/favorites.test.ts
@@ -4,6 +4,7 @@ import {
   buildLoginUrl,
   toggleFavoriteState,
 } from "@/lib/favorites/constants"
+import { fetchFavoriteListings } from "@/lib/favorites"
 
 describe("favorites.toggleFavoriteState", () => {
   it("flips a false favorite to true", () => {
@@ -26,5 +27,86 @@ describe("favorites.buildLoginUrl", () => {
     expect(buildLoginUrl("/?category=books&offset=12")).toContain(
       "next=%2F%3Fcategory%3Dbooks%26offset%3D12"
     )
+  })
+})
+
+describe("favorites.fetchFavoriteListings (P1.14 #81)", () => {
+  // The read fetchers accept an optional client as their last argument, so the
+  // real join/normalisation logic runs against a lightweight fake (the same
+  // injection the listings-reads tests use).
+  const builder = (result: unknown): Record<string, unknown> => {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      eq: () => b,
+      order: () => b,
+      range: () => b,
+      then: (resolve: (value: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve),
+    }
+    return b
+  }
+  const db = (from: (table: string) => unknown) => ({ from } as never)
+
+  const favoriteRow = (id: string) => ({
+    created_at: "2026-01-01",
+    listing: {
+      id,
+      title: "Chair",
+      price: 100,
+      condition: "Fair",
+      city: "Bole",
+      published_at: "2026-01-01",
+      seller: [
+        {
+          id: "seller-1",
+          full_name: "Alem",
+          avatar_url: null,
+          role: "seller",
+          trust_score: 50,
+          phone_verified: true,
+          fayda_verified: false,
+        },
+      ],
+      images: [{ id: "img-1", image_url: "cover.jpg", display_order: 0 }],
+    },
+  })
+
+  it("maps joined listings and derives hasMore from the count", async () => {
+    const client = db(() =>
+      builder({ data: [favoriteRow("l1")], error: null, count: 5 })
+    )
+    const result = await fetchFavoriteListings("user-1", {}, client)
+    expect(result.error).toBeNull()
+    expect(result.listings[0].title).toBe("Chair")
+    expect(result.listings[0].image_url).toBe("cover.jpg")
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("drops favorites whose listing is no longer readable, keeping the raw count", async () => {
+    const client = db(() =>
+      builder({
+        data: [favoriteRow("l1"), { created_at: "2026-01-02", listing: null }],
+        error: null,
+        count: 2,
+      })
+    )
+    const result = await fetchFavoriteListings("user-1", {}, client)
+    expect(result.listings.length).toBe(1)
+    // The count counts favorites rows (2), so the window reports more rows —
+    // the next page terminates because it returns zero visible listings.
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("returns an empty page when the query fails", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" }, count: null })
+    )
+    const result = await fetchFavoriteListings("user-1", {}, client)
+    expect(result).toMatchObject({
+      listings: [],
+      count: null,
+      hasMore: false,
+      error: "db down",
+    })
   })
 })

--- a/web/tests/unit/listings-reads.test.ts
+++ b/web/tests/unit/listings-reads.test.ts
@@ -264,27 +264,48 @@ describe("fetchSimilarListings (#78)", () => {
   })
 })
 
-describe("fetchSellerListings", () => {
-  it("maps the cover (lowest display_order) and numeric price", async () => {
-    const row = {
-      ...listingRow,
-      price: "100",
-      images: [
-        { image_url: "b.jpg", display_order: 1 },
-        { image_url: "a.jpg", display_order: 0 },
-      ],
-    }
-    const client = db(() => builder({ data: [row], error: null }))
-    const result = await fetchSellerListings("seller-1", client)
-    expect(result[0].price).toBe(100)
-    expect(result[0].cover_image_url).toBe("a.jpg")
+describe("fetchSellerListings (P1.14 #81)", () => {
+  const sellerRow = (overrides: Record<string, unknown> = {}) => ({
+    ...listingRow,
+    price: "100",
+    images: [
+      { image_url: "b.jpg", display_order: 1 },
+      { image_url: "a.jpg", display_order: 0 },
+    ],
+    ...overrides,
   })
 
-  it("returns an empty list when the query fails", async () => {
+  it("maps the cover (lowest display_order), numeric price, and the count", async () => {
     const client = db(() =>
-      builder({ data: null, error: { message: "db down" } })
+      builder({ data: [sellerRow()], error: null, count: 1 })
     )
-    expect(await fetchSellerListings("seller-1", client)).toEqual([])
+    const result = await fetchSellerListings("seller-1", {}, client)
+    expect(result.listings[0].price).toBe(100)
+    expect(result.listings[0].cover_image_url).toBe("a.jpg")
+    expect(result.count).toBe(1)
+    expect(result.hasMore).toBe(false)
+  })
+
+  it("derives hasMore from the server count", async () => {
+    const client = db(() =>
+      builder({ data: [sellerRow()], error: null, count: 25 })
+    )
+    const result = await fetchSellerListings("seller-1", {}, client)
+    expect(result.listings.length).toBe(1)
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("returns an empty page when the query fails", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" }, count: null })
+    )
+    const result = await fetchSellerListings("seller-1", {}, client)
+    expect(result).toMatchObject({
+      listings: [],
+      count: null,
+      hasMore: false,
+      error: "db down",
+    })
   })
 })
 

--- a/web/tests/unit/reviews.test.ts
+++ b/web/tests/unit/reviews.test.ts
@@ -7,6 +7,10 @@ import {
   REVIEWABLE_OFFER_STATUS,
   ratingAverageToTrustScore,
 } from "@/lib/reviews/constants"
+import {
+  fetchSellerRatingSummary,
+  fetchSellerReviews,
+} from "@/lib/reviews"
 
 describe("reviews rating bounds", () => {
   it("exposes a 1-5 rating range", () => {
@@ -52,5 +56,113 @@ describe("reviews.ratingAverageToTrustScore", () => {
 
   it("clamps values below 1 to the 20 floor", () => {
     expect(ratingAverageToTrustScore(-3)).toBe(20)
+  })
+})
+
+describe("reviews.fetchSellerReviews (P1.14 #81)", () => {
+  const builder = (result: unknown): Record<string, unknown> => {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      eq: () => b,
+      order: () => b,
+      range: () => b,
+      then: (resolve: (value: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve),
+    }
+    return b
+  }
+  const db = (from: (table: string) => unknown) => ({ from } as never)
+
+  const reviewRow = () => ({
+    id: "r1",
+    rating: 5,
+    comment: "Great seller",
+    created_at: "2026-01-01",
+    buyer: [{ id: "b1", full_name: "Buyer", avatar_url: null }],
+  })
+
+  it("maps rows with the reviewer identity and derives hasMore", async () => {
+    const client = db(() =>
+      builder({ data: [reviewRow()], error: null, count: 20 })
+    )
+    const result = await fetchSellerReviews(
+      "11111111-1111-1111-1111-111111111111",
+      {},
+      client
+    )
+    expect(result.error).toBeNull()
+    expect(result.reviews[0].rating).toBe(5)
+    expect(result.reviews[0].buyer?.full_name).toBe("Buyer")
+    expect(result.hasMore).toBe(true)
+  })
+
+  it("returns an empty page for an invalid seller id without touching the db", async () => {
+    const result = await fetchSellerReviews("nope")
+    expect(result).toMatchObject({
+      reviews: [],
+      count: 0,
+      hasMore: false,
+      error: null,
+    })
+  })
+
+  it("returns an empty page when the query fails", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" }, count: null })
+    )
+    const result = await fetchSellerReviews(
+      "11111111-1111-1111-1111-111111111111",
+      {},
+      client
+    )
+    expect(result).toMatchObject({
+      reviews: [],
+      hasMore: false,
+      error: "db down",
+    })
+  })
+})
+
+describe("reviews.fetchSellerRatingSummary (P1.14 #81)", () => {
+  const builder = (result: unknown): Record<string, unknown> => {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      eq: () => b,
+      then: (resolve: (value: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve),
+    }
+    return b
+  }
+  const db = (from: (table: string) => unknown) => ({ from } as never)
+
+  it("averages every rating, not just the visible page", async () => {
+    const client = db(() =>
+      builder({ data: [{ rating: 5 }, { rating: 3 }], error: null })
+    )
+    const result = await fetchSellerRatingSummary(
+      "11111111-1111-1111-1111-111111111111",
+      client
+    )
+    expect(result).toEqual({ average: 4, count: 2 })
+  })
+
+  it("returns a neutral summary when there are no reviews", async () => {
+    const client = db(() => builder({ data: [], error: null }))
+    const result = await fetchSellerRatingSummary(
+      "11111111-1111-1111-1111-111111111111",
+      client
+    )
+    expect(result).toEqual({ average: null, count: 0 })
+  })
+
+  it("returns a neutral summary on a failed query", async () => {
+    const client = db(() =>
+      builder({ data: null, error: { message: "db down" } })
+    )
+    const result = await fetchSellerRatingSummary(
+      "11111111-1111-1111-1111-111111111111",
+      client
+    )
+    expect(result).toEqual({ average: null, count: 0 })
   })
 })


### PR DESCRIPTION
Closes #81 (P1.14, parent #68).

Closes the last full-table-fetch reads. Offers were windowed in the earlier work; this PR adds the shared paging seam and windows every remaining surface:

- **lib/pagination.ts** — new shared `PagingArgs` / `resolveWindow` / `pagedHasMore` helpers so every windowed read resolves limit/offset and derives `hasMore` from a server count the same way (no drift).
- **favorites** — `fetchFavoriteListings` returns a paged `FavoritesPage` (`count`-backed `hasMore`, RLS-hidden listings still dropped); `/favorites` reads `?offset=` and renders Load more.
- **reviews** — `fetchSellerReviews` paginates; the profile header summary is now a dedicated `fetchSellerRatingSummary` read (averages ALL ratings, not the visible page); the old list-derived `summarizeRating` is removed.
- **seller dashboard manager** — `fetchSellerListings` returns a page object; Load more link below the manager.
- **admin users/listings** — both lists page via `?offset=`; the listings mapper now flattens the to-one `seller` join (PostgREST returns it as an array); the "N users/listings" copy uses the total count.

Behavior notes:
- The 1000-row `MAX_PAGING_OFFSET` guard stays scoped to search/browse; these personal/admin lists have no ceiling, matching the offers pattern.
- Page size is the shared `PAGE_SIZE` (12) used by browse/search/offers.

Validation:
- `tsc --noEmit` clean
- `vitest run` 354/354 pass (new tests for favorites, reviews list + summary, admin users/listings, seller listings)
- `eslint` 0 errors (only the pre-existing `_formData` warning)
- `next build` compiles

Remaining from #81's original scope: none — offers were already done in the earlier PR. #81 stays closed only when this merges.